### PR TITLE
Add Roughdraft install onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ npx roughdraft
 
 This starts Roughdraft locally and opens it automatically.
 
+If you want a persistent `roughdraft` command and the user-level agent guidance block, run:
+
+```bash
+npx --yes roughdraft install
+```
+
+That installs `roughdraft` globally and updates `~/CLAUDE.md` plus `~/AGENTS.md` with Roughdraft instructions.
+
 On macOS, if Google Chrome is installed, Roughdraft prefers opening in a separate Chrome app window instead of a normal browser tab.
 
 ```bash
@@ -52,8 +60,8 @@ Open a specific markdown file directly.
 If the local server is already running, you can also open a folder or file directly by URL:
 
 ```text
-http://localhost:3000/absolute/path/to/my-essay
-http://localhost:3000/absolute/path/to/my-essay/draft.md
+http://roughdraft.localhost:3000/absolute/path/to/my-essay
+http://roughdraft.localhost:3000/absolute/path/to/my-essay/draft.md
 ```
 
 That makes an agent-friendly workflow possible:
@@ -71,7 +79,7 @@ That makes an agent-friendly workflow possible:
 ./scripts/run.sh
 ```
 
-`./scripts/setup.sh` installs workspace dependencies and builds the app and server. `./scripts/run.sh` serves the built app at `http://localhost:3000`.
+`./scripts/setup.sh` installs workspace dependencies and builds the app and server. `./scripts/run.sh` serves the built app at `http://roughdraft.localhost:3000`.
 
 The two scripts coordinate through a lock file, so it's safe to start `./scripts/run.sh` while `./scripts/setup.sh` is still in progress. `run` will wait for setup to finish, or trigger setup itself if nothing has been built yet.
 
@@ -111,7 +119,7 @@ Roughdraft includes a skill for Claude Code that lets your agent:
 - Rearrange the canvas layout when exploring multiple versions
 
 ```bash
-# The skill is installed automatically when you run roughdraft
+# The guidance block is installed when you run `npx --yes roughdraft install`
 claude code --skill roughdraft
 ```
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "setup": "./scripts/setup.sh",
     "start": "./scripts/run.sh",
     "dev": "node scripts/dev.mjs",
+    "dev:web": "VITE_PREVIEW_WEB=1 pnpm --filter @roughdraft/app dev",
     "lint": "biome check . --assist-enabled=false",
     "lint:fix": "biome check --write . --assist-enabled=false",
     "format": "biome format --write .",

--- a/packages/app/public/install.sh
+++ b/packages/app/public/install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PACKAGE_SPEC="${ROUGHDRAFT_PACKAGE_SPEC:-roughdraft@latest}"
+
+log() {
+  printf '[roughdraft-install] %s\n' "$1"
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'roughdraft install error: missing required command `%s`\n' "$1" >&2
+    exit 1
+  fi
+}
+
+require_command node
+require_command npx
+
+log "Running npx --yes ${PACKAGE_SPEC} install"
+exec npx --yes "$PACKAGE_SPEC" install

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -238,28 +238,29 @@ function buildAgentInstallPrompt() {
   ].join("\n");
 }
 
-function Homepage({
-  onOpenDemo,
-}: {
-  onOpenDemo: () => void;
-}) {
+function Homepage({ onOpenDemo }: { onOpenDemo: () => void }) {
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [copyState, setCopyState] = useState<"idle" | "prompt" | "command">("idle");
+  const [copyState, setCopyState] = useState<"idle" | "prompt" | "command">(
+    "idle",
+  );
   const installCommand = getInstallCommand();
   const agentPrompt = buildAgentInstallPrompt();
 
-  const copyText = useCallback(async (text: string, nextState: "prompt" | "command") => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopyState(nextState);
-      window.setTimeout(() => {
-        setCopyState((current) => (current === nextState ? "idle" : current));
-      }, 1800);
-    } catch (error) {
-      console.error("Failed to copy text:", error);
-      setCopyState("idle");
-    }
-  }, []);
+  const copyText = useCallback(
+    async (text: string, nextState: "prompt" | "command") => {
+      try {
+        await navigator.clipboard.writeText(text);
+        setCopyState(nextState);
+        window.setTimeout(() => {
+          setCopyState((current) => (current === nextState ? "idle" : current));
+        }, 1800);
+      } catch (error) {
+        console.error("Failed to copy text:", error);
+        setCopyState("idle");
+      }
+    },
+    [],
+  );
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[radial-gradient(circle_at_top_left,_rgba(235,94,40,0.18),_transparent_28%),radial-gradient(circle_at_80%_20%,_rgba(15,23,42,0.12),_transparent_24%),linear-gradient(180deg,_#fcfaf6_0%,_#f3eee3_100%)] text-slate-950">
@@ -305,9 +306,10 @@ function Homepage({
                 Let your agent wire up the rest.
               </h1>
               <p className="mt-6 max-w-2xl text-lg leading-8 text-slate-700 sm:text-xl">
-                Roughdraft turns markdown review into a local workflow your agent can actually use.
-                Install it, teach your agent to open `.md` files in Roughdraft, and keep comments,
-                revisions, and final edits in normal markdown on disk.
+                Roughdraft turns markdown review into a local workflow your
+                agent can actually use. Install it, teach your agent to open
+                `.md` files in Roughdraft, and keep comments, revisions, and
+                final edits in normal markdown on disk.
               </p>
 
               <div className="mt-8 flex flex-col gap-3 sm:flex-row">
@@ -339,7 +341,8 @@ function Homepage({
                     Run one `npx` install command.
                   </p>
                   <p className="mt-2 text-sm leading-6 text-slate-600">
-                    It installs the CLI and appends a marked Roughdraft block to your user-level agent docs.
+                    It installs the CLI and appends a marked Roughdraft block to
+                    your user-level agent docs.
                   </p>
                 </div>
                 <div className="rounded-[28px] border border-white/70 bg-white/72 p-5 shadow-[0_20px_60px_rgba(15,23,42,0.08)] backdrop-blur">
@@ -350,7 +353,8 @@ function Homepage({
                     Ask your agent to open the doc.
                   </p>
                   <p className="mt-2 text-sm leading-6 text-slate-600">
-                    The guidance tells it to prefer `roughdraft` whenever you want to review or comment on markdown.
+                    The guidance tells it to prefer `roughdraft` whenever you
+                    want to review or comment on markdown.
                   </p>
                 </div>
                 <div className="rounded-[28px] border border-white/70 bg-white/72 p-5 shadow-[0_20px_60px_rgba(15,23,42,0.08)] backdrop-blur">
@@ -361,7 +365,8 @@ function Homepage({
                     Leave comments in normal markdown.
                   </p>
                   <p className="mt-2 text-sm leading-6 text-slate-600">
-                    Roughdraft keeps everything local and agent-friendly, so the next pass can happen on the same files.
+                    Roughdraft keeps everything local and agent-friendly, so the
+                    next pass can happen on the same files.
                   </p>
                 </div>
               </div>
@@ -403,15 +408,21 @@ function Homepage({
 
                 <div className="mt-4 grid gap-3 sm:grid-cols-2">
                   <div className="rounded-[20px] border border-white/8 bg-white/5 p-4">
-                    <div className="text-sm font-medium text-white">Updates user guidance</div>
+                    <div className="text-sm font-medium text-white">
+                      Updates user guidance
+                    </div>
                     <p className="mt-2 text-sm leading-6 text-slate-400">
-                      Appends a managed Roughdraft block to `~/CLAUDE.md` and `~/AGENTS.md` if it is not already there.
+                      Appends a managed Roughdraft block to `~/CLAUDE.md` and
+                      `~/AGENTS.md` if it is not already there.
                     </p>
                   </div>
                   <div className="rounded-[20px] border border-white/8 bg-white/5 p-4">
-                    <div className="text-sm font-medium text-white">Keeps the workflow local</div>
+                    <div className="text-sm font-medium text-white">
+                      Keeps the workflow local
+                    </div>
                     <p className="mt-2 text-sm leading-6 text-slate-400">
-                      Your agent opens files with `roughdraft`, and the markdown stays on your machine.
+                      Your agent opens files with `roughdraft`, and the markdown
+                      stays on your machine.
                     </p>
                   </div>
                 </div>
@@ -424,12 +435,14 @@ function Homepage({
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent className="max-w-3xl rounded-[28px] border border-slate-200 bg-[#faf7f1] p-0 text-slate-950 shadow-[0_32px_120px_rgba(15,23,42,0.28)]">
           <div className="border-b border-slate-200 px-6 py-5 sm:px-8">
-              <DialogHeader className="gap-2">
+            <DialogHeader className="gap-2">
               <DialogTitle className="text-2xl font-semibold tracking-[-0.04em] text-slate-950">
                 Copy this prompt into Claude Code or another local agent
               </DialogTitle>
               <DialogDescription className="max-w-2xl text-sm leading-6 text-slate-600">
-                The prompt tells the agent to run `npx --yes roughdraft install`, verify the `roughdraft` CLI, and update `~/CLAUDE.md` plus `~/AGENTS.md` with Roughdraft guidance.
+                The prompt tells the agent to run `npx --yes roughdraft
+                install`, verify the `roughdraft` CLI, and update `~/CLAUDE.md`
+                plus `~/AGENTS.md` with Roughdraft guidance.
               </DialogDescription>
             </DialogHeader>
           </div>

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -6,6 +6,14 @@ import { PageCard } from "./PageCard";
 import { PathSwitcher } from "./PathSwitcher";
 import { ProjectTreeSidebar } from "./ProjectTreeSidebar";
 import { Button } from "./components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./components/ui/dialog";
 
 interface RequestedPathState {
   rawPath: string | null;
@@ -215,6 +223,295 @@ function buildLocationForPath(path?: string | null) {
   return `${url.pathname}${url.search}${url.hash}`;
 }
 
+function getInstallCommand() {
+  return "npx --yes roughdraft install";
+}
+
+function buildAgentInstallPrompt() {
+  return [
+    "Install Roughdraft on this machine and set it up for future markdown review workflows.",
+    "",
+    `1. Run \`${getInstallCommand()}\`.`,
+    "2. Let the command update or create user-level `~/CLAUDE.md` and `~/AGENTS.md` with Roughdraft guidance.",
+    "3. Confirm that the `roughdraft` command is available when you are done.",
+    "4. Do not modify any project files as part of setup.",
+  ].join("\n");
+}
+
+function Homepage({
+  onOpenDemo,
+}: {
+  onOpenDemo: () => void;
+}) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [copyState, setCopyState] = useState<"idle" | "prompt" | "command">("idle");
+  const installCommand = getInstallCommand();
+  const agentPrompt = buildAgentInstallPrompt();
+
+  const copyText = useCallback(async (text: string, nextState: "prompt" | "command") => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopyState(nextState);
+      window.setTimeout(() => {
+        setCopyState((current) => (current === nextState ? "idle" : current));
+      }, 1800);
+    } catch (error) {
+      console.error("Failed to copy text:", error);
+      setCopyState("idle");
+    }
+  }, []);
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-[radial-gradient(circle_at_top_left,_rgba(235,94,40,0.18),_transparent_28%),radial-gradient(circle_at_80%_20%,_rgba(15,23,42,0.12),_transparent_24%),linear-gradient(180deg,_#fcfaf6_0%,_#f3eee3_100%)] text-slate-950">
+      <div className="pointer-events-none absolute inset-0 opacity-70">
+        <div className="absolute top-[-8rem] right-[-6rem] h-[24rem] w-[24rem] rounded-full bg-[radial-gradient(circle,_rgba(190,24,93,0.14),_transparent_62%)]" />
+        <div className="absolute bottom-[-10rem] left-[-5rem] h-[28rem] w-[28rem] rounded-full bg-[radial-gradient(circle,_rgba(2,132,199,0.12),_transparent_60%)]" />
+      </div>
+
+      <div className="relative mx-auto flex min-h-screen w-full max-w-7xl flex-col px-6 py-8 sm:px-10 lg:px-14">
+        <header className="flex items-center justify-between gap-4">
+          <div className="inline-flex items-center gap-3 rounded-full border border-slate-900/10 bg-white/70 px-4 py-2 shadow-[0_12px_40px_rgba(15,23,42,0.08)] backdrop-blur">
+            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-950 text-[0.72rem] font-semibold tracking-[0.18em] text-white uppercase">
+              Rd
+            </div>
+            <div>
+              <div className="text-[0.76rem] font-semibold tracking-[0.24em] text-slate-500 uppercase">
+                Roughdraft
+              </div>
+              <div className="text-sm font-medium text-slate-950">
+                Markdown review for AI workflows
+              </div>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            className="rounded-full border border-slate-900/10 bg-white/70 px-4 py-2 text-sm font-medium text-slate-700 shadow-[0_12px_40px_rgba(15,23,42,0.08)] backdrop-blur transition hover:border-slate-900/20 hover:text-slate-950"
+            onClick={onOpenDemo}
+          >
+            Try the demo
+          </button>
+        </header>
+
+        <main className="flex flex-1 items-center py-12 lg:py-16">
+          <div className="grid w-full gap-10 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)] lg:items-center">
+            <section className="max-w-3xl">
+              <div className="inline-flex items-center gap-2 rounded-full border border-amber-300/60 bg-amber-100/80 px-3 py-1 text-[0.77rem] font-semibold tracking-[0.16em] text-amber-900 uppercase shadow-[0_10px_30px_rgba(217,119,6,0.12)]">
+                Install through your agent
+              </div>
+              <h1 className="mt-6 max-w-4xl text-5xl font-semibold tracking-[-0.06em] text-slate-950 sm:text-6xl lg:text-7xl">
+                Paste one prompt.
+                <br />
+                Let your agent wire up the rest.
+              </h1>
+              <p className="mt-6 max-w-2xl text-lg leading-8 text-slate-700 sm:text-xl">
+                Roughdraft turns markdown review into a local workflow your agent can actually use.
+                Install it, teach your agent to open `.md` files in Roughdraft, and keep comments,
+                revisions, and final edits in normal markdown on disk.
+              </p>
+
+              <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+                <Button
+                  type="button"
+                  size="lg"
+                  className="h-12 rounded-full bg-slate-950 px-6 text-sm font-semibold text-white hover:bg-slate-800"
+                  onClick={() => setDialogOpen(true)}
+                >
+                  Install Now
+                </Button>
+                <Button
+                  type="button"
+                  size="lg"
+                  variant="outline"
+                  className="h-12 rounded-full border-slate-300 bg-white/70 px-6 text-sm font-semibold text-slate-700 hover:bg-white"
+                  onClick={onOpenDemo}
+                >
+                  Open browser demo
+                </Button>
+              </div>
+
+              <div className="mt-10 grid gap-4 sm:grid-cols-3">
+                <div className="rounded-[28px] border border-white/70 bg-white/72 p-5 shadow-[0_20px_60px_rgba(15,23,42,0.08)] backdrop-blur">
+                  <div className="text-[0.72rem] font-semibold tracking-[0.18em] text-slate-500 uppercase">
+                    01
+                  </div>
+                  <p className="mt-3 text-base font-medium tracking-[-0.02em] text-slate-950">
+                    Run one `npx` install command.
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-600">
+                    It installs the CLI and appends a marked Roughdraft block to your user-level agent docs.
+                  </p>
+                </div>
+                <div className="rounded-[28px] border border-white/70 bg-white/72 p-5 shadow-[0_20px_60px_rgba(15,23,42,0.08)] backdrop-blur">
+                  <div className="text-[0.72rem] font-semibold tracking-[0.18em] text-slate-500 uppercase">
+                    02
+                  </div>
+                  <p className="mt-3 text-base font-medium tracking-[-0.02em] text-slate-950">
+                    Ask your agent to open the doc.
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-600">
+                    The guidance tells it to prefer `roughdraft` whenever you want to review or comment on markdown.
+                  </p>
+                </div>
+                <div className="rounded-[28px] border border-white/70 bg-white/72 p-5 shadow-[0_20px_60px_rgba(15,23,42,0.08)] backdrop-blur">
+                  <div className="text-[0.72rem] font-semibold tracking-[0.18em] text-slate-500 uppercase">
+                    03
+                  </div>
+                  <p className="mt-3 text-base font-medium tracking-[-0.02em] text-slate-950">
+                    Leave comments in normal markdown.
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-600">
+                    Roughdraft keeps everything local and agent-friendly, so the next pass can happen on the same files.
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <section className="relative">
+              <div className="absolute inset-x-8 top-8 h-full rounded-[34px] bg-slate-950/8 blur-3xl" />
+              <div className="relative overflow-hidden rounded-[34px] border border-slate-900/10 bg-[#171717] p-5 text-slate-100 shadow-[0_24px_90px_rgba(15,23,42,0.25)]">
+                <div className="flex items-center gap-2">
+                  <span className="h-3 w-3 rounded-full bg-rose-400" />
+                  <span className="h-3 w-3 rounded-full bg-amber-300" />
+                  <span className="h-3 w-3 rounded-full bg-emerald-400" />
+                  <div className="ml-3 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[0.72rem] tracking-[0.18em] text-slate-400 uppercase">
+                    Agent setup preview
+                  </div>
+                </div>
+
+                <div className="mt-5 rounded-[24px] border border-white/8 bg-black/25 p-4">
+                  <div className="text-[0.72rem] font-semibold tracking-[0.16em] text-slate-500 uppercase">
+                    Prompt
+                  </div>
+                  <pre className="mt-3 overflow-x-auto whitespace-pre-wrap text-sm leading-7 text-slate-100">
+                    {agentPrompt}
+                  </pre>
+                </div>
+
+                <div className="mt-4 rounded-[24px] border border-white/8 bg-white/5 p-4">
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <div className="text-[0.72rem] font-semibold tracking-[0.16em] text-slate-500 uppercase">
+                        Install command
+                      </div>
+                      <code className="mt-2 block text-sm leading-6 text-slate-100">
+                        {installCommand}
+                      </code>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                  <div className="rounded-[20px] border border-white/8 bg-white/5 p-4">
+                    <div className="text-sm font-medium text-white">Updates user guidance</div>
+                    <p className="mt-2 text-sm leading-6 text-slate-400">
+                      Appends a managed Roughdraft block to `~/CLAUDE.md` and `~/AGENTS.md` if it is not already there.
+                    </p>
+                  </div>
+                  <div className="rounded-[20px] border border-white/8 bg-white/5 p-4">
+                    <div className="text-sm font-medium text-white">Keeps the workflow local</div>
+                    <p className="mt-2 text-sm leading-6 text-slate-400">
+                      Your agent opens files with `roughdraft`, and the markdown stays on your machine.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </main>
+      </div>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="max-w-3xl rounded-[28px] border border-slate-200 bg-[#faf7f1] p-0 text-slate-950 shadow-[0_32px_120px_rgba(15,23,42,0.28)]">
+          <div className="border-b border-slate-200 px-6 py-5 sm:px-8">
+              <DialogHeader className="gap-2">
+              <DialogTitle className="text-2xl font-semibold tracking-[-0.04em] text-slate-950">
+                Copy this prompt into Claude Code or another local agent
+              </DialogTitle>
+              <DialogDescription className="max-w-2xl text-sm leading-6 text-slate-600">
+                The prompt tells the agent to run `npx --yes roughdraft install`, verify the `roughdraft` CLI, and update `~/CLAUDE.md` plus `~/AGENTS.md` with Roughdraft guidance.
+              </DialogDescription>
+            </DialogHeader>
+          </div>
+
+          <div className="space-y-5 px-6 py-6 sm:px-8">
+            <div className="rounded-[24px] border border-slate-200 bg-white p-4 shadow-[0_16px_40px_rgba(15,23,42,0.05)]">
+              <div className="mb-3 flex items-center justify-between gap-4">
+                <div>
+                  <div className="text-[0.72rem] font-semibold tracking-[0.18em] text-slate-500 uppercase">
+                    Agent prompt
+                  </div>
+                  <div className="mt-1 text-sm text-slate-600">
+                    Paste this as-is into the agent.
+                  </div>
+                </div>
+                <Button
+                  type="button"
+                  size="lg"
+                  className="h-10 rounded-full bg-slate-950 px-5 text-sm font-semibold text-white hover:bg-slate-800"
+                  onClick={() => void copyText(agentPrompt, "prompt")}
+                >
+                  {copyState === "prompt" ? "Copied prompt" : "Copy prompt"}
+                </Button>
+              </div>
+              <textarea
+                readOnly
+                value={agentPrompt}
+                className="min-h-[220px] w-full resize-none rounded-[18px] border border-slate-200 bg-[#fcfbf8] p-4 text-sm leading-6 text-slate-800 outline-none"
+              />
+            </div>
+
+            <div className="rounded-[24px] border border-slate-200 bg-white p-4 shadow-[0_16px_40px_rgba(15,23,42,0.05)]">
+              <div className="mb-3 flex items-center justify-between gap-4">
+                <div>
+                  <div className="text-[0.72rem] font-semibold tracking-[0.18em] text-slate-500 uppercase">
+                    Direct install command
+                  </div>
+                  <div className="mt-1 text-sm text-slate-600">
+                    For users who want to run it manually.
+                  </div>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="lg"
+                  className="h-10 rounded-full border-slate-300 px-5 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+                  onClick={() => void copyText(installCommand, "command")}
+                >
+                  {copyState === "command" ? "Copied command" : "Copy command"}
+                </Button>
+              </div>
+              <code className="block overflow-x-auto rounded-[18px] bg-slate-950 px-4 py-4 text-sm leading-6 text-slate-100">
+                {installCommand}
+              </code>
+            </div>
+          </div>
+
+          <DialogFooter className="border-t border-slate-200 px-6 py-4 sm:px-8">
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              className="h-10 rounded-full border-slate-300 px-5 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+              onClick={onOpenDemo}
+            >
+              Open browser demo
+            </Button>
+            <Button
+              type="button"
+              size="lg"
+              className="h-10 rounded-full bg-slate-950 px-5 text-sm font-semibold text-white hover:bg-slate-800"
+              onClick={() => setDialogOpen(false)}
+            >
+              Close
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
 function syncProjectPathInUrl(projectPath?: string) {
   const nextLocation = buildLocationForPath(getWorkspacePath(projectPath));
   const currentLocation = `${window.location.pathname}${window.location.search}${window.location.hash}`;
@@ -256,6 +553,7 @@ export function App() {
     useState<HTMLDivElement | null>(null);
   const [projectTreeVersion, setProjectTreeVersion] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [demoModeEnabled, setDemoModeEnabled] = useState(false);
   const backendRef = useRef<StorageBackend | null>(null);
   const layoutRef = useRef<ProjectLayout>({ pages: {} });
   const saveLayoutTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -633,6 +931,15 @@ export function App() {
         <p>Loading canvas...</p>
       </div>
     );
+  }
+
+  const shouldShowHomepage =
+    backend?.info.kind === "local-storage" &&
+    !requestedPathState.rawPath &&
+    !demoModeEnabled;
+
+  if (shouldShowHomepage) {
+    return <Homepage onOpenDemo={() => setDemoModeEnabled(true)} />;
   }
 
   const documentAbsolutePath =

--- a/packages/app/src/detect-backend.ts
+++ b/packages/app/src/detect-backend.ts
@@ -3,6 +3,10 @@ import { ApiBackend } from "./api-backend";
 import { LocalStorageBackend } from "./local-storage-backend";
 
 export async function detectBackend(): Promise<StorageBackend> {
+  if (import.meta.env.VITE_PREVIEW_WEB === "1") {
+    return new LocalStorageBackend();
+  }
+
   try {
     const res = await fetch("/api/status");
     if (res.ok) {

--- a/packages/app/src/types.d.ts
+++ b/packages/app/src/types.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="vite/client" />
+
 declare module "@joplin/turndown-plugin-gfm" {
   export const tables: unknown;
   export const taskListItems: unknown;

--- a/packages/server/bin/roughdraft.mjs
+++ b/packages/server/bin/roughdraft.mjs
@@ -56,7 +56,9 @@ function installCommandOnPath() {
 }
 
 function writeGuidanceBlock(targetFile) {
-  const existing = fs.existsSync(targetFile) ? fs.readFileSync(targetFile, "utf8") : "";
+  const existing = fs.existsSync(targetFile)
+    ? fs.readFileSync(targetFile, "utf8")
+    : "";
   const filteredLines = [];
   let skipping = false;
 
@@ -76,7 +78,10 @@ function writeGuidanceBlock(targetFile) {
     }
   }
 
-  while (filteredLines.length > 0 && filteredLines[filteredLines.length - 1] === "") {
+  while (
+    filteredLines.length > 0 &&
+    filteredLines[filteredLines.length - 1] === ""
+  ) {
     filteredLines.pop();
   }
 
@@ -98,9 +103,13 @@ function printHelp() {
 function runInstall() {
   logInstall(`Installing ${PACKAGE_SPEC}`);
 
-  const installResult = spawnSync("npm", ["install", "--global", PACKAGE_SPEC], {
-    stdio: "inherit",
-  });
+  const installResult = spawnSync(
+    "npm",
+    ["install", "--global", PACKAGE_SPEC],
+    {
+      stdio: "inherit",
+    },
+  );
 
   if (installResult.status !== 0) {
     failInstall(`npm install --global ${PACKAGE_SPEC} failed`);
@@ -118,8 +127,12 @@ function runInstall() {
     return;
   }
 
-  logInstall("Roughdraft installed, but the command is not on PATH in this shell yet.");
-  logInstall("You may need to restart your terminal so your global npm bin directory is picked up.");
+  logInstall(
+    "Roughdraft installed, but the command is not on PATH in this shell yet.",
+  );
+  logInstall(
+    "You may need to restart your terminal so your global npm bin directory is picked up.",
+  );
 }
 
 function resolveTargetPath(inputPath) {
@@ -219,9 +232,12 @@ function buildLoopbackUrl(host, port, pathname = "/") {
 async function findRunningRoughdraftPort(port) {
   for (const host of [ROUGHDRAFT_BIND_HOST, ...ROUGHDRAFT_LOOPBACK_HOSTS]) {
     try {
-      const response = await fetch(buildLoopbackUrl(host, port, "/api/status"), {
-        signal: AbortSignal.timeout(750),
-      });
+      const response = await fetch(
+        buildLoopbackUrl(host, port, "/api/status"),
+        {
+          signal: AbortSignal.timeout(750),
+        },
+      );
       if (!response.ok) {
         continue;
       }
@@ -230,9 +246,7 @@ async function findRunningRoughdraftPort(port) {
       if (payload?.backend === "local-files") {
         return port;
       }
-    } catch {
-      continue;
-    }
+    } catch {}
   }
 
   return null;

--- a/packages/server/bin/roughdraft.mjs
+++ b/packages/server/bin/roughdraft.mjs
@@ -1,10 +1,126 @@
 #!/usr/bin/env node
 
 import { createServer } from "../dist/index.js";
+import {
+  ROUGHDRAFT_BIND_HOST,
+  ROUGHDRAFT_LOOPBACK_HOSTS,
+  ROUGHDRAFT_PUBLIC_HOST,
+} from "../dist/network.js";
 import path from "node:path";
 import fs from "node:fs";
+import os from "node:os";
 import { spawn, spawnSync } from "node:child_process";
 import { findAvailablePort } from "../dist/ports.js";
+
+const PACKAGE_SPEC = process.env.ROUGHDRAFT_PACKAGE_SPEC || "roughdraft@latest";
+const MARKER_START = "<!-- roughdraft:start -->";
+const MARKER_END = "<!-- roughdraft:end -->";
+const CONFIG_FILES = ["CLAUDE.md", "AGENTS.md"];
+const GUIDANCE_BLOCK = `<!-- roughdraft:start -->
+## Roughdraft
+
+When the user wants to open, review, comment on, or compare Markdown files, prefer Roughdraft over reading raw markdown in the terminal.
+
+Use \`roughdraft "<absolute path to a markdown file or folder>"\` to open the relevant file or directory for the user.
+
+If Roughdraft is not already running, start it with that command. After the user finishes reviewing in Roughdraft, continue the workflow by reading the markdown files from disk and making the requested changes there.
+
+<!-- roughdraft:end -->`;
+
+function logInstall(message) {
+  console.log(`[roughdraft-install] ${message}`);
+}
+
+function failInstall(message) {
+  console.error(`roughdraft install error: ${message}`);
+  process.exit(1);
+}
+
+function installCommandOnPath() {
+  const locator = process.platform === "win32" ? "where" : "which";
+  const result = spawnSync(locator, ["roughdraft"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+
+  if (result.status !== 0) {
+    return null;
+  }
+
+  const commandPath = result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+
+  return commandPath || null;
+}
+
+function writeGuidanceBlock(targetFile) {
+  const existing = fs.existsSync(targetFile) ? fs.readFileSync(targetFile, "utf8") : "";
+  const filteredLines = [];
+  let skipping = false;
+
+  for (const line of existing.split(/\r?\n/)) {
+    if (line === MARKER_START) {
+      skipping = true;
+      continue;
+    }
+
+    if (line === MARKER_END) {
+      skipping = false;
+      continue;
+    }
+
+    if (!skipping) {
+      filteredLines.push(line);
+    }
+  }
+
+  while (filteredLines.length > 0 && filteredLines[filteredLines.length - 1] === "") {
+    filteredLines.pop();
+  }
+
+  const nextContents =
+    filteredLines.length > 0
+      ? `${filteredLines.join("\n")}\n\n${GUIDANCE_BLOCK}\n`
+      : `${GUIDANCE_BLOCK}\n`;
+
+  fs.mkdirSync(path.dirname(targetFile), { recursive: true });
+  fs.writeFileSync(targetFile, nextContents);
+}
+
+function printHelp() {
+  console.log("Usage:");
+  console.log("  roughdraft [path]");
+  console.log("  roughdraft install");
+}
+
+function runInstall() {
+  logInstall(`Installing ${PACKAGE_SPEC}`);
+
+  const installResult = spawnSync("npm", ["install", "--global", PACKAGE_SPEC], {
+    stdio: "inherit",
+  });
+
+  if (installResult.status !== 0) {
+    failInstall(`npm install --global ${PACKAGE_SPEC} failed`);
+  }
+
+  for (const filename of CONFIG_FILES) {
+    const targetFile = path.join(os.homedir(), filename);
+    writeGuidanceBlock(targetFile);
+    logInstall(`Updated ${targetFile}`);
+  }
+
+  const installedPath = installCommandOnPath();
+  if (installedPath) {
+    logInstall(`Roughdraft is ready: ${installedPath}`);
+    return;
+  }
+
+  logInstall("Roughdraft installed, but the command is not on PATH in this shell yet.");
+  logInstall("You may need to restart your terminal so your global npm bin directory is picked up.");
+}
 
 function resolveTargetPath(inputPath) {
   const fallbackDir = process.cwd();
@@ -87,7 +203,7 @@ function openRoughdraftUrl(url) {
 }
 
 function buildTargetUrl(port, openPath) {
-  const url = new URL(`http://localhost:${port}`);
+  const url = new URL(`http://${ROUGHDRAFT_PUBLIC_HOST}:${port}`);
   const normalizedPath = openPath.replace(/\\/g, "/");
   url.pathname = normalizedPath.startsWith("/")
     ? normalizedPath
@@ -95,19 +211,28 @@ function buildTargetUrl(port, openPath) {
   return url.toString();
 }
 
-async function findRunningRoughdraftPort(port) {
-  try {
-    const response = await fetch(`http://localhost:${port}/api/status`, {
-      signal: AbortSignal.timeout(750),
-    });
-    if (!response.ok) return null;
+function buildLoopbackUrl(host, port, pathname = "/") {
+  const baseHost = host.includes(":") ? `[${host}]` : host;
+  return new URL(`http://${baseHost}:${port}${pathname}`);
+}
 
-    const payload = await response.json();
-    if (payload?.backend === "local-files") {
-      return port;
+async function findRunningRoughdraftPort(port) {
+  for (const host of [ROUGHDRAFT_BIND_HOST, ...ROUGHDRAFT_LOOPBACK_HOSTS]) {
+    try {
+      const response = await fetch(buildLoopbackUrl(host, port, "/api/status"), {
+        signal: AbortSignal.timeout(750),
+      });
+      if (!response.ok) {
+        continue;
+      }
+
+      const payload = await response.json();
+      if (payload?.backend === "local-files") {
+        return port;
+      }
+    } catch {
+      continue;
     }
-  } catch {
-    return null;
   }
 
   return null;
@@ -121,23 +246,36 @@ async function waitForServer(port) {
   }
 }
 
+const args = process.argv.slice(2);
+const command = args[0];
+
+if (command === "install") {
+  runInstall();
+  process.exit(0);
+}
+
+if (command === "help" || command === "--help" || command === "-h") {
+  printHelp();
+  process.exit(0);
+}
+
 const preferredPort = parseInt(process.env.PORT || "3000", 10);
-const { projectDir, openPath } = resolveTargetPath(process.argv[2]);
+const { projectDir, openPath } = resolveTargetPath(command);
 const runningPort = await findRunningRoughdraftPort(preferredPort);
 const port = runningPort ?? (await findAvailablePort(preferredPort));
 
 if (runningPort) {
   console.log(
-    `Reusing Roughdraft already running at http://localhost:${runningPort}`,
+    `Reusing Roughdraft already running at http://${ROUGHDRAFT_PUBLIC_HOST}:${runningPort}`,
   );
 } else if (port !== preferredPort) {
   console.log(
     `Preferred port ${preferredPort} is busy, using ${port} instead.`,
   );
-  createServer(port, projectDir);
+  await createServer(port, projectDir);
   await waitForServer(port);
 } else {
-  createServer(port, projectDir);
+  await createServer(port, projectDir);
   await waitForServer(port);
 }
 

--- a/packages/server/src/dev.ts
+++ b/packages/server/src/dev.ts
@@ -19,4 +19,4 @@ if (port !== preferredPort) {
   );
 }
 
-createServer(port, projectDir);
+await createServer(port, projectDir);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -687,8 +687,8 @@ export async function createServer(
             listeningHosts.push(host);
             resolve();
           });
-        })
-    )
+        }),
+    ),
   );
 
   if (listeningHosts.length === 0) {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,9 +1,13 @@
 import express, { type Express, type Request, type Response } from "express";
-import type { Server } from "node:http";
 import os from "node:os";
+import { createServer as createHttpServer } from "node:http";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 import fs from "node:fs";
+import {
+  ROUGHDRAFT_LOOPBACK_HOSTS,
+  ROUGHDRAFT_PUBLIC_HOST,
+} from "./network.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const staticDir = path.resolve(__dirname, "../../app/dist");
@@ -654,12 +658,45 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
   return { app, defaultProjectDir, port };
 }
 
-export function createServer(port = 3000, projectDir?: string): Server {
+export async function createServer(
+  port = 3000,
+  projectDir?: string,
+): Promise<void> {
   const { app, defaultProjectDir } = createApp({ port, projectDir });
-  const server = app.listen(port, () => {
-    console.log(`\n  Roughdraft running at http://localhost:${port}`);
-    console.log(`  Default project directory: ${defaultProjectDir}\n`);
-  });
+  const listeningHosts: string[] = [];
 
-  return server;
+  await Promise.all(
+    ROUGHDRAFT_LOOPBACK_HOSTS.map(
+      (host) =>
+        new Promise<void>((resolve, reject) => {
+          const server = createHttpServer(app);
+
+          server.once("error", (error: NodeJS.ErrnoException) => {
+            if (
+              error.code === "EAFNOSUPPORT" ||
+              error.code === "EADDRNOTAVAIL"
+            ) {
+              resolve();
+              return;
+            }
+
+            reject(error);
+          });
+
+          server.listen(port, host, () => {
+            listeningHosts.push(host);
+            resolve();
+          });
+        })
+    )
+  );
+
+  if (listeningHosts.length === 0) {
+    throw new Error("Roughdraft could not bind to any loopback interface.");
+  }
+
+  console.log(
+    `\n  Roughdraft running at http://${ROUGHDRAFT_PUBLIC_HOST}:${port}`,
+  );
+  console.log(`  Default project directory: ${defaultProjectDir}\n`);
 }

--- a/packages/server/src/network.ts
+++ b/packages/server/src/network.ts
@@ -1,0 +1,3 @@
+export const ROUGHDRAFT_BIND_HOST = "127.0.0.1";
+export const ROUGHDRAFT_LOOPBACK_HOSTS = ["127.0.0.1", "::1"] as const;
+export const ROUGHDRAFT_PUBLIC_HOST = "roughdraft.localhost";

--- a/packages/server/src/ports.ts
+++ b/packages/server/src/ports.ts
@@ -1,35 +1,60 @@
 import net from "node:net";
+import { ROUGHDRAFT_BIND_HOST, ROUGHDRAFT_LOOPBACK_HOSTS } from "./network.js";
 
-export async function findAvailablePort(
-  preferredPort: number,
-): Promise<number> {
+async function canListenOnPort(port: number, host: string): Promise<boolean> {
   return new Promise((resolve, reject) => {
     const server = net.createServer();
 
     server.unref();
 
     server.on("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "EAFNOSUPPORT" || error.code === "EADDRNOTAVAIL") {
+        resolve(false);
+        return;
+      }
+
       if (error.code === "EADDRINUSE") {
-        resolve(findAvailablePort(preferredPort + 1));
+        reject(error);
         return;
       }
 
       reject(error);
     });
 
-    server.listen(preferredPort, () => {
-      const address = server.address();
-      const port =
-        typeof address === "object" && address ? address.port : preferredPort;
-
+    server.listen(port, host, () => {
       server.close((closeError) => {
         if (closeError) {
           reject(closeError);
           return;
         }
 
-        resolve(port);
+        resolve(true);
       });
     });
   });
+}
+
+export async function findAvailablePort(
+  preferredPort: number,
+  host = ROUGHDRAFT_BIND_HOST,
+): Promise<number> {
+  try {
+    const hostsToCheck = Array.from(
+      new Set([host, ...ROUGHDRAFT_LOOPBACK_HOSTS]),
+    );
+    const results = await Promise.all(
+      hostsToCheck.map((nextHost) => canListenOnPort(preferredPort, nextHost)),
+    );
+
+    if (results.some(Boolean)) {
+      return preferredPort;
+    }
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode !== "EADDRINUSE") {
+      throw error;
+    }
+  }
+
+  return findAvailablePort(preferredPort + 1, host);
 }

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -15,6 +15,6 @@ if ! setup_ready; then
 fi
 
 port="${PORT:-3000}"
-log "Starting Roughdraft on http://localhost:${port}"
+log "Starting Roughdraft on http://roughdraft.localhost:${port}"
 
 exec env ROUGHDRAFT_NO_OPEN=1 node "$repo_root/packages/server/bin/roughdraft.mjs"

--- a/specs/user-level-agent-guidance.md
+++ b/specs/user-level-agent-guidance.md
@@ -1,0 +1,215 @@
+# User-Level Agent Guidance
+
+## Purpose
+
+Roughdraft should help users set up one durable, user-level source of truth for agent guidance so their coding agents know to open markdown files in Roughdraft for review instead of treating markdown review as a terminal-only workflow.
+
+The product goal is not to invent a new universal agent standard. The goal is to give users a safe, pragmatic bootstrap path that works across today’s fragmented tool landscape while preserving a clean future migration path if a global `AGENTS.md` standard eventually lands.
+
+## Problem
+
+Project-level agent guidance is converging on `AGENTS.md`, but user-level guidance is still fragmented.
+
+- Claude Code documents user-level memory at `~/.claude/CLAUDE.md`
+- Factory documents a personal override at `~/.factory/AGENTS.md`
+- Amp documents both `$HOME/.config/amp/AGENTS.md` and `$HOME/.config/AGENTS.md`
+- A proposal exists to standardize user-level guidance at `$XDG_CONFIG_HOME/agents/AGENTS.md`, but it is not yet adopted across tools
+
+This means Roughdraft should not assume that `~/CLAUDE.md` or `~/AGENTS.md` is a real standard location, and it should not silently write to those paths.
+
+## Product stance
+
+- The canonical Roughdraft-managed user-level source of truth should be `~/.config/agents/AGENTS.md`
+- Provider-specific files should point at that canonical file when it is safe to do so
+- `AGENTS.md` should be the source of truth, not `CLAUDE.md`
+- Roughdraft should prefer symlinks for clean installs
+- Roughdraft should use non-destructive migration behavior for users who already have existing global agent files
+- Roughdraft should install guidance for markdown review workflows, not broad personal-agent policy
+
+## Why `~/.config/agents/AGENTS.md`
+
+- It keeps the source of truth in `AGENTS.md`, which is the open, tool-agnostic format Roughdraft should align with
+- It matches the direction of the open proposal for a global user-level path
+- It avoids pretending that any vendor-specific path is the universal home for all agents
+- It gives Roughdraft one predictable canonical file to create, update, and document
+
+## Supported target files
+
+Roughdraft should manage a canonical file and then create or maintain tool-specific adapters.
+
+### Canonical file
+
+- `~/.config/agents/AGENTS.md`
+
+### Provider-specific adapters
+
+- Claude Code: `~/.claude/CLAUDE.md`
+- Factory / droid: `~/.factory/AGENTS.md`
+- Amp: `~/.config/amp/AGENTS.md`
+
+### Deferred / experimental adapters
+
+- Codex: `~/.codex/AGENTS.md`
+
+Codex should be treated differently for now. OpenAI’s current public Codex docs clearly document `~/.codex/config.toml` as a configuration path and strongly emphasize project-level `AGENTS.md`, but they do not clearly document a user-level `~/.codex/AGENTS.md` path. Roughdraft can support this path later as an opt-in or experimental adapter, but should not rely on it as a guaranteed official location until OpenAI documents it.
+
+## Adapter strategy
+
+Roughdraft should use the following rules when bootstrapping or updating user-level guidance.
+
+### Case 1: canonical file missing
+
+- Create `~/.config/agents/`
+- Create `~/.config/agents/AGENTS.md`
+- Write the Roughdraft managed block into that file
+
+### Case 2: canonical file exists
+
+- Update the Roughdraft managed block in place
+- Leave all non-Roughdraft user content intact
+
+### Case 3: provider-specific file missing
+
+- Create the parent directory if needed
+- Create a symlink from the provider-specific file to the canonical `~/.config/agents/AGENTS.md`
+
+This is the preferred clean-install path.
+
+### Case 4: provider-specific file already symlinks to the canonical file
+
+- Leave the symlink in place
+- Only update the canonical file
+
+### Case 5: provider-specific file exists and is empty
+
+- Replace it with a symlink to the canonical file
+
+### Case 6: provider-specific file exists and contains user-authored content
+
+Roughdraft should not overwrite it silently.
+
+Instead, Roughdraft should choose a non-destructive fallback:
+
+- Preserve the existing file
+- Add or update a Roughdraft-managed block directly inside that file if needed
+- Show the user a migration note explaining that a unified symlinked setup is possible, but was not forced because the target file already had content
+
+This means Roughdraft gets the user the markdown-review behavior immediately without risking data loss.
+
+## Claude-specific behavior
+
+Claude Code officially reads `CLAUDE.md`, not `AGENTS.md`, and its docs recommend creating a `CLAUDE.md` that imports `AGENTS.md` when a project already uses `AGENTS.md`.
+
+For user-level setup, Roughdraft should still prefer a symlink for clean installs because the user explicitly wants `AGENTS.md` as the source of truth. A symlink gives Claude a file named `CLAUDE.md` while still preserving `AGENTS.md` as the canonical content.
+
+If `~/.claude/CLAUDE.md` already exists with user-authored content, Roughdraft should not replace it automatically. In that case the safer migration path is:
+
+- keep the existing file
+- append or update a Roughdraft-managed block there
+- optionally suggest that the user later convert it into a symlink or import-based shim manually
+
+## Guidance content
+
+The managed guidance should stay narrowly focused on the Roughdraft review workflow.
+
+It should tell the agent:
+
+- when the agent wants the user to review, comment on, or compare markdown files, use Roughdraft
+- open the relevant markdown file or folder with `roughdraft "<absolute path>"`
+- after the user finishes reviewing in Roughdraft, continue by reading the markdown file from disk
+- if it needs a refresher on Roughdraft usage or CriticMarkup syntax, run a Roughdraft help command instead of guessing
+
+## Required CLI help surface
+
+Roughdraft should expose a user- and agent-facing help surface that makes the guidance self-contained and durable.
+
+### Minimum requirement
+
+- `roughdraft help`
+
+This should cover:
+
+- what Roughdraft is for
+- how to open a file or folder
+- how the review loop works
+- where to go for CriticMarkup help
+
+### Recommended addition
+
+- `roughdraft help criticmarkup`
+
+This should include a compact reference for:
+
+- comments: `{>>comment<<}`
+- insertions: `{++new text++}`
+- deletions: `{--old text--}`
+- substitutions: `{~~old~>new~~}`
+- highlights: `{==text==}`
+
+The agent guidance should reference `roughdraft help` or `roughdraft help criticmarkup`, not a long syntax tutorial inline.
+
+## Managed block behavior
+
+Roughdraft should manage its own block inside whichever file it edits.
+
+- Use explicit start and end markers
+- Replace only the Roughdraft-managed block on update
+- Never rewrite the rest of the file unnecessarily
+- Keep the managed content short so it does not dilute other personal agent instructions
+
+## User flows
+
+### Clean bootstrap
+
+1. User runs `roughdraft onboard`
+2. Roughdraft creates `~/.config/agents/AGENTS.md`
+3. Roughdraft writes the managed Roughdraft block into that canonical file
+4. Roughdraft creates symlinks for supported provider-specific targets that do not already exist
+5. Roughdraft prints a short summary of what it created
+
+### Existing-user bootstrap
+
+1. User runs `roughdraft onboard`
+2. Roughdraft updates or creates the canonical file
+3. Roughdraft inspects provider-specific targets
+4. Missing or empty targets become symlinks
+5. Non-empty user-authored targets are preserved and get a managed Roughdraft block instead of forced replacement
+6. Roughdraft prints which files were symlinked and which were preserved
+
+### Edit-only flow
+
+If the user already has a unified setup, rerunning onboarding should behave like an updater:
+
+- update the managed Roughdraft block in the canonical file
+- leave symlinks untouched
+- avoid additional prompts or churn
+
+## Non-goals
+
+- Defining a new cross-vendor standard for user-level agent memory
+- Overwriting existing user-authored global agent files without consent
+- Assuming `~/CLAUDE.md` or `~/AGENTS.md` are universal user-level paths
+- Injecting large Roughdraft manuals directly into the global guidance file
+- Solving every tool’s configuration model in v1
+
+## Open questions
+
+- Whether Codex should get an experimental `~/.codex/AGENTS.md` symlink path in v1 or wait for clearer official documentation
+- Whether onboarding should modify files directly, or instead generate a reviewable patch/proposal for the user’s current agent to apply
+- Whether the product should distinguish between "bootstrap global guidance" and "print guidance snippet only"
+
+## Recommended next steps
+
+1. Rename `roughdraft install` to `roughdraft onboard`
+2. Add `roughdraft help criticmarkup`
+3. Replace the current simplistic `~/CLAUDE.md` and `~/AGENTS.md` install story with the canonical-plus-adapters model in this spec
+4. Start with documented adapters for Claude, Factory, and Amp
+5. Leave Codex as explicit follow-up work until its user-level global path is documented more clearly
+
+## References
+
+- Anthropic Claude Code memory docs: https://code.claude.com/docs/en/memory
+- Factory AGENTS.md docs: https://docs.factory.ai/cli/configuration/agents-md
+- Amp manual: https://ampcode.com/manual
+- Proposal to standardize user-level AGENTS.md: https://github.com/agentsmd/agents.md/issues/91
+- OpenAI Codex docs home: https://developers.openai.com/codex


### PR DESCRIPTION
This adds a preview-style homepage and install modal that guide users toward a one-command Roughdraft setup and a browser demo fallback.

It introduces `roughdraft install`, a public `install.sh` helper, and managed user-guidance updates for `~/CLAUDE.md` and `~/AGENTS.md`.

It also switches local URLs to `roughdraft.localhost`, updates loopback binding and port checks accordingly, and documents the broader user-level guidance direction in the new spec.