### PR TITLE
Add update notice and fix macOS add-comment shortcut

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -7,8 +7,10 @@ import { HomeScreen } from "./HomeScreen";
 import { PageCard } from "./PageCard";
 import { PathSwitcher } from "./PathSwitcher";
 import { ProjectTreeSidebar } from "./ProjectTreeSidebar";
+import { UpdateNotice } from "./UpdateNotice";
 import { LocalStorageBackend } from "./local-storage-backend";
 import { recordRecentOpen } from "./recent-items";
+import { fetchUpdateStatus, type UpdateStatus } from "./update-status";
 import { Button } from "./components/ui/button";
 
 interface RequestedPathState {
@@ -279,6 +281,7 @@ export function App() {
   const [projectTreeVersion, setProjectTreeVersion] = useState(0);
   const [loading, setLoading] = useState(true);
   const [demoModeEnabled, setDemoModeEnabled] = useState(false);
+  const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null);
   const [sidebarVisible, setSidebarVisible] = useState(
     () => !getRequestedPathState().documentPath,
   );
@@ -356,6 +359,23 @@ export function App() {
     setSelectedId(null);
     setDocumentPage(null);
     setActiveDocumentPath(null);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadUpdateStatus = async () => {
+      const nextUpdateStatus = await fetchUpdateStatus();
+      if (!cancelled) {
+        setUpdateStatus(nextUpdateStatus);
+      }
+    };
+
+    void loadUpdateStatus();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -673,11 +693,7 @@ export function App() {
   );
 
   if (loading) {
-    return (
-      <div className="flex h-screen items-center justify-center bg-slate-950 text-sm font-medium tracking-[0.18em] text-slate-200 uppercase">
-        <p>Loading canvas...</p>
-      </div>
-    );
+    return <div className="h-screen bg-white" aria-hidden="true" />;
   }
 
   const shouldShowHomepage = !requestedPathState.rawPath && !demoModeEnabled;
@@ -688,6 +704,7 @@ export function App() {
         backend={backend}
         buildLocationForPath={buildLocationForPath}
         onOpenDemo={() => void handleOpenDemo()}
+        updateStatus={updateStatus}
       />
     );
   }
@@ -870,6 +887,17 @@ export function App() {
       ) : null}
 
       <main className="relative min-w-0 flex-1 overflow-hidden">
+        {updateStatus ? (
+          <div
+            className={`pointer-events-none absolute right-4 z-40 max-w-sm ${
+              isDocumentMode ? "top-16" : "top-4"
+            }`}
+          >
+            <div className="pointer-events-auto">
+              <UpdateNotice updateStatus={updateStatus} />
+            </div>
+          </div>
+        ) : null}
         {!sidebarVisible && !isDocumentMode ? (
           <div className="absolute top-4 left-4 z-30">
             <Button

--- a/packages/app/src/HomeScreen.tsx
+++ b/packages/app/src/HomeScreen.tsx
@@ -3,15 +3,18 @@ import { ChevronLeft, ChevronRight, FileText, Folder } from "lucide-react";
 import type { StorageBackend } from "./storage";
 import { Button } from "./components/ui/button";
 import { Input } from "./components/ui/input";
+import { UpdateNotice } from "./UpdateNotice";
 import {
   getFileSystemBrowserError,
   useFileSystemBrowser,
 } from "./file-system-browser";
+import type { UpdateStatus } from "./update-status";
 
 interface HomeScreenProps {
   backend: StorageBackend | null;
   buildLocationForPath: (path?: string | null) => string;
   onOpenDemo: () => void;
+  updateStatus: UpdateStatus | null;
 }
 
 const disabledBackend: StorageBackend = {
@@ -284,6 +287,7 @@ export function HomeScreen({
   backend,
   buildLocationForPath,
   onOpenDemo,
+  updateStatus,
 }: HomeScreenProps) {
   return (
     <div className="min-h-screen bg-slate-50 text-slate-950">
@@ -305,6 +309,12 @@ export function HomeScreen({
             >
               Open demo workspace
             </Button>
+          ) : null}
+
+          {updateStatus ? (
+            <div className="mt-6 max-w-xl">
+              <UpdateNotice updateStatus={updateStatus} />
+            </div>
           ) : null}
 
           <div className="mt-8">

--- a/packages/app/src/UpdateNotice.tsx
+++ b/packages/app/src/UpdateNotice.tsx
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from "react";
+import { ArrowUpRight } from "lucide-react";
+import { Button } from "./components/ui/button";
+import type { UpdateStatus } from "./update-status";
+
+interface UpdateNoticeProps {
+  updateStatus: UpdateStatus;
+}
+
+export function UpdateNotice({ updateStatus }: UpdateNoticeProps) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+
+    const timer = window.setTimeout(() => {
+      setCopied(false);
+    }, 1600);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [copied]);
+
+  const handleUpdate = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(updateStatus.updateCommand);
+      setCopied(true);
+    } catch {
+      window.open(
+        `https://www.npmjs.com/package/${encodeURIComponent(updateStatus.packageName)}`,
+        "_blank",
+        "noopener,noreferrer",
+      );
+    }
+  }, [updateStatus.packageName, updateStatus.updateCommand]);
+
+  return (
+    <div className="rounded-2xl border border-amber-200 bg-amber-50/95 p-4 text-slate-900 shadow-[0_14px_34px_rgba(120,53,15,0.12)] backdrop-blur">
+      <div className="text-[0.68rem] font-semibold tracking-[0.18em] text-amber-700 uppercase">
+        Update available
+      </div>
+      <p className="mt-2 text-sm leading-6 text-slate-700">
+        You&apos;re on {updateStatus.currentVersion}. The latest version is{" "}
+        {updateStatus.latestVersion}.
+      </p>
+      <div className="mt-3 flex items-center gap-3">
+        <Button
+          type="button"
+          size="sm"
+          className="h-8 rounded-lg bg-slate-950 px-3 text-sm font-semibold text-white hover:bg-slate-800"
+          onClick={() => void handleUpdate()}
+          title={`Copy ${updateStatus.updateCommand}`}
+        >
+          {copied ? "Copied" : "Update"}
+        </Button>
+        <span className="inline-flex items-center gap-1 text-xs text-slate-500">
+          {copied ? (
+            "Copied the npm command"
+          ) : (
+            <>
+              Copies the npm command
+              <ArrowUpRight className="size-3" />
+            </>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/comment-shortcuts.ts
+++ b/packages/app/src/comment-shortcuts.ts
@@ -9,6 +9,7 @@ export function getAddCommentShortcutLabel(platform?: string | null) {
 }
 
 export interface AddCommentShortcutEventLike {
+  code: string;
   key: string;
   altKey: boolean;
   ctrlKey: boolean;
@@ -20,7 +21,7 @@ export function matchesAddCommentShortcut(
   event: AddCommentShortcutEventLike,
   platform?: string | null,
 ) {
-  if (event.shiftKey || event.key.toLowerCase() !== "m" || !event.altKey) {
+  if (event.shiftKey || event.code !== "KeyM" || !event.altKey) {
     return false;
   }
 

--- a/packages/app/src/update-status.ts
+++ b/packages/app/src/update-status.ts
@@ -1,0 +1,35 @@
+export interface UpdateStatus {
+  packageName: string;
+  currentVersion: string | null;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+  updateCommand: string;
+}
+
+export async function fetchUpdateStatus(): Promise<UpdateStatus | null> {
+  try {
+    const response = await fetch("/api/update-status");
+    if (!response.ok) return null;
+
+    const payload = (await response.json()) as Partial<UpdateStatus>;
+    if (!payload.updateAvailable) return null;
+    if (
+      typeof payload.packageName !== "string" ||
+      typeof payload.currentVersion !== "string" ||
+      typeof payload.latestVersion !== "string" ||
+      typeof payload.updateCommand !== "string"
+    ) {
+      return null;
+    }
+
+    return {
+      packageName: payload.packageName,
+      currentVersion: payload.currentVersion,
+      latestVersion: payload.latestVersion,
+      updateAvailable: true,
+      updateCommand: payload.updateCommand,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/packages/app/test/comment-shortcuts.test.ts
+++ b/packages/app/test/comment-shortcuts.test.ts
@@ -19,6 +19,7 @@ describe("comment shortcuts", () => {
     expect(
       matchesAddCommentShortcut(
         {
+          code: "KeyM",
           key: "m",
           altKey: true,
           ctrlKey: false,
@@ -34,6 +35,7 @@ describe("comment shortcuts", () => {
     expect(
       matchesAddCommentShortcut(
         {
+          code: "KeyM",
           key: "M",
           altKey: true,
           ctrlKey: true,
@@ -49,6 +51,7 @@ describe("comment shortcuts", () => {
     expect(
       matchesAddCommentShortcut(
         {
+          code: "KeyM",
           key: "m",
           altKey: false,
           ctrlKey: true,
@@ -62,9 +65,42 @@ describe("comment shortcuts", () => {
     expect(
       matchesAddCommentShortcut(
         {
+          code: "KeyM",
           key: "m",
           altKey: true,
           ctrlKey: true,
+          metaKey: true,
+          shiftKey: false,
+        },
+        "MacIntel",
+      ),
+    ).toBe(false);
+  });
+
+  it("matches the Mac shortcut from the physical key code even when Option changes the character", () => {
+    expect(
+      matchesAddCommentShortcut(
+        {
+          code: "KeyM",
+          key: "µ",
+          altKey: true,
+          ctrlKey: false,
+          metaKey: true,
+          shiftKey: false,
+        },
+        "MacIntel",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects non-M physical keys even if the produced character is m", () => {
+    expect(
+      matchesAddCommentShortcut(
+        {
+          code: "KeyN",
+          key: "m",
+          altKey: true,
+          ctrlKey: false,
           metaKey: true,
           shiftKey: false,
         },

--- a/packages/app/test/update-notice.test.tsx
+++ b/packages/app/test/update-notice.test.tsx
@@ -1,0 +1,43 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { UpdateNotice } from "../src/UpdateNotice";
+
+describe("UpdateNotice", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders the current and latest versions with an update button", async () => {
+    await act(async () => {
+      root.render(
+        <UpdateNotice
+          updateStatus={{
+            packageName: "roughdraft",
+            currentVersion: "0.1.0",
+            latestVersion: "0.2.0",
+            updateAvailable: true,
+            updateCommand: "npm i -g roughdraft@latest",
+          }}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("Update available");
+    expect(container.textContent).toContain("0.1.0");
+    expect(container.textContent).toContain("0.2.0");
+    expect(container.querySelector("button")?.textContent).toContain("Update");
+  });
+});

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -1,8 +1,19 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath, URL } from "node:url";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
   test: {
     environment: "jsdom",
-    include: ["src/**/*.test.ts", "test/**/*.test.ts"],
+    include: [
+      "src/**/*.test.ts",
+      "src/**/*.test.tsx",
+      "test/**/*.test.ts",
+      "test/**/*.test.tsx",
+    ],
   },
 });

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -137,6 +137,36 @@ describe("createApp", () => {
     expect(response.body).not.toHaveProperty("projectDir");
   });
 
+  it("reports update status from npm metadata", async () => {
+    const packageJsonPath = path.join(projectDir, "package.json");
+    fs.writeFileSync(
+      packageJsonPath,
+      JSON.stringify({ name: "roughdraft", version: "0.1.0" }),
+    );
+
+    const { app } = createApp({
+      homeDir,
+      staticDirPath: projectDir,
+      packageJsonPath,
+      fetchImpl: async () =>
+        new Response(JSON.stringify({ version: "0.2.0" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    const response = await request(app).get("/api/update-status");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      packageName: "roughdraft",
+      currentVersion: "0.1.0",
+      latestVersion: "0.2.0",
+      updateAvailable: true,
+      updateCommand: "npm i -g roughdraft@latest",
+    });
+  });
+
   it("lists directories from the home directory when no path is provided", async () => {
     fs.mkdirSync(path.join(homeDir, "docs"));
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,6 +8,7 @@ import {
   ROUGHDRAFT_LOOPBACK_HOSTS,
   ROUGHDRAFT_PUBLIC_HOST,
 } from "./network.js";
+import { resolveUpdateStatus } from "./update-status.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const staticDir = path.resolve(__dirname, "../../app/dist");
@@ -63,6 +64,9 @@ interface CreateAppOptions {
   projectDir?: string;
   homeDir?: string;
   staticDirPath?: string;
+  packageJsonPath?: string;
+  fetchImpl?: typeof fetch;
+  packageName?: string;
 }
 
 interface CreateAppResult {
@@ -299,6 +303,7 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
   const port = options.port ?? 3000;
   const homeDir = options.homeDir ?? os.homedir();
   const staticDirPath = options.staticDirPath ?? staticDir;
+  const fetchImpl = options.fetchImpl ?? fetch;
   const app = express();
 
   app.use(express.json({ limit: "50mb" }));
@@ -500,6 +505,15 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
         fileSystemBrowsing: true,
       },
     });
+  });
+
+  app.get("/api/update-status", async (_req, res) => {
+    const updateStatus = await resolveUpdateStatus({
+      fetchImpl,
+      packageJsonPath: options.packageJsonPath,
+      packageName: options.packageName,
+    });
+    res.json(updateStatus);
   });
 
   app.get("/api/directories", (req, res) => {

--- a/packages/server/src/update-status.test.ts
+++ b/packages/server/src/update-status.test.ts
@@ -1,0 +1,81 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { compareVersions, resolveUpdateStatus } from "./update-status";
+
+describe("compareVersions", () => {
+  it("orders numeric versions correctly", () => {
+    expect(compareVersions("0.1.0", "0.2.0")).toBeLessThan(0);
+    expect(compareVersions("1.4.0", "1.4.0")).toBe(0);
+    expect(compareVersions("2.0.0", "1.9.9")).toBeGreaterThan(0);
+  });
+
+  it("treats prereleases as older than stable releases", () => {
+    expect(compareVersions("0.2.0-beta.1", "0.2.0")).toBeLessThan(0);
+    expect(compareVersions("0.2.0-beta.2", "0.2.0-beta.1")).toBeGreaterThan(0);
+  });
+});
+
+describe("resolveUpdateStatus", () => {
+  const tempPaths: string[] = [];
+
+  afterEach(() => {
+    tempPaths.forEach((tempPath) => {
+      fs.rmSync(tempPath, { recursive: true, force: true });
+    });
+    tempPaths.length = 0;
+  });
+
+  it("reports when the installed version is behind npm", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "roughdraft-pkg-"));
+    const packageJsonPath = path.join(tempDir, "package.json");
+    tempPaths.push(tempDir);
+    fs.writeFileSync(
+      packageJsonPath,
+      JSON.stringify({ name: "roughdraft", version: "0.1.0" }),
+    );
+
+    const status = await resolveUpdateStatus({
+      packageJsonPath,
+      fetchImpl: async () =>
+        new Response(JSON.stringify({ version: "0.2.0" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    expect(status).toEqual({
+      packageName: "roughdraft",
+      currentVersion: "0.1.0",
+      latestVersion: "0.2.0",
+      updateAvailable: true,
+      updateCommand: "npm i -g roughdraft@latest",
+    });
+  });
+
+  it("degrades cleanly when npm cannot be reached", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "roughdraft-pkg-"));
+    const packageJsonPath = path.join(tempDir, "package.json");
+    tempPaths.push(tempDir);
+    fs.writeFileSync(
+      packageJsonPath,
+      JSON.stringify({ name: "roughdraft", version: "0.1.0" }),
+    );
+
+    const status = await resolveUpdateStatus({
+      packageJsonPath,
+      fetchImpl: async () => {
+        throw new Error("offline");
+      },
+    });
+
+    expect(status).toEqual({
+      packageName: "roughdraft",
+      currentVersion: "0.1.0",
+      latestVersion: null,
+      updateAvailable: false,
+      updateCommand: "npm i -g roughdraft@latest",
+    });
+  });
+});

--- a/packages/server/src/update-status.ts
+++ b/packages/server/src/update-status.ts
@@ -1,0 +1,168 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const defaultPackageJsonPath = path.resolve(__dirname, "../../../package.json");
+const DEFAULT_PACKAGE_NAME = "roughdraft";
+
+interface PackageManifest {
+  name?: string;
+  version?: string;
+}
+
+interface ParsedVersion {
+  parts: number[];
+  prerelease: string[];
+}
+
+export interface UpdateStatus {
+  packageName: string;
+  currentVersion: string | null;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+  updateCommand: string;
+}
+
+interface ResolveUpdateStatusOptions {
+  fetchImpl?: typeof fetch;
+  packageJsonPath?: string;
+  packageName?: string;
+}
+
+function readInstalledPackageInfo(packageJsonPath = defaultPackageJsonPath): {
+  packageName: string;
+  currentVersion: string | null;
+} {
+  try {
+    const raw = fs.readFileSync(packageJsonPath, "utf8");
+    const manifest = JSON.parse(raw) as PackageManifest;
+    return {
+      packageName: manifest.name?.trim() || DEFAULT_PACKAGE_NAME,
+      currentVersion: manifest.version?.trim() || null,
+    };
+  } catch {
+    return {
+      packageName: DEFAULT_PACKAGE_NAME,
+      currentVersion: null,
+    };
+  }
+}
+
+function parseVersion(version: string): ParsedVersion {
+  const normalizedVersion = version.trim().replace(/^v/i, "");
+  const [mainVersion, prereleaseVersion = ""] = normalizedVersion.split("-", 2);
+  const parts = mainVersion
+    .split(".")
+    .map((part) => Number.parseInt(part, 10))
+    .map((part) => (Number.isNaN(part) ? 0 : part));
+
+  const prerelease = prereleaseVersion
+    .split(".")
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  return { parts, prerelease };
+}
+
+function comparePrerelease(left: string[], right: string[]) {
+  if (left.length === 0 && right.length === 0) return 0;
+  if (left.length === 0) return 1;
+  if (right.length === 0) return -1;
+
+  const length = Math.max(left.length, right.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = left[index];
+    const rightPart = right[index];
+
+    if (leftPart === undefined) return -1;
+    if (rightPart === undefined) return 1;
+    if (leftPart === rightPart) continue;
+
+    const leftNumber = Number.parseInt(leftPart, 10);
+    const rightNumber = Number.parseInt(rightPart, 10);
+    const leftIsNumeric = /^[0-9]+$/.test(leftPart);
+    const rightIsNumeric = /^[0-9]+$/.test(rightPart);
+
+    if (leftIsNumeric && rightIsNumeric) {
+      if (leftNumber !== rightNumber) {
+        return leftNumber < rightNumber ? -1 : 1;
+      }
+      continue;
+    }
+
+    if (leftIsNumeric !== rightIsNumeric) {
+      return leftIsNumeric ? -1 : 1;
+    }
+
+    return leftPart.localeCompare(rightPart);
+  }
+
+  return 0;
+}
+
+export function compareVersions(leftVersion: string, rightVersion: string) {
+  const left = parseVersion(leftVersion);
+  const right = parseVersion(rightVersion);
+  const length = Math.max(left.parts.length, right.parts.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = left.parts[index] ?? 0;
+    const rightPart = right.parts[index] ?? 0;
+
+    if (leftPart !== rightPart) {
+      return leftPart < rightPart ? -1 : 1;
+    }
+  }
+
+  return comparePrerelease(left.prerelease, right.prerelease);
+}
+
+async function fetchLatestVersion(
+  packageName: string,
+  fetchImpl: typeof fetch,
+): Promise<string | null> {
+  try {
+    const response = await fetchImpl(
+      `https://registry.npmjs.org/${encodeURIComponent(packageName)}/latest`,
+      {
+        headers: { accept: "application/json" },
+        signal: AbortSignal.timeout(1500),
+      },
+    );
+
+    if (!response.ok) return null;
+
+    const payload = (await response.json()) as PackageManifest;
+    return payload.version?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveUpdateStatus(
+  options: ResolveUpdateStatusOptions = {},
+): Promise<UpdateStatus> {
+  const installedPackageInfo = readInstalledPackageInfo(
+    options.packageJsonPath,
+  );
+  const packageName =
+    options.packageName?.trim() || installedPackageInfo.packageName;
+  const currentVersion = installedPackageInfo.currentVersion;
+  const latestVersion = await fetchLatestVersion(
+    packageName,
+    options.fetchImpl ?? fetch,
+  );
+
+  return {
+    packageName,
+    currentVersion,
+    latestVersion,
+    updateAvailable:
+      !!currentVersion &&
+      !!latestVersion &&
+      compareVersions(currentVersion, latestVersion) < 0,
+    updateCommand: `npm i -g ${packageName}@latest`,
+  };
+}


### PR DESCRIPTION
This adds an /api/update-status endpoint that compares the installed CLI version with the latest npm release and exposes an update command. The app now fetches that status and shows an update notice on the home screen and in the editor, with tests covering the client and server behavior. It also fixes macOS add-comment shortcut detection by matching the physical KeyM code so Option-modified characters still trigger the shortcut correctly.