### PR TITLE
Improve worktree dev routing and document editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ roughdraft start
 Open a specific project folder:
 
 ```bash
-roughdraft open /absolute/path/to/my-essay
+roughdraft open ./path/to/my-essay
 ```
 
 Open a specific markdown file directly:
 
 ```bash
-roughdraft open /absolute/path/to/my-essay/draft.md
+roughdraft open ./path/to/my-essay/draft.md
 ```
 
 Check or stop the background server:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ If you prefer package scripts, the same commands are available as `pnpm setup` a
 
 Running `pnpm setup` also installs a per-worktree dev CLI wrapper into `~/.local/bin` by default, using the current worktree directory name. For example, this checkout might install `roughdraft-dev-lyon-v2`, which points at this worktree's local code while leaving the published global `roughdraft` command untouched.
 
+Each dev wrapper keeps its own server state under `~/.roughdraft/dev/<wrapper-name>` by default, so opening a file from one worktree will not accidentally reuse a backend started from another worktree. `roughdraft-dev-<worktree> open ...` can start its own background server as needed; you do not need to run `pnpm dev` first just to open files in Roughdraft.
+
 You can refresh that wrapper manually with:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "./scripts/run.sh",
     "dev": "node scripts/dev.mjs",
     "dev:install-cli": "node scripts/install-dev-cli.mjs",
-    "dev:web": "VITE_PREVIEW_WEB=1 pnpm --filter @roughdraft/app dev",
+    "dev:web": "node scripts/dev-web.mjs",
     "lint": "biome check . --assist-enabled=false",
     "lint:fix": "biome check --write . --assist-enabled=false",
     "format": "biome format --write .",

--- a/packages/app/components.json
+++ b/packages/app/components.json
@@ -6,7 +6,7 @@
   "tailwind": {
     "config": "",
     "css": "src/style.css",
-    "baseColor": "zinc",
+    "baseColor": "stone",
     "cssVariables": true,
     "prefix": ""
   },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -11,6 +11,10 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.41.1",
     "@fontsource-variable/inter": "^5.2.8",
     "@joplin/turndown-plugin-gfm": "^1.0.64",
     "@pierre/trees": "1.0.0-beta.3",
@@ -30,6 +34,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "codemirror": "^6.0.2",
     "lucide-react": "^1.8.0",
     "marked": "^15.0.0",
     "react": "^19.1.0",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -58,9 +58,9 @@ export function App() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [canvasRevealRequest, setCanvasRevealRequest] =
     useState<CanvasRevealRequest | null>(null);
-  const [, setDocumentSaveState] = useState<
-    "idle" | "saving" | "error"
-  >("idle");
+  const [, setDocumentSaveState] = useState<"idle" | "saving" | "error">(
+    "idle",
+  );
   const documentEditorViewMode =
     getDocumentEditorViewModeFromLocation("rich-text");
   const [projectTreeVersion, setProjectTreeVersion] = useState(0);
@@ -605,7 +605,9 @@ export function App() {
               activeDocumentPath={activeDocumentPath}
               documentFilenameLabel={documentFilenameLabel}
               documentEditorViewMode={documentEditorViewMode}
-              onDocumentEditorViewModeChange={handleDocumentEditorViewModeChange}
+              onDocumentEditorViewModeChange={
+                handleDocumentEditorViewModeChange
+              }
               onSaveDocument={handleSaveDocument}
               onDocumentSaveStateChange={setDocumentSaveState}
               backend={backend}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,255 +1,40 @@
 import { useEffect, useState, useCallback, useRef } from "react";
-import { ChevronLeft, Menu } from "lucide-react";
 import type { StorageBackend, Page, ProjectLayout } from "./storage";
 import { detectBackend } from "./detect-backend";
-import { Canvas } from "./Canvas";
+import { AppSidebar } from "./AppSidebar";
+import { CanvasWorkspace } from "./CanvasWorkspace";
+import { DocumentWorkspace } from "./DocumentWorkspace";
 import { HomeScreen } from "./HomeScreen";
-import { PageCard } from "./PageCard";
-import { PathSwitcher } from "./PathSwitcher";
-import { ProjectTreeSidebar } from "./ProjectTreeSidebar";
 import { UpdateNotice } from "./UpdateNotice";
+import {
+  CANVAS_FRAME_WIDTH,
+  type DocumentEditorViewMode,
+  type RequestedPathState,
+  type ViewMode,
+  buildLocationForDocumentEditorViewMode,
+  buildLocationForPath,
+  buildLocationForViewMode,
+  formatWorkspacePathForDisplay,
+  getCanvasFrameWidth,
+  getCanvasPageId,
+  getDocumentEditorViewModeFromLocation,
+  getDocumentNavigationState,
+  getPathLeaf,
+  getRequestedPathState,
+  getViewModeFromLocation,
+  getWorkspaceName,
+  getWorkspacePath,
+  joinPath,
+  syncProjectPathInUrl,
+  syncRequestedPathInUrl,
+} from "./app-navigation";
 import { LocalStorageBackend } from "./local-storage-backend";
 import { recordRecentOpen } from "./recent-items";
 import { fetchUpdateStatus, type UpdateStatus } from "./update-status";
-import { Button } from "./components/ui/button";
-
-interface RequestedPathState {
-  rawPath: string | null;
-  projectPath: string | null;
-  documentPath: string | null;
-}
 
 interface CanvasRevealRequest {
   pageId: string;
   key: string;
-}
-
-type ViewMode = "canvas" | "document";
-
-const CANVAS_FRAME_WIDTH = 680;
-const CANVAS_FRAME_WIDTH_WITH_RAIL = 960;
-
-function normalizePathSeparators(value: string) {
-  return value.replace(/\\/g, "/");
-}
-
-function getRawPathFromLocation(): string | null {
-  const searchParams = new URLSearchParams(window.location.search);
-  const queryPath = searchParams.get("path")?.trim();
-  if (queryPath) return queryPath;
-
-  const normalizedPathname = normalizePathSeparators(window.location.pathname);
-  if (normalizedPathname !== "/" && !normalizedPathname.startsWith("/api")) {
-    const decodedPathname = decodeURIComponent(normalizedPathname);
-    return decodedPathname.startsWith("/")
-      ? decodedPathname
-      : `/${decodedPathname}`;
-  }
-
-  return null;
-}
-
-function getViewModeFromLocation(fallbackMode: ViewMode): ViewMode {
-  const searchParams = new URLSearchParams(window.location.search);
-  const requestedMode = searchParams.get("mode");
-  if (requestedMode === "canvas" || requestedMode === "document") {
-    return requestedMode;
-  }
-  return fallbackMode;
-}
-
-function getRequestedPathState(): RequestedPathState {
-  const rawPath = getRawPathFromLocation();
-  if (!rawPath) {
-    return { rawPath: null, projectPath: null, documentPath: null };
-  }
-
-  const normalizedPath = normalizePathSeparators(rawPath);
-  if (!normalizedPath.toLowerCase().endsWith(".md")) {
-    return { rawPath, projectPath: rawPath, documentPath: null };
-  }
-
-  const lastSlashIndex = Math.max(
-    normalizedPath.lastIndexOf("/"),
-    normalizedPath.lastIndexOf("\\"),
-  );
-  const projectPath =
-    lastSlashIndex >= 0 ? rawPath.slice(0, lastSlashIndex) || "/" : ".";
-  const documentPath = rawPath.slice(lastSlashIndex + 1);
-
-  return { rawPath, projectPath, documentPath };
-}
-
-function getWorkspacePath(path?: string) {
-  return path?.trim() || null;
-}
-
-function formatWorkspacePathForDisplay(path?: string | null) {
-  const value = path?.trim();
-  if (!value) return null;
-
-  const normalizedPath = normalizePathSeparators(value);
-  const collapsedHomePath = normalizedPath.replace(
-    /^\/Users\/[^/]+(?=\/|$)/,
-    "~",
-  );
-  return value.includes("\\")
-    ? collapsedHomePath.replace(/\//g, "\\")
-    : collapsedHomePath;
-}
-
-function getWorkspaceName(path?: string) {
-  const workspacePath = getWorkspacePath(path);
-  if (!workspacePath) return "Browser drafts";
-
-  const segments = workspacePath.split(/[\\/]/).filter(Boolean);
-  return segments.at(-1) || workspacePath;
-}
-
-function getPathLeaf(path?: string | null) {
-  const value = path?.trim();
-  if (!value) return null;
-
-  const segments = value.split(/[\\/]/).filter(Boolean);
-  return segments.at(-1) || value;
-}
-
-function hasCriticMarkupComments(content: string) {
-  return content.includes("{>>");
-}
-
-function getCanvasFrameWidth(
-  page: Page | null | undefined,
-  fallbackWidth: number,
-) {
-  if (!page) return fallbackWidth;
-  return hasCriticMarkupComments(page.content)
-    ? CANVAS_FRAME_WIDTH_WITH_RAIL
-    : fallbackWidth;
-}
-
-function getSaveStateLabel(saveState: "idle" | "saving" | "error") {
-  switch (saveState) {
-    case "saving":
-      return "Saving…";
-    case "error":
-      return "Save failed";
-    default:
-      return "Saved";
-  }
-}
-
-function joinPath(basePath: string, relativePath: string) {
-  const separator = basePath.includes("\\") ? "\\" : "/";
-  const normalizedBasePath = basePath.endsWith(separator)
-    ? basePath.slice(0, -1)
-    : basePath;
-
-  return relativePath
-    .split("/")
-    .filter(Boolean)
-    .reduce(
-      (result, segment) => `${result}${separator}${segment}`,
-      normalizedBasePath,
-    );
-}
-
-function getCanvasPageId(relativePath: string) {
-  const normalizedPath = normalizePathSeparators(relativePath);
-  if (normalizedPath.includes("/")) return null;
-  return normalizedPath.replace(/\.md$/i, "");
-}
-
-function getContainingPath(pathValue: string) {
-  const trimmedPath = pathValue.trim();
-  if (!trimmedPath) return trimmedPath;
-
-  const normalizedPath = trimmedPath.replace(/[\\/]+$/, "");
-  if (!normalizedPath) return trimmedPath.startsWith("\\") ? "\\" : "/";
-
-  const lastSeparatorIndex = Math.max(
-    normalizedPath.lastIndexOf("/"),
-    normalizedPath.lastIndexOf("\\"),
-  );
-
-  if (lastSeparatorIndex < 0) return ".";
-  if (lastSeparatorIndex === 0) return normalizedPath[0] === "\\" ? "\\" : "/";
-  return normalizedPath.slice(0, lastSeparatorIndex);
-}
-
-function getOpenedFolderPath(pathValue: string) {
-  const trimmedPath = pathValue.trim();
-  if (!trimmedPath) return trimmedPath;
-
-  return normalizePathSeparators(trimmedPath).toLowerCase().endsWith(".md")
-    ? getContainingPath(trimmedPath)
-    : trimmedPath.replace(/[\\/]+$/, "") || trimmedPath;
-}
-
-function getDocumentNavigationState(
-  projectPath: string,
-  relativePath: string,
-  currentRawPath: string | null,
-): RequestedPathState {
-  const relativeFolderPath = getContainingPath(relativePath);
-  const nextFolderPath =
-    relativeFolderPath === "."
-      ? projectPath
-      : joinPath(projectPath, relativeFolderPath);
-  const shouldPreserveUrl =
-    !!currentRawPath &&
-    normalizePathSeparators(getOpenedFolderPath(currentRawPath)) ===
-      normalizePathSeparators(nextFolderPath);
-
-  return {
-    rawPath: shouldPreserveUrl
-      ? currentRawPath
-      : joinPath(projectPath, relativePath),
-    projectPath,
-    documentPath: relativePath,
-  };
-}
-
-function buildLocationForPath(path?: string | null) {
-  const nextPath = path?.trim() || null;
-  const url = new URL(window.location.href);
-
-  if (nextPath) {
-    if (!nextPath.includes("\\")) {
-      url.pathname = nextPath.startsWith("/") ? nextPath : `/${nextPath}`;
-      url.searchParams.delete("path");
-    } else {
-      url.pathname = "/";
-      url.searchParams.set("path", nextPath);
-    }
-  } else {
-    url.searchParams.delete("path");
-    url.pathname = "/";
-  }
-
-  return `${url.pathname}${url.search}${url.hash}`;
-}
-
-function buildLocationForViewMode(mode: ViewMode) {
-  const url = new URL(window.location.href);
-  url.searchParams.set("mode", mode);
-  return `${url.pathname}${url.search}${url.hash}`;
-}
-
-function syncProjectPathInUrl(projectPath?: string) {
-  const nextLocation = buildLocationForPath(getWorkspacePath(projectPath));
-  const currentLocation = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-  if (nextLocation !== currentLocation) {
-    window.history.replaceState(null, "", nextLocation);
-  }
-}
-
-function syncRequestedPathInUrl(path?: string | null) {
-  const nextLocation = buildLocationForPath(path);
-  const currentLocation = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-  if (nextLocation !== currentLocation) {
-    window.history.replaceState(null, "", nextLocation);
-  }
 }
 
 export function App() {
@@ -273,11 +58,11 @@ export function App() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [canvasRevealRequest, setCanvasRevealRequest] =
     useState<CanvasRevealRequest | null>(null);
-  const [documentSaveState, setDocumentSaveState] = useState<
+  const [, setDocumentSaveState] = useState<
     "idle" | "saving" | "error"
   >("idle");
-  const [documentToolbarHost, setDocumentToolbarHost] =
-    useState<HTMLDivElement | null>(null);
+  const documentEditorViewMode =
+    getDocumentEditorViewModeFromLocation("rich-text");
   const [projectTreeVersion, setProjectTreeVersion] = useState(0);
   const [loading, setLoading] = useState(true);
   const [demoModeEnabled, setDemoModeEnabled] = useState(false);
@@ -692,6 +477,14 @@ export function App() {
     [viewMode],
   );
 
+  const handleDocumentEditorViewModeChange = useCallback(
+    (nextMode: DocumentEditorViewMode) => {
+      if (nextMode === documentEditorViewMode) return;
+      window.location.assign(buildLocationForDocumentEditorViewMode(nextMode));
+    },
+    [documentEditorViewMode],
+  );
+
   if (loading) {
     return <div className="h-screen bg-[#FCFCFC]" aria-hidden="true" />;
   }
@@ -768,241 +561,74 @@ export function App() {
         }
       : null;
   const projectLabel = getPathLeaf(backend?.info.projectPath) ?? workspaceName;
-  const documentSaveStateClass =
-    documentSaveState === "error"
-      ? "text-rose-600"
-      : documentSaveState === "saving"
-        ? "text-amber-600"
-        : "text-slate-400";
+  const documentFilenameLabel =
+    getPathLeaf(activeDocumentPath) ?? "Untitled.md";
   const sidebarToggleLabel = sidebarVisible ? "Hide sidebar" : "Show sidebar";
 
   return (
     <div className="flex h-screen overflow-hidden bg-[#FCFCFC] text-slate-950">
       {sidebarVisible ? (
-        <aside
-          className={`flex h-full w-[320px] max-w-[34vw] min-w-[280px] shrink-0 flex-col border-r ${
-            isDocumentMode
-              ? "border-slate-200 bg-white"
-              : "border-slate-200/80 bg-white"
-          }`}
-        >
-          <div
-            className={`border-b px-4 pt-5 pb-4 ${isDocumentMode ? "border-slate-200" : "border-slate-200/80"}`}
-          >
-            {!isDocumentMode ? (
-              <div className="mb-3 flex justify-end">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="rounded-[10px] text-slate-600 hover:bg-slate-100 hover:text-slate-900"
-                  onClick={() => setSidebarVisible(false)}
-                  aria-label={sidebarToggleLabel}
-                  title={sidebarToggleLabel}
-                >
-                  <ChevronLeft className="size-4" />
-                </Button>
-              </div>
-            ) : null}
-
-            {backend ? (
-              <PathSwitcher
-                backend={backend}
-                currentLabel={projectLabel}
-                currentPath={displayPath ?? null}
-                projectPath={backend.info.projectPath ?? null}
-                buildLocationForPath={buildLocationForPath}
-                dismissCount={pathSwitcherDismissCount}
-                description={workspacePathLabel}
-              />
-            ) : (
-              <div className="rounded-[14px] border border-slate-200/80 bg-white/80 px-4 py-3 shadow-[0_8px_24px_rgba(15,23,42,0.06)]">
-                <div className="truncate text-[0.95rem] font-semibold tracking-[-0.02em] text-slate-950">
-                  {projectLabel}
-                </div>
-                <div className="mt-1 truncate text-[0.74rem] text-slate-500">
-                  {workspacePathLabel}
-                </div>
-              </div>
-            )}
-
-            <div className="mt-4">
-              <div className="grid h-9 grid-cols-2 rounded-[10px] border border-slate-200/80 bg-white/75 p-1 shadow-[0_6px_18px_rgba(15,23,42,0.04)]">
-                <button
-                  type="button"
-                  className={`rounded-[8px] px-3 text-[0.82rem] font-semibold transition ${
-                    viewMode === "canvas"
-                      ? "bg-slate-900 text-white shadow-[0_6px_14px_rgba(15,23,42,0.18)]"
-                      : "text-slate-600 hover:bg-slate-100/80"
-                  }`}
-                  onClick={() => void handleViewModeChange("canvas")}
-                >
-                  Canvas
-                </button>
-                <button
-                  type="button"
-                  className={`rounded-[8px] px-3 text-[0.82rem] font-semibold transition ${
-                    isDocumentMode
-                      ? "bg-slate-900 text-white shadow-[0_6px_14px_rgba(15,23,42,0.18)]"
-                      : "text-slate-600 hover:bg-slate-100/80"
-                  }`}
-                  onClick={() => void handleViewModeChange("document")}
-                >
-                  Document
-                </button>
-              </div>
-            </div>
-
-            <div className="mt-3">
-              <Button
-                type="button"
-                variant={isDocumentMode ? "outline" : "default"}
-                className={`h-10 w-full justify-center rounded-[10px] border text-[0.84rem] font-semibold shadow-none ${
-                  isDocumentMode
-                    ? "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
-                    : "border-slate-900 bg-slate-900 text-white hover:bg-slate-800"
-                }`}
-                onClick={() => void handleCreatePage()}
-                title={isDocumentMode ? "New document" : "New page"}
-              >
-                {isDocumentMode ? "+ New document" : "+ New page"}
-              </Button>
-            </div>
-          </div>
-
-          <div className="min-h-0 flex-1">
-            {backend ? (
-              <ProjectTreeSidebar
-                backend={backend}
-                projectPath={backend.info.projectPath ?? null}
-                currentPath={treeCurrentPath ?? null}
-                buildLocationForPath={buildLocationForPath}
-                layout="embedded"
-                refreshKey={projectTreeVersion}
-                onOpenMarkdownPage={handleOpenMarkdownPage}
-              />
-            ) : null}
-          </div>
-        </aside>
+        <AppSidebar
+          isDocumentMode={isDocumentMode}
+          sidebarToggleLabel={sidebarToggleLabel}
+          backend={backend}
+          projectLabel={projectLabel}
+          displayPath={displayPath ?? null}
+          workspacePathLabel={workspacePathLabel}
+          buildLocationForPath={buildLocationForPath}
+          pathSwitcherDismissCount={pathSwitcherDismissCount}
+          viewMode={viewMode}
+          onViewModeChange={handleViewModeChange}
+          onCreatePage={() => void handleCreatePage()}
+          onHideSidebar={() => setSidebarVisible(false)}
+          treeCurrentPath={treeCurrentPath ?? null}
+          projectTreeVersion={projectTreeVersion}
+          onOpenMarkdownPage={handleOpenMarkdownPage}
+        />
       ) : null}
 
       <main className="relative min-w-0 flex-1 overflow-hidden">
         {updateStatus ? (
-          <div
-            className={`pointer-events-none absolute right-4 z-40 max-w-sm ${
-              isDocumentMode ? "top-16" : "top-4"
-            }`}
-          >
+          <div className="pointer-events-none absolute top-4 right-4 z-40 max-w-sm">
             <div className="pointer-events-auto">
               <UpdateNotice updateStatus={updateStatus} />
             </div>
           </div>
         ) : null}
-        {!sidebarVisible && !isDocumentMode ? (
-          <div className="absolute top-4 left-4 z-30">
-            <Button
-              type="button"
-              variant="outline"
-              size="icon"
-              className="size-9 rounded-[10px] border-slate-200 bg-white/94 text-slate-700 shadow-[0_10px_24px_rgba(15,23,42,0.08)] backdrop-blur hover:bg-white"
-              onClick={() => setSidebarVisible(true)}
-              aria-label={sidebarToggleLabel}
-              title={sidebarToggleLabel}
-            >
-              <Menu className="size-4" />
-            </Button>
-          </div>
-        ) : null}
         <div className="flex h-full flex-col overflow-hidden bg-[#FCFCFC]">
           {isDocumentMode ? (
-            <>
-              <div className="border-b border-slate-200 bg-[#FCFCFC]/92 px-5 py-2 backdrop-blur sm:px-8">
-                <div className="flex w-full items-center gap-2">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-sm"
-                    className="shrink-0 rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-900"
-                    onClick={() => setSidebarVisible((visible) => !visible)}
-                    aria-label={sidebarToggleLabel}
-                    title={sidebarToggleLabel}
-                  >
-                    {sidebarVisible ? (
-                      <ChevronLeft className="size-4" />
-                    ) : (
-                      <Menu className="size-4" />
-                    )}
-                  </Button>
-                  <div
-                    ref={setDocumentToolbarHost}
-                    className="min-w-0 flex-1 overflow-x-auto"
-                  />
-                  <div
-                    className={`shrink-0 text-[0.68rem] font-medium ${documentSaveStateClass}`}
-                    title={getSaveStateLabel(documentSaveState)}
-                  >
-                    {getSaveStateLabel(documentSaveState)}
-                  </div>
-                </div>
-              </div>
-              <div className="min-h-0 flex-1 overflow-y-auto px-8 py-8 sm:px-12">
-                <div className="mx-auto min-h-full max-w-[1080px]">
-                  {documentPage ? (
-                    backend ? (
-                      <PageCard
-                        key={`${documentPage.id}:${activeDocumentPath ?? ""}`}
-                        page={documentPage}
-                        mode="document"
-                        selected
-                        canDelete={false}
-                        onSave={handleSaveDocument}
-                        onSaveStateChange={setDocumentSaveState}
-                        documentToolbarHost={documentToolbarHost}
-                        backend={backend}
-                      />
-                    ) : null
-                  ) : (
-                    <div className="flex min-h-[50vh] items-center justify-center text-sm text-slate-500">
-                      Select a markdown file from the sidebar.
-                    </div>
-                  )}
-                </div>
-              </div>
-            </>
+            <DocumentWorkspace
+              sidebarVisible={sidebarVisible}
+              sidebarToggleLabel={sidebarToggleLabel}
+              onToggleSidebar={() => setSidebarVisible((visible) => !visible)}
+              documentPage={documentPage}
+              activeDocumentPath={activeDocumentPath}
+              documentFilenameLabel={documentFilenameLabel}
+              documentEditorViewMode={documentEditorViewMode}
+              onDocumentEditorViewModeChange={handleDocumentEditorViewModeChange}
+              onSaveDocument={handleSaveDocument}
+              onDocumentSaveStateChange={setDocumentSaveState}
+              backend={backend}
+            />
           ) : (
-            <Canvas
-              onPointerDownOnCanvas={handleCanvasPointerDown}
+            <CanvasWorkspace
+              sidebarVisible={sidebarVisible}
+              sidebarToggleLabel={sidebarToggleLabel}
+              onShowSidebar={() => setSidebarVisible(true)}
+              pages={pages}
+              layout={layout}
+              backend={backend}
+              selectedId={selectedId}
+              canvasRevealRequest={canvasRevealRequest}
               initialWorldCenter={initialWorldCenter}
               initialWorldCenterKey={initialWorldCenterKey}
-              focusedWorldFrame={revealedPageFrame}
-              focusedWorldFrameKey={canvasRevealRequest?.key}
-            >
-              {pages.map((page) => {
-                const pos = layout.pages[page.id] || { x: 0, y: 0 };
-                if (!backend) return null;
-
-                return (
-                  <PageCard
-                    key={page.id}
-                    page={page}
-                    x={pos.x}
-                    y={pos.y}
-                    selected={selectedId === page.id}
-                    focusRequestKey={
-                      canvasRevealRequest?.pageId === page.id
-                        ? canvasRevealRequest.key
-                        : null
-                    }
-                    canDelete
-                    onSelect={setSelectedId}
-                    onSave={handleSavePage}
-                    onReposition={handleReposition}
-                    onDelete={handleDeletePage}
-                    backend={backend}
-                  />
-                );
-              })}
-            </Canvas>
+              revealedPageFrame={revealedPageFrame}
+              onCanvasPointerDown={handleCanvasPointerDown}
+              onSelectPage={setSelectedId}
+              onSavePage={handleSavePage}
+              onReposition={handleReposition}
+              onDeletePage={handleDeletePage}
+            />
           )}
         </div>
       </main>

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -693,7 +693,7 @@ export function App() {
   );
 
   if (loading) {
-    return <div className="h-screen bg-white" aria-hidden="true" />;
+    return <div className="h-screen bg-[#FCFCFC]" aria-hidden="true" />;
   }
 
   const shouldShowHomepage = !requestedPathState.rawPath && !demoModeEnabled;
@@ -777,7 +777,7 @@ export function App() {
   const sidebarToggleLabel = sidebarVisible ? "Hide sidebar" : "Show sidebar";
 
   return (
-    <div className="flex h-screen overflow-hidden bg-white text-slate-950">
+    <div className="flex h-screen overflow-hidden bg-[#FCFCFC] text-slate-950">
       {sidebarVisible ? (
         <aside
           className={`flex h-full w-[320px] max-w-[34vw] min-w-[280px] shrink-0 flex-col border-r ${
@@ -913,10 +913,10 @@ export function App() {
             </Button>
           </div>
         ) : null}
-        <div className="flex h-full flex-col overflow-hidden bg-white">
+        <div className="flex h-full flex-col overflow-hidden bg-[#FCFCFC]">
           {isDocumentMode ? (
             <>
-              <div className="border-b border-slate-200 bg-white/92 px-5 py-2 backdrop-blur sm:px-8">
+              <div className="border-b border-slate-200 bg-[#FCFCFC]/92 px-5 py-2 backdrop-blur sm:px-8">
                 <div className="flex w-full items-center gap-2">
                   <Button
                     type="button"

--- a/packages/app/src/AppSidebar.tsx
+++ b/packages/app/src/AppSidebar.tsx
@@ -1,0 +1,150 @@
+import { ChevronLeft } from "lucide-react";
+import { Button } from "./components/ui/button";
+import { PathSwitcher } from "./PathSwitcher";
+import { ProjectTreeSidebar } from "./ProjectTreeSidebar";
+import type { StorageBackend } from "./storage";
+import type { ViewMode } from "./app-navigation";
+
+interface AppSidebarProps {
+  isDocumentMode: boolean;
+  sidebarToggleLabel: string;
+  backend: StorageBackend | null;
+  projectLabel: string;
+  displayPath: string | null;
+  workspacePathLabel: string;
+  buildLocationForPath: (path?: string | null) => string;
+  pathSwitcherDismissCount: number;
+  viewMode: ViewMode;
+  onViewModeChange: (mode: ViewMode) => void;
+  onCreatePage: () => void;
+  onHideSidebar: () => void;
+  treeCurrentPath: string | null;
+  projectTreeVersion: number;
+  onOpenMarkdownPage: (relativePath: string) => void | Promise<void>;
+}
+
+export function AppSidebar({
+  isDocumentMode,
+  sidebarToggleLabel,
+  backend,
+  projectLabel,
+  displayPath,
+  workspacePathLabel,
+  buildLocationForPath,
+  pathSwitcherDismissCount,
+  viewMode,
+  onViewModeChange,
+  onCreatePage,
+  onHideSidebar,
+  treeCurrentPath,
+  projectTreeVersion,
+  onOpenMarkdownPage,
+}: AppSidebarProps) {
+  return (
+    <aside
+      className={`flex h-full w-[320px] max-w-[34vw] min-w-[280px] shrink-0 flex-col border-r ${
+        isDocumentMode
+          ? "border-slate-200 bg-white"
+          : "border-slate-200/80 bg-white"
+      }`}
+    >
+      <div
+        className={`border-b px-4 pt-5 pb-4 ${isDocumentMode ? "border-slate-200" : "border-slate-200/80"}`}
+      >
+        {!isDocumentMode ? (
+          <div className="mb-3 flex justify-end">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="rounded-[10px] text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+              onClick={onHideSidebar}
+              aria-label={sidebarToggleLabel}
+              title={sidebarToggleLabel}
+            >
+              <ChevronLeft className="size-4" />
+            </Button>
+          </div>
+        ) : null}
+
+        {backend ? (
+          <PathSwitcher
+            backend={backend}
+            currentLabel={projectLabel}
+            currentPath={displayPath}
+            projectPath={backend.info.projectPath ?? null}
+            buildLocationForPath={buildLocationForPath}
+            dismissCount={pathSwitcherDismissCount}
+            description={workspacePathLabel}
+          />
+        ) : (
+          <div className="rounded-[14px] border border-slate-200/80 bg-white/80 px-4 py-3 shadow-[0_8px_24px_rgba(15,23,42,0.06)]">
+            <div className="truncate text-[0.95rem] font-semibold tracking-[-0.02em] text-slate-950">
+              {projectLabel}
+            </div>
+            <div className="mt-1 truncate text-[0.74rem] text-slate-500">
+              {workspacePathLabel}
+            </div>
+          </div>
+        )}
+
+        <div className="mt-4">
+          <div className="grid h-9 grid-cols-2 rounded-[10px] border border-slate-200/80 bg-white/75 p-1 shadow-[0_6px_18px_rgba(15,23,42,0.04)]">
+            <button
+              type="button"
+              className={`rounded-[8px] px-3 text-[0.82rem] font-semibold transition ${
+                viewMode === "canvas"
+                  ? "bg-slate-900 text-white shadow-[0_6px_14px_rgba(15,23,42,0.18)]"
+                  : "text-slate-600 hover:bg-slate-100/80"
+              }`}
+              onClick={() => onViewModeChange("canvas")}
+            >
+              Canvas
+            </button>
+            <button
+              type="button"
+              className={`rounded-[8px] px-3 text-[0.82rem] font-semibold transition ${
+                isDocumentMode
+                  ? "bg-slate-900 text-white shadow-[0_6px_14px_rgba(15,23,42,0.18)]"
+                  : "text-slate-600 hover:bg-slate-100/80"
+              }`}
+              onClick={() => onViewModeChange("document")}
+            >
+              Document
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-3">
+          <Button
+            type="button"
+            variant={isDocumentMode ? "outline" : "default"}
+            className={`h-10 w-full justify-center rounded-[10px] border text-[0.84rem] font-semibold shadow-none ${
+              isDocumentMode
+                ? "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
+                : "border-slate-900 bg-slate-900 text-white hover:bg-slate-800"
+            }`}
+            onClick={onCreatePage}
+            title={isDocumentMode ? "New document" : "New page"}
+          >
+            {isDocumentMode ? "+ New document" : "+ New page"}
+          </Button>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1">
+        {backend ? (
+          <ProjectTreeSidebar
+            backend={backend}
+            projectPath={backend.info.projectPath ?? null}
+            currentPath={treeCurrentPath}
+            buildLocationForPath={buildLocationForPath}
+            layout="embedded"
+            refreshKey={projectTreeVersion}
+            onOpenMarkdownPage={(relativePath) => void onOpenMarkdownPage(relativePath)}
+          />
+        ) : null}
+      </div>
+    </aside>
+  );
+}

--- a/packages/app/src/AppSidebar.tsx
+++ b/packages/app/src/AppSidebar.tsx
@@ -141,7 +141,9 @@ export function AppSidebar({
             buildLocationForPath={buildLocationForPath}
             layout="embedded"
             refreshKey={projectTreeVersion}
-            onOpenMarkdownPage={(relativePath) => void onOpenMarkdownPage(relativePath)}
+            onOpenMarkdownPage={(relativePath) =>
+              void onOpenMarkdownPage(relativePath)
+            }
           />
         ) : null}
       </div>

--- a/packages/app/src/Canvas.tsx
+++ b/packages/app/src/Canvas.tsx
@@ -812,7 +812,7 @@ export function Canvas({
           isPanning ? "cursor-grabbing" : "cursor-grab"
         }`}
         style={{
-          background: "#ffffff",
+          background: "#FCFCFC",
         }}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}

--- a/packages/app/src/CanvasWorkspace.tsx
+++ b/packages/app/src/CanvasWorkspace.tsx
@@ -1,0 +1,111 @@
+import { Menu } from "lucide-react";
+import { Canvas } from "./Canvas";
+import { PageCard } from "./PageCard";
+import { Button } from "./components/ui/button";
+import type { Page, ProjectLayout, StorageBackend } from "./storage";
+
+interface CanvasRevealRequest {
+  pageId: string;
+  key: string;
+}
+
+interface WorldPoint {
+  x: number;
+  y: number;
+}
+
+interface WorldFrame extends WorldPoint {
+  width: number;
+  height: number;
+}
+
+interface CanvasWorkspaceProps {
+  sidebarVisible: boolean;
+  sidebarToggleLabel: string;
+  onShowSidebar: () => void;
+  pages: Page[];
+  layout: ProjectLayout;
+  backend: StorageBackend | null;
+  selectedId: string | null;
+  canvasRevealRequest: CanvasRevealRequest | null;
+  initialWorldCenter: WorldPoint | null;
+  initialWorldCenterKey: string;
+  revealedPageFrame: WorldFrame | null;
+  onCanvasPointerDown: () => void;
+  onSelectPage: (id: string) => void;
+  onSavePage: (id: string, content: string) => Promise<void>;
+  onReposition: (id: string, x: number, y: number) => void;
+  onDeletePage: (id: string) => void | Promise<void>;
+}
+
+export function CanvasWorkspace({
+  sidebarVisible,
+  sidebarToggleLabel,
+  onShowSidebar,
+  pages,
+  layout,
+  backend,
+  selectedId,
+  canvasRevealRequest,
+  initialWorldCenter,
+  initialWorldCenterKey,
+  revealedPageFrame,
+  onCanvasPointerDown,
+  onSelectPage,
+  onSavePage,
+  onReposition,
+  onDeletePage,
+}: CanvasWorkspaceProps) {
+  return (
+    <>
+      {!sidebarVisible ? (
+        <div className="absolute top-2 left-2 z-30">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-9 rounded-[10px] border-transparent bg-transparent text-slate-700 shadow-none hover:bg-transparent"
+            onClick={onShowSidebar}
+            aria-label={sidebarToggleLabel}
+            title={sidebarToggleLabel}
+          >
+            <Menu className="size-4" />
+          </Button>
+        </div>
+      ) : null}
+      <Canvas
+        onPointerDownOnCanvas={onCanvasPointerDown}
+        initialWorldCenter={initialWorldCenter}
+        initialWorldCenterKey={initialWorldCenterKey}
+        focusedWorldFrame={revealedPageFrame}
+        focusedWorldFrameKey={canvasRevealRequest?.key}
+      >
+        {pages.map((page) => {
+          const pos = layout.pages[page.id] || { x: 0, y: 0 };
+          if (!backend) return null;
+
+          return (
+            <PageCard
+              key={page.id}
+              page={page}
+              x={pos.x}
+              y={pos.y}
+              selected={selectedId === page.id}
+              focusRequestKey={
+                canvasRevealRequest?.pageId === page.id
+                  ? canvasRevealRequest.key
+                  : null
+              }
+              canDelete
+              onSelect={onSelectPage}
+              onSave={onSavePage}
+              onReposition={onReposition}
+              onDelete={(id) => void onDeletePage(id)}
+              backend={backend}
+            />
+          );
+        })}
+      </Canvas>
+    </>
+  );
+}

--- a/packages/app/src/CommentEditorList.tsx
+++ b/packages/app/src/CommentEditorList.tsx
@@ -267,14 +267,12 @@ const COMMENT_AVATAR_CENTER = 16;
 
 function CommentActionButton({
   label,
-  variant,
   tone = "neutral",
   icon,
   compact = false,
   onClick,
 }: {
   label: string;
-  variant: "banner" | "rail";
   tone?: "neutral" | "danger";
   icon: ReactNode;
   compact?: boolean;
@@ -546,7 +544,6 @@ function CommentThreadNode({
                   <>
                     <CommentActionButton
                       label="Save"
-                      variant={variant}
                       icon={<Check className="size-3.5" />}
                       onClick={(event) => {
                         event.stopPropagation();
@@ -555,7 +552,6 @@ function CommentThreadNode({
                     />
                     <CommentActionButton
                       label="Cancel"
-                      variant={variant}
                       icon={<X className="size-3.5" />}
                       onClick={(event) => {
                         event.stopPropagation();
@@ -567,7 +563,6 @@ function CommentThreadNode({
                   <>
                     <CommentActionButton
                       label="Reply"
-                      variant={variant}
                       icon={<Reply className="size-3.5" />}
                       compact
                       onClick={(event) => {
@@ -577,7 +572,6 @@ function CommentThreadNode({
                     />
                     <CommentActionButton
                       label="Edit"
-                      variant={variant}
                       icon={<Pencil className="size-3.5" />}
                       compact
                       onClick={(event) => {
@@ -587,7 +581,6 @@ function CommentThreadNode({
                     />
                     <CommentActionButton
                       label="Delete"
-                      variant={variant}
                       tone="danger"
                       icon={<Trash2 className="size-3.5" />}
                       compact

--- a/packages/app/src/CommentEditorList.tsx
+++ b/packages/app/src/CommentEditorList.tsx
@@ -1,18 +1,13 @@
+import { Bot, Check, Pencil, Reply, Trash2, User, X } from "lucide-react";
 import {
+  type MouseEvent,
+  type MutableRefObject,
+  type ReactNode,
   useEffect,
   useMemo,
   useRef,
   useState,
-  type MouseEvent,
-  type MutableRefObject,
-  type ReactNode,
 } from "react";
-import { Bot, Check, Pencil, Reply, Trash2, User, X } from "lucide-react";
-import {
-  buildCommentThreads,
-  type CriticComment,
-  type CriticCommentThread,
-} from "./critic-markup";
 import { Button } from "./components/ui/button";
 import { Textarea } from "./components/ui/textarea";
 import {
@@ -20,6 +15,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "./components/ui/tooltip";
+import {
+  buildCommentThreads,
+  type CriticComment,
+  type CriticCommentThread,
+} from "./critic-markup";
 import { cn } from "./lib/utils";
 
 interface CommentEditorListProps {
@@ -189,10 +189,10 @@ export function CommentEditorList({
       className={cn(
         variant === "banner"
           ? cn(
-              "space-y-2 rounded-2xl border bg-white p-3",
+              "space-y-2 rounded-xl border border-transparent bg-transparent p-3 shadow-none transition-[background-color,border-color,box-shadow] duration-200 ease-out",
               hasActiveSelection
-                ? "border-[#DFDFDC] shadow-[0_20px_48px_rgba(57,47,38,0.14)]"
-                : "border-[#E9E9E8] shadow-[0_18px_44px_rgba(57,47,38,0.08)]",
+                ? "border-[#DFDFDC] bg-white shadow-[0_20px_48px_rgba(57,47,38,0.14)]"
+                : "",
             )
           : "space-y-1.5 px-4 py-3",
         className,
@@ -204,6 +204,8 @@ export function CommentEditorList({
           thread={thread}
           depth={0}
           index={index}
+          isLast={index === threads.length - 1}
+          parentLines={[]}
           variant={variant}
           interactive={interactive}
           drafts={drafts}
@@ -236,6 +238,8 @@ interface CommentThreadNodeProps {
   thread: CriticCommentThread;
   depth: number;
   index: number;
+  isLast: boolean;
+  parentLines: boolean[];
   variant: "banner" | "rail";
   interactive: boolean;
   drafts: Record<string, string>;
@@ -254,6 +258,12 @@ interface CommentThreadNodeProps {
   onCancelEditingComment: (commentId: string) => void;
   onChangeDraft: (commentId: string, nextContent: string) => void;
 }
+
+const COMMENT_TREE_INDENT = 20;
+const COMMENT_TREE_ELBOW_TOP = 14;
+const COMMENT_TREE_ROW_GAP = 12;
+const COMMENT_AVATAR_SIZE = 28;
+const COMMENT_AVATAR_CENTER = 16;
 
 function CommentActionButton({
   label,
@@ -283,12 +293,8 @@ function CommentActionButton({
                 ? "rounded-full border border-transparent transition-colors duration-150"
                 : "h-7 rounded-full border border-transparent px-2.5 text-[11px] font-medium tracking-[0.08em] uppercase transition-colors duration-150",
               tone === "danger"
-                ? variant === "banner"
-                  ? "text-amber-900/75 hover:bg-rose-100 hover:text-rose-700"
-                  : "text-slate-400 hover:bg-rose-50 hover:text-slate-900"
-                : variant === "banner"
-                  ? "text-amber-900/80 hover:bg-amber-100 hover:text-amber-950"
-                  : "text-slate-400 hover:bg-slate-100 hover:text-slate-900",
+                ? "text-stone-400 hover:bg-rose-100 hover:text-rose-700"
+                : "text-stone-400 hover:bg-[#DED8CE]/45 hover:text-stone-600",
             )}
           >
             {icon}
@@ -308,6 +314,8 @@ function CommentThreadNode({
   thread,
   depth,
   index,
+  isLast,
+  parentLines,
   variant,
   interactive,
   drafts,
@@ -327,25 +335,26 @@ function CommentThreadNode({
   onChangeDraft,
 }: CommentThreadNodeProps) {
   const { comment, replies } = thread;
+  const hasReplies = replies.length > 0;
   const isSelected = comment.id === selectedCommentId;
   const isHovered = comment.id === hoveredCommentId;
   const isEditing = interactive && editingCommentIds.includes(comment.id);
   const isAiAuthor = comment.authorType === "ai";
+  const userAuthorId = comment.authorId?.trim();
   const authorLabel = isAiAuthor
     ? "AI"
-    : comment.authorId?.trim()
-      ? comment.authorId
-      : "User";
+    : userAuthorId && userAuthorId.toLowerCase() !== "user"
+      ? userAuthorId
+      : "Me";
   const AuthorIcon = isAiAuthor ? Bot : User;
   const draftContent = drafts[comment.id] ?? comment.content;
-  const showThreadLine = replies.length > 0;
   const avatarTone = isAiAuthor
     ? variant === "banner"
       ? "border-sky-200 bg-sky-100 text-sky-700"
       : "border-sky-200 bg-sky-50 text-sky-700"
     : variant === "banner"
-      ? "border-amber-200 bg-amber-100 text-amber-800"
-      : "border-amber-200 bg-amber-50 text-amber-700";
+      ? "border-[#D2C7B8] bg-[#DED8CE] text-stone-700"
+      : "border-[#D2C7B8] bg-[#DED8CE] text-stone-700";
   const bodyTone =
     variant === "banner"
       ? isSelected
@@ -354,8 +363,17 @@ function CommentThreadNode({
           ? "bg-white"
           : "bg-transparent"
       : "bg-transparent";
-  const threadLineTone =
-    variant === "banner" ? "bg-amber-200/80" : "bg-slate-200/90";
+  const treeLineTone =
+    variant === "banner" ? "bg-[#DED8CE]/90" : "bg-[#DED8CE]/85";
+  const ancestorGuideOffsets = parentLines.reduce<number[]>(
+    (offsets, showLine, guideIndex) => {
+      if (showLine) {
+        offsets.push(guideIndex * COMMENT_TREE_INDENT + COMMENT_AVATAR_CENTER);
+      }
+      return offsets;
+    },
+    [],
+  );
 
   return (
     <div
@@ -382,162 +400,219 @@ function CommentThreadNode({
         onSelectComment?.(comment.id);
       }}
     >
-      {showThreadLine ? (
-        <div
-          aria-hidden="true"
-          className={cn(
-            "pointer-events-none absolute left-4 w-px",
-            threadLineTone,
-            depth > 0 ? "top-0 bottom-0" : "top-10 bottom-0",
-          )}
-        />
-      ) : null}
-      <div className="grid grid-cols-[2rem_minmax(0,1fr)] gap-x-2">
-        <div className="relative flex justify-center">
+      <div className="relative flex min-w-0 items-stretch">
+        {depth > 0 ? (
           <div
-            className={cn(
-              "relative z-10 flex size-7 items-center justify-center rounded-full border shadow-[0_1px_2px_rgba(15,23,42,0.08)]",
-              avatarTone,
-            )}
-            title={authorLabel}
+            aria-hidden="true"
+            className="pointer-events-none relative shrink-0 self-stretch"
+            style={{ width: depth * COMMENT_TREE_INDENT }}
           >
-            <AuthorIcon className="size-4 shrink-0" />
-          </div>
-        </div>
-        <div className={cn("min-w-0 rounded-2xl px-0.5", bodyTone)}>
-          <div className="truncate text-[13px] font-semibold text-slate-900">
-            {authorLabel}
-          </div>
-          <div
-            className={cn(
-              "mt-1 text-sm leading-6 whitespace-pre-wrap",
-              variant === "banner" ? "text-slate-800" : "text-slate-700",
-            )}
-          >
-            {isEditing
-              ? null
-              : comment.content.trim().length > 0
-                ? comment.content
-                : "Empty comment"}
-          </div>
-          {isEditing ? (
-            <Textarea
-              ref={(node) => {
-                if (node) {
-                  textareaRefs.current.set(comment.id, node);
-                } else {
-                  textareaRefs.current.delete(comment.id);
-                }
-              }}
-              value={draftContent}
-              placeholder={depth === 0 ? "Add your comment" : "Write a reply"}
-              rows={1}
+            {ancestorGuideOffsets.map((left) => (
+              <div
+                key={`${comment.id}-guide-${left}`}
+                className={cn("absolute top-0 bottom-0 w-px", treeLineTone)}
+                style={{
+                  left,
+                  top: -COMMENT_TREE_ROW_GAP,
+                  bottom: -COMMENT_TREE_ROW_GAP,
+                }}
+              />
+            ))}
+            <div
               className={cn(
-                "mt-1 min-h-12 px-3 py-2 text-sm leading-6 md:text-sm md:leading-6",
-                variant === "banner"
-                  ? "border-amber-200 bg-white/90 text-slate-800"
-                  : "border-slate-200 bg-white text-slate-700 shadow-none",
+                "absolute w-px",
+                treeLineTone,
+                isLast ? "" : "bottom-0",
               )}
-              onPointerDown={(event) => {
-                event.stopPropagation();
-                onSelectComment?.(comment.id);
-              }}
-              onClick={(event) => {
-                event.stopPropagation();
-              }}
-              onKeyDown={(event) => {
-                if (
-                  (event.metaKey || event.ctrlKey) &&
-                  event.key.toLowerCase() === "enter"
-                ) {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  onSubmitEditingComment(comment.id);
-                  return;
-                }
-
-                if (event.key !== "Escape") return;
-
-                event.preventDefault();
-                event.stopPropagation();
-                onCancelEditingComment(comment.id);
-              }}
-              onFocus={() => {
-                onSelectComment?.(comment.id);
-              }}
-              onChange={(event) => {
-                onChangeDraft(comment.id, event.target.value);
+              style={{
+                left: (depth - 1) * COMMENT_TREE_INDENT + COMMENT_AVATAR_CENTER,
+                top: -COMMENT_TREE_ROW_GAP,
+                ...(isLast
+                  ? {
+                      height: COMMENT_TREE_ELBOW_TOP + COMMENT_TREE_ROW_GAP,
+                    }
+                  : {
+                      bottom: -COMMENT_TREE_ROW_GAP,
+                    }),
               }}
             />
-          ) : null}
-          <div className="mt-2 flex flex-wrap items-center gap-1">
-            {isEditing ? (
-              <>
-                <CommentActionButton
-                  label="Save"
-                  variant={variant}
-                  icon={<Check className="size-3.5" />}
+            <div
+              className={cn("absolute h-px", treeLineTone)}
+              style={{
+                left: (depth - 1) * COMMENT_TREE_INDENT + COMMENT_AVATAR_CENTER,
+                top: COMMENT_TREE_ELBOW_TOP,
+                width: COMMENT_TREE_INDENT,
+              }}
+            />
+          </div>
+        ) : null}
+        <div className="min-w-0 flex-1">
+          <div className="relative grid grid-cols-[2rem_minmax(0,1fr)] gap-x-2">
+            {hasReplies ? (
+              <div
+                aria-hidden="true"
+                className={cn(
+                  "pointer-events-none absolute w-px",
+                  treeLineTone,
+                )}
+                style={{
+                  left: COMMENT_AVATAR_CENTER,
+                  top: COMMENT_AVATAR_SIZE,
+                  bottom: -COMMENT_TREE_ROW_GAP,
+                }}
+              />
+            ) : null}
+            <div className="relative flex justify-center">
+              <div
+                className={cn(
+                  "relative z-10 flex size-7 items-center justify-center rounded-full border shadow-[0_1px_2px_rgba(15,23,42,0.08)]",
+                  avatarTone,
+                )}
+                title={authorLabel}
+              >
+                <AuthorIcon className="size-3.5 shrink-0" />
+              </div>
+            </div>
+            <div className={cn("min-w-0 rounded-xl px-0.5", bodyTone)}>
+              <div className="truncate text-[13px] font-semibold text-slate-900">
+                {authorLabel}
+              </div>
+              <div
+                className={cn(
+                  "mt-1 text-sm leading-6 whitespace-pre-wrap",
+                  variant === "banner" ? "text-slate-800" : "text-slate-700",
+                )}
+              >
+                {isEditing
+                  ? null
+                  : comment.content.trim().length > 0
+                    ? comment.content
+                    : "Empty comment"}
+              </div>
+              {isEditing ? (
+                <Textarea
+                  ref={(node) => {
+                    if (node) {
+                      textareaRefs.current.set(comment.id, node);
+                    } else {
+                      textareaRefs.current.delete(comment.id);
+                    }
+                  }}
+                  value={draftContent}
+                  placeholder={
+                    depth === 0 ? "Add your comment" : "Write a reply"
+                  }
+                  rows={1}
+                  className={cn(
+                    "mt-1 min-h-12 px-3 py-2 text-sm leading-6 md:text-sm md:leading-6",
+                    variant === "banner"
+                      ? "border-amber-200 bg-white/90 text-slate-800"
+                      : "border-slate-200 bg-white text-slate-700 shadow-none",
+                  )}
+                  onPointerDown={(event) => {
+                    event.stopPropagation();
+                    onSelectComment?.(comment.id);
+                  }}
                   onClick={(event) => {
                     event.stopPropagation();
-                    onSubmitEditingComment(comment.id);
                   }}
-                />
-                <CommentActionButton
-                  label="Cancel"
-                  variant={variant}
-                  icon={<X className="size-3.5" />}
-                  onClick={(event) => {
+                  onKeyDown={(event) => {
+                    if (
+                      (event.metaKey || event.ctrlKey) &&
+                      event.key.toLowerCase() === "enter"
+                    ) {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      onSubmitEditingComment(comment.id);
+                      return;
+                    }
+
+                    if (event.key !== "Escape") return;
+
+                    event.preventDefault();
                     event.stopPropagation();
                     onCancelEditingComment(comment.id);
                   }}
-                />
-              </>
-            ) : (
-              <>
-                <CommentActionButton
-                  label="Reply"
-                  variant={variant}
-                  icon={<Reply className="size-3.5" />}
-                  compact
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onReplyComment?.(comment.id);
+                  onFocus={() => {
+                    onSelectComment?.(comment.id);
+                  }}
+                  onChange={(event) => {
+                    onChangeDraft(comment.id, event.target.value);
                   }}
                 />
-                <CommentActionButton
-                  label="Edit"
-                  variant={variant}
-                  icon={<Pencil className="size-3.5" />}
-                  compact
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onStartEditingComment(comment.id);
-                  }}
-                />
-                <CommentActionButton
-                  label="Delete"
-                  variant={variant}
-                  tone="danger"
-                  icon={<Trash2 className="size-3.5" />}
-                  compact
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onDeleteComment(comment.id);
-                  }}
-                />
-              </>
-            )}
+              ) : null}
+              <div className="mt-2 flex flex-wrap items-center gap-1">
+                {isEditing ? (
+                  <>
+                    <CommentActionButton
+                      label="Save"
+                      variant={variant}
+                      icon={<Check className="size-3.5" />}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onSubmitEditingComment(comment.id);
+                      }}
+                    />
+                    <CommentActionButton
+                      label="Cancel"
+                      variant={variant}
+                      icon={<X className="size-3.5" />}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onCancelEditingComment(comment.id);
+                      }}
+                    />
+                  </>
+                ) : (
+                  <>
+                    <CommentActionButton
+                      label="Reply"
+                      variant={variant}
+                      icon={<Reply className="size-3.5" />}
+                      compact
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onReplyComment?.(comment.id);
+                      }}
+                    />
+                    <CommentActionButton
+                      label="Edit"
+                      variant={variant}
+                      icon={<Pencil className="size-3.5" />}
+                      compact
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onStartEditingComment(comment.id);
+                      }}
+                    />
+                    <CommentActionButton
+                      label="Delete"
+                      variant={variant}
+                      tone="danger"
+                      icon={<Trash2 className="size-3.5" />}
+                      compact
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onDeleteComment(comment.id);
+                      }}
+                    />
+                  </>
+                )}
+              </div>
+            </div>
           </div>
         </div>
       </div>
-      {replies.length > 0 ? (
-        <div className="mt-3 ml-5 space-y-3">
+      {hasReplies ? (
+        <div className="mt-3 space-y-3">
           {replies.map((reply, replyIndex) => (
             <CommentThreadNode
               key={reply.comment.id}
               thread={reply}
               depth={depth + 1}
               index={replyIndex}
+              isLast={replyIndex === replies.length - 1}
+              parentLines={depth === 0 ? [] : [...parentLines, !isLast]}
               variant={variant}
               interactive={interactive}
               drafts={drafts}

--- a/packages/app/src/CommentEditorList.tsx
+++ b/packages/app/src/CommentEditorList.tsx
@@ -63,6 +63,9 @@ export function CommentEditorList({
     () => new Map(comments.map((comment) => [comment.id, comment])),
     [comments],
   );
+  const hasActiveSelection =
+    !!selectedCommentId &&
+    comments.some((comment) => comment.id === selectedCommentId);
 
   useEffect(() => {
     const validCommentIds = new Set(comments.map((comment) => comment.id));
@@ -185,7 +188,12 @@ export function CommentEditorList({
       data-comment-thread-container="true"
       className={cn(
         variant === "banner"
-          ? "space-y-2 rounded-2xl border border-amber-200/80 bg-amber-50/70 p-3"
+          ? cn(
+              "space-y-2 rounded-2xl border bg-white p-3",
+              hasActiveSelection
+                ? "border-[#DFDFDC] shadow-[0_20px_48px_rgba(57,47,38,0.14)]"
+                : "border-[#E9E9E8] shadow-[0_18px_44px_rgba(57,47,38,0.08)]",
+            )
           : "space-y-1.5 px-4 py-3",
         className,
       )}
@@ -341,9 +349,9 @@ function CommentThreadNode({
   const bodyTone =
     variant === "banner"
       ? isSelected
-        ? "bg-white/85"
+        ? "bg-white"
         : isHovered
-          ? "bg-white/70"
+          ? "bg-white"
           : "bg-transparent"
       : "bg-transparent";
   const threadLineTone =

--- a/packages/app/src/DocumentCommentRail.tsx
+++ b/packages/app/src/DocumentCommentRail.tsx
@@ -1,13 +1,16 @@
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useCanvasScale } from "./Canvas";
+import { CommentEditorList } from "./CommentEditorList";
 import type { CriticComment } from "./critic-markup";
 import {
-  getPreferredCommentId,
-  normalizeCommentMeasurement,
-  resolveCommentRailLayouts,
+  buildCommentThreadRailItems,
   type CommentGroupAnchor,
+  type CommentThreadRailItem,
+  getPreferredCommentId,
+  getRootThreadIdForCommentId,
+  normalizeCommentMeasurement,
+  resolveCommentThreadRailLayouts,
 } from "./document-comments";
-import { CommentEditorList } from "./CommentEditorList";
 import { cn } from "./lib/utils";
 
 interface DocumentCommentRailProps {
@@ -43,68 +46,75 @@ export function DocumentCommentRail({
   pendingFocusCommentId = null,
   onAutoFocusComment,
 }: DocumentCommentRailProps) {
-  const groupRefs = useRef(new Map<string, HTMLDivElement>());
+  const threadRefs = useRef(new Map<string, HTMLDivElement>());
   const scale = useCanvasScale();
-  const [groupHeights, setGroupHeights] = useState<Record<string, number>>({});
+  const [threadHeights, setThreadHeights] = useState<Record<string, number>>(
+    {},
+  );
 
-  const visibleGroups = useMemo(
+  const activeRootThreadId = useMemo(
+    () => getRootThreadIdForCommentId(selectedCommentId, comments),
+    [comments, selectedCommentId],
+  );
+
+  const visibleThreads = useMemo(
     () =>
-      commentGroups
-        .map((group) => {
-          const visibleComments = group.commentIds
+      buildCommentThreadRailItems(commentGroups, comments)
+        .map((item) => {
+          const visibleComments = item.commentIds
             .map((commentId) => comments.get(commentId))
             .filter((comment): comment is CriticComment => Boolean(comment));
 
           if (visibleComments.length === 0) return null;
 
           return {
-            ...group,
+            ...item,
             visibleComments,
           };
         })
         .filter(
           (
-            group,
-          ): group is CommentGroupAnchor & {
+            item,
+          ): item is CommentThreadRailItem & {
             visibleComments: CriticComment[];
-          } => Boolean(group),
+          } => Boolean(item),
         ),
     [commentGroups, comments],
   );
 
-  const setGroupRef = useCallback(
+  const setThreadRef = useCallback(
     (key: string, node: HTMLDivElement | null) => {
       if (node) {
-        groupRefs.current.set(key, node);
+        threadRefs.current.set(key, node);
       } else {
-        groupRefs.current.delete(key);
+        threadRefs.current.delete(key);
       }
     },
     [],
   );
 
   useLayoutEffect(() => {
-    if (visibleGroups.length === 0) {
-      setGroupHeights({});
+    if (visibleThreads.length === 0) {
+      setThreadHeights({});
       return;
     }
 
     const updateHeights = () => {
-      setGroupHeights((current) => {
+      setThreadHeights((current) => {
         const next: Record<string, number> = {};
         let changed = false;
 
-        for (const group of visibleGroups) {
-          const element = groupRefs.current.get(group.key);
+        for (const thread of visibleThreads) {
+          const element = threadRefs.current.get(thread.key);
           const measuredHeight = Math.ceil(
             element?.getBoundingClientRect().height ?? 0,
           );
           const height =
             measuredHeight > 0
               ? Math.ceil(normalizeCommentMeasurement(measuredHeight, scale))
-              : (current[group.key] ?? 0);
-          next[group.key] = height;
-          if (current[group.key] !== height) {
+              : (current[thread.key] ?? 0);
+          next[thread.key] = height;
+          if (current[thread.key] !== height) {
             changed = true;
           }
         }
@@ -126,8 +136,8 @@ export function DocumentCommentRail({
       updateHeights();
     });
 
-    for (const group of visibleGroups) {
-      const element = groupRefs.current.get(group.key);
+    for (const thread of visibleThreads) {
+      const element = threadRefs.current.get(thread.key);
       if (element) {
         resizeObserver.observe(element);
       }
@@ -136,23 +146,27 @@ export function DocumentCommentRail({
     return () => {
       resizeObserver.disconnect();
     };
-  }, [scale, visibleGroups]);
+  }, [scale, visibleThreads]);
 
   const layouts = useMemo(() => {
-    const baseLayouts = resolveCommentRailLayouts(visibleGroups, groupHeights);
+    const baseLayouts = resolveCommentThreadRailLayouts(
+      visibleThreads,
+      threadHeights,
+      activeRootThreadId,
+    );
 
     return baseLayouts.map((layout) => ({
       ...layout,
       visibleComments:
-        visibleGroups.find((group) => group.key === layout.key)
+        visibleThreads.find((thread) => thread.key === layout.key)
           ?.visibleComments ?? [],
     }));
-  }, [groupHeights, visibleGroups]);
+  }, [activeRootThreadId, threadHeights, visibleThreads]);
 
   const railHeight =
     Math.max(contentHeight, layouts.at(-1)?.railBottom ?? 0) + 24;
 
-  if (visibleGroups.length === 0) {
+  if (visibleThreads.length === 0) {
     return <aside className={cn("min-w-0", className)} aria-hidden="true" />;
   }
 
@@ -161,10 +175,7 @@ export function DocumentCommentRail({
       <div className="relative" style={{ minHeight: railHeight }}>
         {layouts.map((layout) => {
           const isSelected =
-            !!selectedCommentId &&
-            layout.commentIds.includes(selectedCommentId);
-          const isHovered =
-            !!hoveredCommentId && layout.commentIds.includes(hoveredCommentId);
+            !!activeRootThreadId && layout.rootCommentId === activeRootThreadId;
           const isExpanded = isSelected;
           const primaryCommentId =
             getPreferredCommentId(layout.commentIds, selectedCommentId) ??
@@ -173,13 +184,13 @@ export function DocumentCommentRail({
           return (
             <div
               key={layout.key}
-              ref={(node) => setGroupRef(layout.key, node)}
+              ref={(node) => setThreadRef(layout.key, node)}
               data-comment-thread-container="true"
               className={cn(
-                "absolute left-0 right-0 rounded-2xl border bg-white transition-all duration-200 ease-out will-change-transform",
+                "absolute left-0 right-0 rounded-xl border border-transparent bg-transparent shadow-none transition-all duration-200 ease-out will-change-transform",
                 isSelected
-                  ? "border-[#DFDFDC] shadow-[0_20px_48px_rgba(57,47,38,0.14)]"
-                  : "border-[#E9E9E8] shadow-[0_18px_44px_rgba(57,47,38,0.08)]",
+                  ? "border-[#DFDFDC] bg-white shadow-[0_20px_48px_rgba(57,47,38,0.14)]"
+                  : "",
                 isSelected && "-translate-x-2",
                 isExpanded ? "cursor-default" : "cursor-pointer",
               )}

--- a/packages/app/src/DocumentCommentRail.tsx
+++ b/packages/app/src/DocumentCommentRail.tsx
@@ -176,12 +176,11 @@ export function DocumentCommentRail({
               ref={(node) => setGroupRef(layout.key, node)}
               data-comment-thread-container="true"
               className={cn(
-                "absolute left-0 right-0 rounded-2xl border bg-white/95 transition-all duration-200 ease-out will-change-transform",
+                "absolute left-0 right-0 rounded-2xl border bg-white transition-all duration-200 ease-out will-change-transform",
                 isSelected
-                  ? "-translate-x-2 border-slate-300 shadow-[0_22px_48px_rgba(15,23,42,0.18)]"
-                  : isHovered
-                    ? "border-slate-300/80"
-                    : "border-slate-200/90",
+                  ? "border-[#DFDFDC] shadow-[0_20px_48px_rgba(57,47,38,0.14)]"
+                  : "border-[#E9E9E8] shadow-[0_18px_44px_rgba(57,47,38,0.08)]",
+                isSelected && "-translate-x-2",
                 isExpanded ? "cursor-default" : "cursor-pointer",
               )}
               style={{ top: layout.railTop }}

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -1,0 +1,146 @@
+import { ChevronLeft, CodeXml, Eye, Menu } from "lucide-react";
+import { useEffect, useState } from "react";
+import type { DocumentEditorViewMode } from "./app-navigation";
+import { Button } from "./components/ui/button";
+import { cn } from "./lib/utils";
+import { PageCard } from "./PageCard";
+import type { Page, StorageBackend } from "./storage";
+
+type SaveState = "idle" | "saving" | "error";
+
+interface DocumentWorkspaceProps {
+  sidebarVisible: boolean;
+  sidebarToggleLabel: string;
+  onToggleSidebar: () => void;
+  documentPage: Page | null;
+  activeDocumentPath: string | null;
+  documentFilenameLabel: string;
+  documentEditorViewMode: DocumentEditorViewMode;
+  onDocumentEditorViewModeChange: (mode: DocumentEditorViewMode) => void;
+  onSaveDocument: (id: string, content: string) => Promise<void>;
+  onDocumentSaveStateChange: (state: SaveState) => void;
+  backend: StorageBackend | null;
+}
+
+export function DocumentWorkspace({
+  sidebarVisible,
+  sidebarToggleLabel,
+  onToggleSidebar,
+  documentPage,
+  activeDocumentPath,
+  documentFilenameLabel,
+  documentEditorViewMode,
+  onDocumentEditorViewModeChange,
+  onSaveDocument,
+  onDocumentSaveStateChange,
+  backend,
+}: DocumentWorkspaceProps) {
+  const [documentHasComments, setDocumentHasComments] = useState(
+    () => !!documentPage?.content.includes("{>>"),
+  );
+
+  useEffect(() => {
+    setDocumentHasComments(!!documentPage?.content.includes("{>>"));
+  }, [documentPage]);
+
+  return (
+    <>
+      <div className="absolute top-2 left-2 z-30">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-9 rounded-[10px] border-transparent bg-transparent text-stone-700 shadow-none hover:bg-transparent"
+          onClick={onToggleSidebar}
+          aria-label={sidebarToggleLabel}
+          title={sidebarToggleLabel}
+        >
+          {sidebarVisible ? (
+            <ChevronLeft className="size-4" />
+          ) : (
+            <Menu className="size-4" />
+          )}
+        </Button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto px-8 pt-20 pb-8 sm:px-12">
+        <div className="mx-auto min-h-full max-w-[1080px]">
+          {documentPage ? (
+            <div
+              className={cn(
+                "document-page-header mb-2 flex w-full max-w-[46.5rem] items-center gap-1.5 px-1 text-[0.62rem] font-medium tracking-[0.01em] text-stone-400",
+                !documentHasComments && "document-page-header-no-comments",
+              )}
+            >
+              <button
+                type="button"
+                className="grid h-[1.25rem] shrink-0 grid-cols-2 rounded-[999px] bg-[#DED8CE] px-[2px] py-[2px] shadow-[inset_0_1px_0_rgba(255,251,245,0.72)]"
+                onClick={() =>
+                  onDocumentEditorViewModeChange(
+                    documentEditorViewMode === "rich-text"
+                      ? "code"
+                      : "rich-text",
+                  )
+                }
+                aria-label={
+                  documentEditorViewMode === "rich-text"
+                    ? "Switch to code view"
+                    : "Switch to rich text view"
+                }
+                title={
+                  documentEditorViewMode === "rich-text"
+                    ? "Switch to code view"
+                    : "Switch to rich text view"
+                }
+              >
+                <span
+                  className={`flex h-[1rem] w-[1.375rem] items-center justify-center rounded-full transition ${
+                    documentEditorViewMode === "rich-text"
+                      ? "bg-[#FFFDFC] text-stone-700 shadow-[0_1px_2px_rgba(41,37,36,0.12)]"
+                      : "text-stone-500"
+                  }`}
+                >
+                  <Eye className="size-[0.75rem]" />
+                </span>
+                <span
+                  className={`flex h-[1rem] w-[1.375rem] items-center justify-center rounded-full transition ${
+                    documentEditorViewMode === "code"
+                      ? "bg-[#FFFDFC] text-stone-700 shadow-[0_1px_2px_rgba(41,37,36,0.12)]"
+                      : "text-stone-500"
+                  }`}
+                >
+                  <CodeXml className="size-[0.75rem]" />
+                </span>
+              </button>
+              <div
+                className="min-w-0 truncate font-mono text-[0.7rem] tracking-[0.01em] text-stone-400"
+                title={documentFilenameLabel}
+              >
+                {documentFilenameLabel}
+              </div>
+            </div>
+          ) : null}
+          {documentPage ? (
+            backend ? (
+              <PageCard
+                key={`${documentPage.id}:${activeDocumentPath ?? ""}`}
+                page={documentPage}
+                mode="document"
+                selected
+                canDelete={false}
+                onSave={onSaveDocument}
+                onSaveStateChange={onDocumentSaveStateChange}
+                editorViewMode={documentEditorViewMode}
+                backend={backend}
+                onCommentRailPresenceChange={setDocumentHasComments}
+              />
+            ) : null
+          ) : (
+            <div className="flex min-h-[50vh] items-center justify-center text-sm text-slate-500">
+              Select a markdown file from the sidebar.
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/packages/app/src/EditorContextMenu.tsx
+++ b/packages/app/src/EditorContextMenu.tsx
@@ -1,7 +1,19 @@
 import type { Editor } from "@tiptap/react";
+import { useEditorState } from "@tiptap/react";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ExternalLink, MessageSquarePlus, Trash2 } from "lucide-react";
+import {
+  Bold,
+  Code2,
+  ExternalLink,
+  Italic,
+  Link2,
+  List,
+  ListOrdered,
+  MessageSquarePlus,
+  Quote,
+  Trash2,
+} from "lucide-react";
 import {
   getAddCommentShortcutLabel,
   matchesAddCommentShortcut,
@@ -68,6 +80,26 @@ function getElementFromDomNode(node: Node | null) {
   return node instanceof Element ? node : node.parentElement;
 }
 
+function getContainedSelectionRange(container: HTMLElement) {
+  const selection = window.getSelection();
+
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+    return null;
+  }
+
+  const range = selection.getRangeAt(0);
+  const ancestor =
+    range.commonAncestorContainer instanceof Element
+      ? range.commonAncestorContainer
+      : range.commonAncestorContainer.parentElement;
+
+  if (!ancestor || !container.contains(ancestor)) {
+    return null;
+  }
+
+  return range;
+}
+
 function findActiveLinkAnchor(
   editor: Editor,
   container: HTMLElement,
@@ -103,6 +135,42 @@ function findActiveLinkAnchor(
   return null;
 }
 
+function SelectionMenuButton({
+  label,
+  icon,
+  active = false,
+  disabled = false,
+  onClick,
+}: {
+  label: string;
+  icon: ReactNode;
+  active?: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`inline-flex size-9 items-center justify-center rounded-xl border text-slate-600 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300 ${
+        active
+          ? "border-slate-900 bg-slate-900 text-white shadow-[0_8px_18px_rgba(15,23,42,0.18)]"
+          : "border-transparent hover:bg-slate-100 hover:text-slate-900"
+      } disabled:cursor-not-allowed disabled:opacity-40`}
+      onMouseDown={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      aria-pressed={active}
+      title={label}
+    >
+      {icon}
+    </button>
+  );
+}
+
 export function EditorContextMenu({
   editor,
   backend,
@@ -120,6 +188,45 @@ export function EditorContextMenu({
   const linkPopoverRef = useRef<HTMLDivElement>(null);
   const linkInputRef = useRef<HTMLInputElement>(null);
   const shortcutLabel = getAddCommentShortcutLabel(getNavigatorPlatform());
+  const selectionMenuState = useEditorState({
+    editor,
+    selector: ({ editor: currentEditor }) => ({
+      isBoldActive: currentEditor?.isActive("bold") ?? false,
+      isItalicActive: currentEditor?.isActive("italic") ?? false,
+      isCodeActive: currentEditor?.isActive("code") ?? false,
+      isBulletListActive: currentEditor?.isActive("bulletList") ?? false,
+      isOrderedListActive: currentEditor?.isActive("orderedList") ?? false,
+      isBlockquoteActive: currentEditor?.isActive("blockquote") ?? false,
+      isLinkActive: currentEditor?.isActive("link") ?? false,
+      canToggleBold:
+        currentEditor?.can().chain().focus().toggleBold().run() ?? false,
+      canToggleItalic:
+        currentEditor?.can().chain().focus().toggleItalic().run() ?? false,
+      canToggleCode:
+        currentEditor?.can().chain().focus().toggleCode().run() ?? false,
+      canToggleBulletList:
+        currentEditor?.can().chain().focus().toggleBulletList().run() ?? false,
+      canToggleOrderedList:
+        currentEditor?.can().chain().focus().toggleOrderedList().run() ??
+        false,
+      canToggleBlockquote:
+        currentEditor?.can().chain().focus().toggleBlockquote().run() ?? false,
+    }),
+  }) ?? {
+    isBoldActive: false,
+    isItalicActive: false,
+    isCodeActive: false,
+    isBulletListActive: false,
+    isOrderedListActive: false,
+    isBlockquoteActive: false,
+    isLinkActive: false,
+    canToggleBold: false,
+    canToggleItalic: false,
+    canToggleCode: false,
+    canToggleBulletList: false,
+    canToggleOrderedList: false,
+    canToggleBlockquote: false,
+  };
 
   const close = useCallback(() => {
     setPosition(null);
@@ -141,25 +248,14 @@ export function EditorContextMenu({
     }
 
     const container = containerRef.current;
-    const selection = window.getSelection();
-
-    if (
-      !container ||
-      !selection ||
-      selection.rangeCount === 0 ||
-      selection.isCollapsed
-    ) {
+    if (!container) {
       setSelectionActionPosition(null);
       return;
     }
 
-    const range = selection.getRangeAt(0);
-    const ancestor =
-      range.commonAncestorContainer instanceof Element
-        ? range.commonAncestorContainer
-        : range.commonAncestorContainer.parentElement;
+    const range = getContainedSelectionRange(container);
 
-    if (!ancestor || !container.contains(ancestor)) {
+    if (!range) {
       setSelectionActionPosition(null);
       return;
     }
@@ -213,6 +309,50 @@ export function EditorContextMenu({
 
     setLinkPopoverState({
       href,
+      rawHref,
+      left: rect.left + rect.width / 2,
+      top: rect.top - 12,
+    });
+  }, [backend, editor]);
+
+  const openLinkPopover = useCallback(() => {
+    if (!editor || !containerRef.current) return;
+
+    const anchor = findActiveLinkAnchor(editor, containerRef.current);
+
+    if (anchor) {
+      const rect = anchor.getBoundingClientRect();
+      const rawHref =
+        (editor.getAttributes("link").dataMarkdownSrc as string | null) ||
+        anchor.getAttribute("data-markdown-src") ||
+        anchor.getAttribute("href") ||
+        "";
+      const href = resolveEditableLinkTarget(
+        rawHref,
+        backend,
+        (editor.getAttributes("link").href as string | null) || anchor.href,
+      );
+
+      setLinkPopoverState({
+        href,
+        rawHref,
+        left: rect.left + rect.width / 2,
+        top: rect.top - 12,
+      });
+      return;
+    }
+
+    const range = getContainedSelectionRange(containerRef.current);
+    if (!range) return;
+
+    const rect = range.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) return;
+
+    const rawHref =
+      (editor.getAttributes("link").dataMarkdownSrc as string | null) || "";
+
+    setLinkPopoverState({
+      href: resolveEditableLinkTarget(rawHref, backend, rawHref || "https://"),
       rawHref,
       left: rect.left + rect.width / 2,
       top: rect.top - 12,
@@ -403,9 +543,8 @@ export function EditorContextMenu({
     >
       {children}
       {selectionActionPosition && !linkPopoverState ? (
-        <button
-          type="button"
-          className="absolute z-30 inline-flex -translate-x-1/2 -translate-y-full items-center gap-2.5 rounded-full border border-slate-950 bg-slate-950 px-4 py-2 text-sm font-semibold text-white shadow-[0_18px_40px_rgba(15,23,42,0.28)] transition hover:border-slate-800 hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2"
+        <div
+          className="absolute z-30 w-max max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-full rounded-[22px] border border-slate-200/90 bg-white/95 p-2 shadow-[0_18px_48px_rgba(15,23,42,0.16)] backdrop-blur-xl"
           style={{
             left: selectionActionPosition.left,
             top: selectionActionPosition.top,
@@ -414,17 +553,79 @@ export function EditorContextMenu({
             event.preventDefault();
             event.stopPropagation();
           }}
-          onClick={() => {
-            onAddComment?.();
-            setSelectionActionPosition(null);
-          }}
         >
-          <MessageSquarePlus className="size-4.5" />
-          <span>Add comment</span>
-          <span className="rounded-full border border-white/12 bg-white/12 px-2.5 py-1 text-[12px] font-semibold tracking-[0.01em] text-slate-100">
-            {shortcutLabel}
-          </span>
-        </button>
+          <div className="flex flex-wrap items-center gap-1">
+            <SelectionMenuButton
+              label="Bold"
+              icon={<Bold className="size-4" />}
+              active={selectionMenuState.isBoldActive}
+              disabled={!selectionMenuState.canToggleBold}
+              onClick={() => editor?.chain().focus().toggleBold().run()}
+            />
+            <SelectionMenuButton
+              label="Italic"
+              icon={<Italic className="size-4" />}
+              active={selectionMenuState.isItalicActive}
+              disabled={!selectionMenuState.canToggleItalic}
+              onClick={() => editor?.chain().focus().toggleItalic().run()}
+            />
+            <SelectionMenuButton
+              label="Inline code"
+              icon={<Code2 className="size-4" />}
+              active={selectionMenuState.isCodeActive}
+              disabled={!selectionMenuState.canToggleCode}
+              onClick={() => editor?.chain().focus().toggleCode().run()}
+            />
+            <SelectionMenuButton
+              label="Blockquote"
+              icon={<Quote className="size-4" />}
+              active={selectionMenuState.isBlockquoteActive}
+              disabled={!selectionMenuState.canToggleBlockquote}
+              onClick={() => editor?.chain().focus().toggleBlockquote().run()}
+            />
+            <SelectionMenuButton
+              label="Bulleted list"
+              icon={<List className="size-4" />}
+              active={selectionMenuState.isBulletListActive}
+              disabled={!selectionMenuState.canToggleBulletList}
+              onClick={() => editor?.chain().focus().toggleBulletList().run()}
+            />
+            <SelectionMenuButton
+              label="Numbered list"
+              icon={<ListOrdered className="size-4" />}
+              active={selectionMenuState.isOrderedListActive}
+              disabled={!selectionMenuState.canToggleOrderedList}
+              onClick={() => editor?.chain().focus().toggleOrderedList().run()}
+            />
+            <SelectionMenuButton
+              label="Link"
+              icon={<Link2 className="size-4" />}
+              active={selectionMenuState.isLinkActive}
+              onClick={openLinkPopover}
+            />
+          </div>
+          <div className="my-2 h-px bg-slate-200/80" aria-hidden="true" />
+          <button
+            type="button"
+            className="flex w-full items-center justify-between gap-3 rounded-xl px-3 py-2 text-left text-sm font-medium text-slate-700 transition hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
+            onMouseDown={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+            }}
+            onClick={() => {
+              onAddComment?.();
+              setSelectionActionPosition(null);
+            }}
+          >
+            <span className="inline-flex items-center gap-2">
+              <MessageSquarePlus className="size-4.5" />
+              <span>Comment</span>
+            </span>
+            <span className="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-[11px] font-semibold tracking-[0.01em] text-slate-500">
+              {shortcutLabel}
+            </span>
+          </button>
+        </div>
       ) : null}
       {linkPopoverState ? (
         <div

--- a/packages/app/src/EditorContextMenu.tsx
+++ b/packages/app/src/EditorContextMenu.tsx
@@ -207,8 +207,7 @@ export function EditorContextMenu({
       canToggleBulletList:
         currentEditor?.can().chain().focus().toggleBulletList().run() ?? false,
       canToggleOrderedList:
-        currentEditor?.can().chain().focus().toggleOrderedList().run() ??
-        false,
+        currentEditor?.can().chain().focus().toggleOrderedList().run() ?? false,
       canToggleBlockquote:
         currentEditor?.can().chain().focus().toggleBlockquote().run() ?? false,
     }),

--- a/packages/app/src/MarkdownCodeEditor.tsx
+++ b/packages/app/src/MarkdownCodeEditor.tsx
@@ -1,0 +1,132 @@
+import { basicSetup } from "codemirror";
+import { markdown } from "@codemirror/lang-markdown";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { useEffect, useRef } from "react";
+
+interface MarkdownCodeEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  autoFocus?: boolean;
+}
+
+export function MarkdownCodeEditor({
+  value,
+  onChange,
+  autoFocus = false,
+}: MarkdownCodeEditorProps) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const editorViewRef = useRef<EditorView | null>(null);
+  const onChangeRef = useRef(onChange);
+  const lastValueRef = useRef(value);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    const hostElement = hostRef.current;
+    if (!hostElement) return;
+
+    const view = new EditorView({
+      parent: hostElement,
+      state: EditorState.create({
+        doc: value,
+        extensions: [
+          basicSetup,
+          markdown(),
+          EditorView.lineWrapping,
+          EditorView.updateListener.of((update) => {
+            if (!update.docChanged) return;
+
+            const nextValue = update.state.doc.toString();
+            if (nextValue === lastValueRef.current) return;
+
+            lastValueRef.current = nextValue;
+            onChangeRef.current(nextValue);
+          }),
+          EditorView.theme({
+            "&": {
+              backgroundColor: "transparent",
+              color: "inherit",
+              fontFamily:
+                'ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, "Liberation Mono", monospace',
+              fontSize: "0.95rem",
+            },
+            ".cm-scroller": {
+              fontFamily: "inherit",
+              lineHeight: "1.75",
+              overflow: "auto",
+            },
+            ".cm-content": {
+              minHeight: "70vh",
+              padding: "0",
+            },
+            ".cm-line": {
+              padding: "0",
+            },
+            ".cm-gutters": {
+              backgroundColor: "transparent",
+              border: "none",
+              color: "rgb(148 163 184)",
+              marginRight: "0.75rem",
+            },
+            ".cm-gutterElement": {
+              padding: "0 0.5rem 0 0",
+            },
+            ".cm-foldGutter": {
+              display: "none",
+            },
+            ".cm-activeLine": {
+              backgroundColor: "transparent",
+            },
+            ".cm-activeLineGutter": {
+              backgroundColor: "transparent",
+              color: "rgb(100 116 139)",
+            },
+            ".cm-selectionBackground, ::selection": {
+              backgroundColor: "rgb(224 242 254)",
+            },
+            "&.cm-focused": {
+              outline: "none",
+            },
+          }),
+        ],
+      }),
+    });
+
+    editorViewRef.current = view;
+    lastValueRef.current = value;
+
+    if (autoFocus) {
+      view.focus();
+    }
+
+    return () => {
+      editorViewRef.current = null;
+      view.destroy();
+    };
+  }, [autoFocus]);
+
+  useEffect(() => {
+    const view = editorViewRef.current;
+    if (!view) return;
+
+    const currentValue = view.state.doc.toString();
+    if (currentValue === value) {
+      lastValueRef.current = value;
+      return;
+    }
+
+    lastValueRef.current = value;
+    view.dispatch({
+      changes: {
+        from: 0,
+        to: currentValue.length,
+        insert: value,
+      },
+    });
+  }, [value]);
+
+  return <div ref={hostRef} className="markdown-code-editor" />;
+}

--- a/packages/app/src/MarkdownCodeEditor.tsx
+++ b/packages/app/src/MarkdownCodeEditor.tsx
@@ -18,6 +18,7 @@ export function MarkdownCodeEditor({
   const hostRef = useRef<HTMLDivElement | null>(null);
   const editorViewRef = useRef<EditorView | null>(null);
   const onChangeRef = useRef(onChange);
+  const initialValueRef = useRef(value);
   const lastValueRef = useRef(value);
 
   useEffect(() => {
@@ -31,7 +32,7 @@ export function MarkdownCodeEditor({
     const view = new EditorView({
       parent: hostElement,
       state: EditorState.create({
-        doc: value,
+        doc: initialValueRef.current,
         extensions: [
           basicSetup,
           markdown(),
@@ -96,7 +97,7 @@ export function MarkdownCodeEditor({
     });
 
     editorViewRef.current = view;
-    lastValueRef.current = value;
+    lastValueRef.current = view.state.doc.toString();
 
     if (autoFocus) {
       view.focus();

--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -4,7 +4,6 @@ import { EditorContent, useEditor, useEditorState } from "@tiptap/react";
 import { TextSelection } from "@tiptap/pm/state";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PointerEvent as ReactPointerEvent } from "react";
-import { createPortal } from "react-dom";
 import { useCanvasScale } from "./Canvas";
 import { CommentEditorList } from "./CommentEditorList";
 import { DocumentCommentRail } from "./DocumentCommentRail";
@@ -23,6 +22,7 @@ import {
 } from "./editor-extensions";
 import { EditorToolbar } from "./EditorToolbar";
 import { cn } from "./lib/utils";
+import { MarkdownCodeEditor } from "./MarkdownCodeEditor";
 import { toHtml } from "./markdown";
 import type { Page, StorageBackend } from "./storage";
 import { useCommentAnchorLayout } from "./useCommentAnchorLayout";
@@ -35,6 +35,7 @@ const CANVAS_RAIL_WIDTH = 420;
 const CANVAS_RAIL_GAP = 24;
 
 type SaveState = "idle" | "saving" | "error";
+type EditorViewMode = "rich-text" | "code";
 
 interface PageCardProps {
   page: Page;
@@ -49,9 +50,10 @@ interface PageCardProps {
   onReposition?: (id: string, x: number, y: number) => void;
   onDelete?: (id: string) => void;
   onSaveStateChange?: (state: SaveState) => void;
-  documentToolbarHost?: HTMLElement | null;
+  editorViewMode?: EditorViewMode;
   backend: StorageBackend;
   onEditorReady?: (editor: Editor | null) => void;
+  onCommentRailPresenceChange?: (hasCommentRailSpace: boolean) => void;
 }
 
 interface PageCardEditorSurfaceProps {
@@ -62,9 +64,31 @@ interface PageCardEditorSurfaceProps {
   onSelect?: (id: string) => void;
   onSave: (id: string, content: string) => Promise<void>;
   onSaveStateChange: (state: SaveState) => void;
-  documentToolbarHost: HTMLElement | null;
+  editorViewMode: EditorViewMode;
   backend: StorageBackend;
   onEditorReady?: (editor: Editor | null) => void;
+  onCommentRailPresenceChange?: (hasCommentRailSpace: boolean) => void;
+}
+
+interface RichTextEditorSurfaceProps {
+  page: Page;
+  selected: boolean;
+  focusRequestKey: string | null;
+  mode: "canvas" | "document";
+  sourceMarkdown: string;
+  onSelect?: (id: string) => void;
+  onMarkdownChange: (markdown: string) => void;
+  backend: StorageBackend;
+  onEditorReady?: (editor: Editor | null) => void;
+  onCommentRailPresenceChange?: (hasCommentRailSpace: boolean) => void;
+}
+
+interface CodeEditorSurfaceProps {
+  page: Page;
+  markdown: string;
+  hasCommentRailSpace: boolean;
+  onSelect?: (id: string) => void;
+  onMarkdownChange: (markdown: string) => void;
 }
 
 function getCanvasFilenameLabel(pageId: string) {
@@ -242,20 +266,18 @@ export function shouldDismissCommentThread(target: EventTarget | null) {
   );
 }
 
-const PageCardEditorSurface = memo(function PageCardEditorSurface({
+const RichTextEditorSurface = memo(function RichTextEditorSurface({
   page,
   selected,
   focusRequestKey,
   mode,
+  sourceMarkdown,
   onSelect,
-  onSave,
-  onSaveStateChange,
-  documentToolbarHost,
+  onMarkdownChange,
   backend,
   onEditorReady,
-}: PageCardEditorSurfaceProps) {
-  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const recentMarkdownRef = useRef<Set<string>>(new Set());
+  onCommentRailPresenceChange,
+}: RichTextEditorSurfaceProps) {
   const editorRef = useRef<Editor | null>(null);
   const commentsRef = useRef<Map<string, CriticComment>>(new Map());
   const lastFocusRequestKeyRef = useRef<string | null>(null);
@@ -275,10 +297,10 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
 
   const parsedContent = useMemo(
     () =>
-      criticMarkdownToEditorState(page.content, {
+      criticMarkdownToEditorState(sourceMarkdown, {
         resolveFileUrl,
       }),
-    [page.content, resolveFileUrl],
+    [resolveFileUrl, sourceMarkdown],
   );
   const [comments, setComments] = useState<Map<string, CriticComment>>(
     () => parsedContent.comments,
@@ -288,37 +310,24 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
     commentsRef.current = comments;
   }, [comments]);
 
-  const scheduleSave = useCallback(
+  useEffect(() => {
+    onCommentRailPresenceChange?.(comments.size > 0);
+  }, [comments.size, onCommentRailPresenceChange]);
+
+  const emitMarkdownChange = useCallback(
     (doc?: JSONContent, nextComments?: Map<string, CriticComment>) => {
       const currentEditor = editorRef.current;
       const currentDoc = doc ?? currentEditor?.getJSON();
-
       if (!currentDoc) return;
 
-      const markdown = editorStateToCriticMarkdown(
-        currentDoc,
-        nextComments ?? commentsRef.current,
+      onMarkdownChange(
+        editorStateToCriticMarkdown(
+          currentDoc,
+          nextComments ?? commentsRef.current,
+        ),
       );
-
-      recentMarkdownRef.current.add(markdown);
-      if (recentMarkdownRef.current.size > 10) {
-        const iterator = recentMarkdownRef.current.values();
-        recentMarkdownRef.current.delete(iterator.next().value as string);
-      }
-
-      if (saveTimer.current) clearTimeout(saveTimer.current);
-      onSaveStateChange("saving");
-      saveTimer.current = setTimeout(async () => {
-        try {
-          await onSave(page.id, markdown);
-          onSaveStateChange("idle");
-        } catch (error) {
-          console.error("Failed to save page:", error);
-          onSaveStateChange("error");
-        }
-      }, 500);
     },
-    [onSave, onSaveStateChange, page.id],
+    [onMarkdownChange],
   );
 
   const insertFiles = useCallback(
@@ -381,7 +390,7 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
         },
       },
       onUpdate: ({ editor: currentEditor }) => {
-        scheduleSave(currentEditor.getJSON());
+        emitMarkdownChange(currentEditor.getJSON());
       },
     },
     [page.id],
@@ -418,10 +427,6 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
   useEffect(() => {
     if (!editor) return;
     if (editor.isFocused) return;
-    if (recentMarkdownRef.current.has(page.content)) {
-      recentMarkdownRef.current.delete(page.content);
-      return;
-    }
 
     commentsRef.current = parsedContent.comments;
     setComments(parsedContent.comments);
@@ -433,15 +438,7 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
     if (JSON.stringify(editor.getJSON()) !== JSON.stringify(nextDoc)) {
       editor.commands.setContent(nextDoc, { emitUpdate: false });
     }
-  }, [editor, page.content, parsedContent]);
-
-  useEffect(() => {
-    return () => {
-      if (saveTimer.current) {
-        clearTimeout(saveTimer.current);
-      }
-    };
-  }, []);
+  }, [editor, parsedContent, sourceMarkdown]);
 
   useEffect(() => {
     if (!editor || !selected || !focusRequestKey) return;
@@ -556,7 +553,6 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
 
   const handleAddComment = useCallback(() => {
     const currentEditor = editorRef.current;
-
     if (!currentEditor || currentEditor.state.selection.empty) return;
 
     const existingIds = getSelectionCommentIds(currentEditor);
@@ -576,25 +572,24 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
 
     setSelectedCommentId(comment.id);
     setPendingFocusCommentId(comment.id);
-    scheduleSave(currentEditor.getJSON(), nextComments);
+    emitMarkdownChange(currentEditor.getJSON(), nextComments);
     requestAnimationFrame(() => {
       measureLayout();
     });
-  }, [measureLayout, scheduleSave]);
+  }, [emitMarkdownChange, measureLayout]);
 
   const updateComment = useCallback(
     (commentId: string, updater: (comment: CriticComment) => CriticComment) => {
       const existingComment = commentsRef.current.get(commentId);
-
       if (!existingComment) return;
 
       const nextComments = new Map(commentsRef.current);
       nextComments.set(commentId, updater(existingComment));
       commentsRef.current = nextComments;
       setComments(nextComments);
-      scheduleSave(undefined, nextComments);
+      emitMarkdownChange(undefined, nextComments);
     },
-    [scheduleSave],
+    [emitMarkdownChange],
   );
 
   const replyToComment = useCallback(
@@ -624,12 +619,12 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
       setSelectedCommentId(comment.id);
       setHoveredCommentId(null);
       setPendingFocusCommentId(comment.id);
-      scheduleSave(currentEditor.getJSON(), nextComments);
+      emitMarkdownChange(currentEditor.getJSON(), nextComments);
       requestAnimationFrame(() => {
         measureLayout();
       });
     },
-    [measureLayout, scheduleSave],
+    [emitMarkdownChange, measureLayout],
   );
 
   const deleteComment = useCallback(
@@ -664,12 +659,12 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
       setPendingFocusCommentId((current) =>
         current && deletedIds.has(current) ? null : current,
       );
-      scheduleSave(currentEditor.getJSON(), nextComments);
+      emitMarkdownChange(currentEditor.getJSON(), nextComments);
       requestAnimationFrame(() => {
         measureLayout();
       });
     },
-    [measureLayout, scheduleSave],
+    [emitMarkdownChange, measureLayout],
   );
 
   const selectComment = useCallback((commentId: string) => {
@@ -716,20 +711,16 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
   const activeComments = activeCommentIds
     .map((commentId) => comments.get(commentId))
     .filter((comment): comment is CriticComment => Boolean(comment));
-  const toolbar = (
-    <EditorToolbar
-      editor={editor}
-      onPickFiles={insertFiles}
-      variant={isCanvasMode ? "canvas" : "document"}
-    />
-  );
+  const toolbar = isCanvasMode ? (
+    <EditorToolbar editor={editor} onPickFiles={insertFiles} variant="canvas" />
+  ) : null;
   const contentCardClass =
-    "rounded-[0.9rem] border border-[#E9E9E8] bg-white shadow-[0_18px_44px_rgba(57,47,38,0.08)]";
+    "rounded-[0.75rem] border border-[#E9E9E8] bg-white shadow-[0_18px_44px_rgba(57,47,38,0.08)]";
 
   if (isCanvasMode) {
     return (
       <div
-        className="cursor-text rounded-b-3xl bg-[#FCFCFC] px-5 pt-4 pb-6"
+        className="cursor-text rounded-b-2xl bg-[#FCFCFC] px-5 pt-4 pb-6"
         onPointerDown={handleBodyPointerDown}
       >
         {toolbar}
@@ -790,9 +781,7 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
       className="cursor-text bg-transparent"
       onPointerDown={handleBodyPointerDown}
     >
-      {!documentToolbarHost
-        ? toolbar
-        : createPortal(toolbar, documentToolbarHost)}
+      {toolbar}
       <div
         className={cn(
           "document-page-shell",
@@ -825,7 +814,9 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
             />
           ) : null}
           <div className="pb-24">
-            <div className={cn(contentCardClass, "px-10 py-8 sm:px-12 sm:py-9")}>
+            <div
+              className={cn(contentCardClass, "px-10 py-10 sm:px-14 sm:py-14")}
+            >
               <EditorContextMenu
                 editor={editor}
                 backend={backend}
@@ -866,6 +857,178 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
   );
 });
 
+const CodeEditorSurface = memo(function CodeEditorSurface({
+  page,
+  markdown,
+  hasCommentRailSpace,
+  onSelect,
+  onMarkdownChange,
+}: CodeEditorSurfaceProps) {
+  const handleBodyPointerDown = useCallback(
+    (event: ReactPointerEvent) => {
+      event.stopPropagation();
+      onSelect?.(page.id);
+    },
+    [onSelect, page.id],
+  );
+
+  return (
+    <div
+      className="cursor-text bg-transparent"
+      onPointerDown={handleBodyPointerDown}
+    >
+      <div
+        className={cn(
+          "document-page-shell",
+          !hasCommentRailSpace && "document-page-shell-no-comments",
+        )}
+      >
+        <div className="document-page-main min-w-0">
+          <div className="pb-24">
+            <div className="markdown-code-shell rounded-[0.75rem] border border-[#E9E9E8] bg-white pl-5 pr-6 py-10 shadow-[0_18px_44px_rgba(57,47,38,0.08)] sm:pl-8 sm:pr-10 sm:py-14">
+              <MarkdownCodeEditor
+                value={markdown}
+                onChange={onMarkdownChange}
+                autoFocus
+              />
+            </div>
+          </div>
+        </div>
+        {hasCommentRailSpace ? (
+          <div
+            className="document-comment-rail pointer-events-none invisible"
+            aria-hidden="true"
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+});
+
+const PageCardEditorSurface = memo(function PageCardEditorSurface({
+  page,
+  selected,
+  focusRequestKey,
+  mode,
+  onSelect,
+  onSave,
+  onSaveStateChange,
+  editorViewMode,
+  backend,
+  onEditorReady,
+  onCommentRailPresenceChange,
+}: PageCardEditorSurfaceProps) {
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const recentMarkdownRef = useRef<Set<string>>(new Set());
+  const previousEditorViewModeRef = useRef<EditorViewMode>(editorViewMode);
+  const [markdown, setMarkdown] = useState(page.content);
+  const [richTextSourceMarkdown, setRichTextSourceMarkdown] = useState(
+    page.content,
+  );
+  const [richTextSourceVersion, setRichTextSourceVersion] = useState(0);
+
+  const scheduleSave = useCallback(
+    (nextMarkdown: string) => {
+      recentMarkdownRef.current.add(nextMarkdown);
+      if (recentMarkdownRef.current.size > 10) {
+        const iterator = recentMarkdownRef.current.values();
+        recentMarkdownRef.current.delete(iterator.next().value as string);
+      }
+
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+      onSaveStateChange("saving");
+      saveTimer.current = setTimeout(async () => {
+        try {
+          await onSave(page.id, nextMarkdown);
+          onSaveStateChange("idle");
+        } catch (error) {
+          console.error("Failed to save page:", error);
+          onSaveStateChange("error");
+        }
+      }, 500);
+    },
+    [onSave, onSaveStateChange, page.id],
+  );
+
+  const handleMarkdownChange = useCallback(
+    (nextMarkdown: string) => {
+      setMarkdown(nextMarkdown);
+      scheduleSave(nextMarkdown);
+    },
+    [scheduleSave],
+  );
+
+  useEffect(() => {
+    if (recentMarkdownRef.current.has(page.content)) {
+      recentMarkdownRef.current.delete(page.content);
+      return;
+    }
+
+    setMarkdown(page.content);
+    setRichTextSourceMarkdown(page.content);
+    setRichTextSourceVersion((current) => current + 1);
+  }, [page.content]);
+
+  useEffect(() => {
+    const previousEditorViewMode = previousEditorViewModeRef.current;
+    previousEditorViewModeRef.current = editorViewMode;
+
+    if (
+      mode !== "document" ||
+      previousEditorViewMode !== "code" ||
+      editorViewMode !== "rich-text"
+    ) {
+      return;
+    }
+
+    setRichTextSourceMarkdown(markdown);
+    setRichTextSourceVersion((current) => current + 1);
+  }, [editorViewMode, markdown, mode]);
+
+  useEffect(() => {
+    return () => {
+      if (saveTimer.current) {
+        clearTimeout(saveTimer.current);
+      }
+    };
+  }, []);
+
+  const hasCommentRailSpace = markdown.includes("{>>");
+
+  useEffect(() => {
+    if (editorViewMode !== "code") return;
+    onCommentRailPresenceChange?.(hasCommentRailSpace);
+  }, [editorViewMode, hasCommentRailSpace, onCommentRailPresenceChange]);
+
+  if (mode === "document" && editorViewMode === "code") {
+    return (
+      <CodeEditorSurface
+        page={page}
+        markdown={markdown}
+        hasCommentRailSpace={hasCommentRailSpace}
+        onSelect={onSelect}
+        onMarkdownChange={handleMarkdownChange}
+      />
+    );
+  }
+
+  return (
+    <RichTextEditorSurface
+      key={`${page.id}:${richTextSourceVersion}`}
+      page={page}
+      selected={selected}
+      focusRequestKey={focusRequestKey}
+      mode={mode}
+      sourceMarkdown={richTextSourceMarkdown}
+      onSelect={onSelect}
+      onMarkdownChange={handleMarkdownChange}
+      onCommentRailPresenceChange={onCommentRailPresenceChange}
+      backend={backend}
+      onEditorReady={onEditorReady}
+    />
+  );
+});
+
 export function PageCard({
   page,
   x = 0,
@@ -879,9 +1042,10 @@ export function PageCard({
   onReposition,
   onDelete,
   onSaveStateChange,
-  documentToolbarHost = null,
+  editorViewMode = "rich-text",
   backend,
   onEditorReady,
+  onCommentRailPresenceChange,
 }: PageCardProps) {
   const isDragging = useRef(false);
   const dragStart = useRef({ x: 0, y: 0, pageX: 0, pageY: 0 });
@@ -934,14 +1098,14 @@ export function PageCard({
       {isCanvasMode ? (
         <div className="relative" style={{ width: CANVAS_CONTENT_WIDTH }}>
           <div
-            className={`rounded-3xl border bg-[#FCFCFC] shadow-[0_18px_50px_rgba(15,23,42,0.14)] backdrop-blur transition-[border-color,box-shadow] ${
+            className={`rounded-2xl border bg-[#FCFCFC] shadow-[0_18px_50px_rgba(15,23,42,0.14)] backdrop-blur transition-[border-color,box-shadow] ${
               selected
                 ? "border-sky-300 shadow-[0_28px_72px_rgba(14,116,144,0.22)]"
                 : "border-slate-200/90"
             }`}
           >
             <div
-              className="flex min-h-10 cursor-grab select-none items-center gap-2 rounded-t-3xl border-b border-slate-200/80 bg-slate-50/90 px-4 active:cursor-grabbing"
+              className="flex min-h-10 cursor-grab select-none items-center gap-2 rounded-t-2xl border-b border-slate-200/80 bg-slate-50/90 px-4 active:cursor-grabbing"
               onPointerDown={handleDragPointerDown}
               onPointerMove={handleDragPointerMove}
               onPointerUp={handleDragPointerUp}
@@ -982,9 +1146,10 @@ export function PageCard({
               onSelect={onSelect}
               onSave={onSave}
               onSaveStateChange={setSaveState}
-              documentToolbarHost={documentToolbarHost}
+              editorViewMode={editorViewMode}
               backend={backend}
               onEditorReady={onEditorReady}
+              onCommentRailPresenceChange={onCommentRailPresenceChange}
             />
           </div>
         </div>
@@ -997,9 +1162,10 @@ export function PageCard({
           onSelect={onSelect}
           onSave={onSave}
           onSaveStateChange={setSaveState}
-          documentToolbarHost={documentToolbarHost}
+          editorViewMode={editorViewMode}
           backend={backend}
           onEditorReady={onEditorReady}
+          onCommentRailPresenceChange={onCommentRailPresenceChange}
         />
       )}
     </div>

--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -438,7 +438,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
     if (JSON.stringify(editor.getJSON()) !== JSON.stringify(nextDoc)) {
       editor.commands.setContent(nextDoc, { emitUpdate: false });
     }
-  }, [editor, parsedContent, sourceMarkdown]);
+  }, [editor, parsedContent]);
 
   useEffect(() => {
     if (!editor || !selected || !focusRequestKey) return;

--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -22,6 +22,7 @@ import {
   createEditorExtensions,
 } from "./editor-extensions";
 import { EditorToolbar } from "./EditorToolbar";
+import { cn } from "./lib/utils";
 import { toHtml } from "./markdown";
 import type { Page, StorageBackend } from "./storage";
 import { useCommentAnchorLayout } from "./useCommentAnchorLayout";
@@ -361,8 +362,8 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
         attributes: {
           class:
             mode === "canvas"
-              ? "tiptap min-h-[120px] text-[1.05rem] leading-8 text-slate-800 outline-none selection:bg-sky-100"
-              : "tiptap min-h-[70vh] text-[1.08rem] leading-8 text-slate-800 outline-none selection:bg-sky-100",
+              ? "tiptap min-h-[120px] selection:bg-sky-100"
+              : "tiptap min-h-[70vh] selection:bg-sky-100",
         },
         handleDrop: (_view, event) => {
           const files = Array.from(event.dataTransfer?.files ?? []);
@@ -711,6 +712,7 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
 
   const isCanvasMode = mode === "canvas";
   const showCanvasRail = isCanvasMode && comments.size > 0;
+  const hasComments = comments.size > 0;
   const activeComments = activeCommentIds
     .map((commentId) => comments.get(commentId))
     .filter((comment): comment is CriticComment => Boolean(comment));
@@ -721,22 +723,26 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
       variant={isCanvasMode ? "canvas" : "document"}
     />
   );
+  const contentCardClass =
+    "rounded-[0.9rem] border border-[#E9E9E8] bg-white shadow-[0_18px_44px_rgba(57,47,38,0.08)]";
 
   if (isCanvasMode) {
     return (
       <div
-        className="cursor-text rounded-b-3xl bg-white px-5 pt-4 pb-6"
+        className="cursor-text rounded-b-3xl bg-[#FCFCFC] px-5 pt-4 pb-6"
         onPointerDown={handleBodyPointerDown}
       >
         {toolbar}
         <div className="relative">
-          <EditorContextMenu
-            editor={editor}
-            backend={backend}
-            onAddComment={handleAddComment}
-          >
-            <EditorContent editor={editor} />
-          </EditorContextMenu>
+          <div className={cn(contentCardClass, "px-8 py-5")}>
+            <EditorContextMenu
+              editor={editor}
+              backend={backend}
+              onAddComment={handleAddComment}
+            >
+              <EditorContent editor={editor} />
+            </EditorContextMenu>
+          </div>
           {showCanvasRail ? (
             <div
               className="absolute top-0"
@@ -787,7 +793,12 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
       {!documentToolbarHost
         ? toolbar
         : createPortal(toolbar, documentToolbarHost)}
-      <div className="document-page-shell">
+      <div
+        className={cn(
+          "document-page-shell",
+          !hasComments && "document-page-shell-no-comments",
+        )}
+      >
         <div className="document-page-main min-w-0">
           {activeComments.length > 0 ? (
             <CommentEditorList
@@ -814,13 +825,15 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
             />
           ) : null}
           <div className="pb-24">
-            <EditorContextMenu
-              editor={editor}
-              backend={backend}
-              onAddComment={handleAddComment}
-            >
-              <EditorContent editor={editor} />
-            </EditorContextMenu>
+            <div className={cn(contentCardClass, "px-10 py-8 sm:px-12 sm:py-9")}>
+              <EditorContextMenu
+                editor={editor}
+                backend={backend}
+                onAddComment={handleAddComment}
+              >
+                <EditorContent editor={editor} />
+              </EditorContextMenu>
+            </div>
           </div>
         </div>
         <DocumentCommentRail
@@ -921,7 +934,7 @@ export function PageCard({
       {isCanvasMode ? (
         <div className="relative" style={{ width: CANVAS_CONTENT_WIDTH }}>
           <div
-            className={`rounded-3xl border bg-white/95 shadow-[0_18px_50px_rgba(15,23,42,0.14)] backdrop-blur transition-[border-color,box-shadow] ${
+            className={`rounded-3xl border bg-[#FCFCFC] shadow-[0_18px_50px_rgba(15,23,42,0.14)] backdrop-blur transition-[border-color,box-shadow] ${
               selected
                 ? "border-sky-300 shadow-[0_28px_72px_rgba(14,116,144,0.22)]"
                 : "border-slate-200/90"

--- a/packages/app/src/app-navigation.ts
+++ b/packages/app/src/app-navigation.ts
@@ -1,0 +1,244 @@
+import type { Page } from "./storage";
+
+export interface RequestedPathState {
+  rawPath: string | null;
+  projectPath: string | null;
+  documentPath: string | null;
+}
+
+export type ViewMode = "canvas" | "document";
+export type DocumentEditorViewMode = "rich-text" | "code";
+
+export const CANVAS_FRAME_WIDTH = 680;
+export const CANVAS_FRAME_WIDTH_WITH_RAIL = 960;
+
+export function normalizePathSeparators(value: string) {
+  return value.replace(/\\/g, "/");
+}
+
+export function getRawPathFromLocation(): string | null {
+  const searchParams = new URLSearchParams(window.location.search);
+  const queryPath = searchParams.get("path")?.trim();
+  if (queryPath) return queryPath;
+
+  const normalizedPathname = normalizePathSeparators(window.location.pathname);
+  if (normalizedPathname !== "/" && !normalizedPathname.startsWith("/api")) {
+    const decodedPathname = decodeURIComponent(normalizedPathname);
+    return decodedPathname.startsWith("/")
+      ? decodedPathname
+      : `/${decodedPathname}`;
+  }
+
+  return null;
+}
+
+export function getViewModeFromLocation(fallbackMode: ViewMode): ViewMode {
+  const searchParams = new URLSearchParams(window.location.search);
+  const requestedMode = searchParams.get("mode");
+  if (requestedMode === "canvas" || requestedMode === "document") {
+    return requestedMode;
+  }
+  return fallbackMode;
+}
+
+export function getDocumentEditorViewModeFromLocation(
+  fallbackMode: DocumentEditorViewMode,
+): DocumentEditorViewMode {
+  const searchParams = new URLSearchParams(window.location.search);
+  const requestedMode = searchParams.get("editor");
+  if (requestedMode === "rich-text" || requestedMode === "code") {
+    return requestedMode;
+  }
+  return fallbackMode;
+}
+
+export function getRequestedPathState(): RequestedPathState {
+  const rawPath = getRawPathFromLocation();
+  if (!rawPath) {
+    return { rawPath: null, projectPath: null, documentPath: null };
+  }
+
+  const normalizedPath = normalizePathSeparators(rawPath);
+  if (!normalizedPath.toLowerCase().endsWith(".md")) {
+    return { rawPath, projectPath: rawPath, documentPath: null };
+  }
+
+  const lastSlashIndex = Math.max(
+    normalizedPath.lastIndexOf("/"),
+    normalizedPath.lastIndexOf("\\"),
+  );
+  const projectPath =
+    lastSlashIndex >= 0 ? rawPath.slice(0, lastSlashIndex) || "/" : ".";
+  const documentPath = rawPath.slice(lastSlashIndex + 1);
+
+  return { rawPath, projectPath, documentPath };
+}
+
+export function getWorkspacePath(path?: string) {
+  return path?.trim() || null;
+}
+
+export function formatWorkspacePathForDisplay(path?: string | null) {
+  const value = path?.trim();
+  if (!value) return null;
+
+  const normalizedPath = normalizePathSeparators(value);
+  const collapsedHomePath = normalizedPath.replace(
+    /^\/Users\/[^/]+(?=\/|$)/,
+    "~",
+  );
+  return value.includes("\\")
+    ? collapsedHomePath.replace(/\//g, "\\")
+    : collapsedHomePath;
+}
+
+export function getWorkspaceName(path?: string) {
+  const workspacePath = getWorkspacePath(path);
+  if (!workspacePath) return "Browser drafts";
+
+  const segments = workspacePath.split(/[\\/]/).filter(Boolean);
+  return segments.at(-1) || workspacePath;
+}
+
+export function getPathLeaf(path?: string | null) {
+  const value = path?.trim();
+  if (!value) return null;
+
+  const segments = value.split(/[\\/]/).filter(Boolean);
+  return segments.at(-1) || value;
+}
+
+export function hasCriticMarkupComments(content: string) {
+  return content.includes("{>>");
+}
+
+export function getCanvasFrameWidth(
+  page: Page | null | undefined,
+  fallbackWidth: number,
+) {
+  if (!page) return fallbackWidth;
+  return hasCriticMarkupComments(page.content)
+    ? CANVAS_FRAME_WIDTH_WITH_RAIL
+    : fallbackWidth;
+}
+
+export function joinPath(basePath: string, relativePath: string) {
+  const separator = basePath.includes("\\") ? "\\" : "/";
+  const normalizedBasePath = basePath.endsWith(separator)
+    ? basePath.slice(0, -1)
+    : basePath;
+
+  return relativePath
+    .split("/")
+    .filter(Boolean)
+    .reduce(
+      (result, segment) => `${result}${separator}${segment}`,
+      normalizedBasePath,
+    );
+}
+
+export function getCanvasPageId(relativePath: string) {
+  const normalizedPath = normalizePathSeparators(relativePath);
+  if (normalizedPath.includes("/")) return null;
+  return normalizedPath.replace(/\.md$/i, "");
+}
+
+export function getContainingPath(pathValue: string) {
+  const trimmedPath = pathValue.trim();
+  if (!trimmedPath) return trimmedPath;
+
+  const normalizedPath = trimmedPath.replace(/[\\/]+$/, "");
+  if (!normalizedPath) return trimmedPath.startsWith("\\") ? "\\" : "/";
+
+  const lastSeparatorIndex = Math.max(
+    normalizedPath.lastIndexOf("/"),
+    normalizedPath.lastIndexOf("\\"),
+  );
+
+  if (lastSeparatorIndex < 0) return ".";
+  if (lastSeparatorIndex === 0) return normalizedPath[0] === "\\" ? "\\" : "/";
+  return normalizedPath.slice(0, lastSeparatorIndex);
+}
+
+export function getOpenedFolderPath(pathValue: string) {
+  const trimmedPath = pathValue.trim();
+  if (!trimmedPath) return trimmedPath;
+
+  return normalizePathSeparators(trimmedPath).toLowerCase().endsWith(".md")
+    ? getContainingPath(trimmedPath)
+    : trimmedPath.replace(/[\\/]+$/, "") || trimmedPath;
+}
+
+export function getDocumentNavigationState(
+  projectPath: string,
+  relativePath: string,
+  currentRawPath: string | null,
+): RequestedPathState {
+  const relativeFolderPath = getContainingPath(relativePath);
+  const nextFolderPath =
+    relativeFolderPath === "."
+      ? projectPath
+      : joinPath(projectPath, relativeFolderPath);
+  const shouldPreserveUrl =
+    !!currentRawPath &&
+    normalizePathSeparators(getOpenedFolderPath(currentRawPath)) ===
+      normalizePathSeparators(nextFolderPath);
+
+  return {
+    rawPath: shouldPreserveUrl
+      ? currentRawPath
+      : joinPath(projectPath, relativePath),
+    projectPath,
+    documentPath: relativePath,
+  };
+}
+
+export function buildLocationForPath(path?: string | null) {
+  const nextPath = path?.trim() || null;
+  const url = new URL(window.location.href);
+
+  if (nextPath) {
+    if (!nextPath.includes("\\")) {
+      url.pathname = nextPath.startsWith("/") ? nextPath : `/${nextPath}`;
+      url.searchParams.delete("path");
+    } else {
+      url.pathname = "/";
+      url.searchParams.set("path", nextPath);
+    }
+  } else {
+    url.searchParams.delete("path");
+    url.pathname = "/";
+  }
+
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function buildLocationForViewMode(mode: ViewMode) {
+  const url = new URL(window.location.href);
+  url.searchParams.set("mode", mode);
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function buildLocationForDocumentEditorViewMode(
+  mode: DocumentEditorViewMode,
+) {
+  const url = new URL(window.location.href);
+  url.searchParams.set("editor", mode);
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function syncProjectPathInUrl(projectPath?: string) {
+  const nextLocation = buildLocationForPath(getWorkspacePath(projectPath));
+  const currentLocation = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (nextLocation !== currentLocation) {
+    window.history.replaceState(null, "", nextLocation);
+  }
+}
+
+export function syncRequestedPathInUrl(path?: string | null) {
+  const nextLocation = buildLocationForPath(path);
+  const currentLocation = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (nextLocation !== currentLocation) {
+    window.history.replaceState(null, "", nextLocation);
+  }
+}

--- a/packages/app/src/document-comments.ts
+++ b/packages/app/src/document-comments.ts
@@ -1,3 +1,9 @@
+import {
+  buildCommentThreads,
+  type CriticComment,
+  flattenCommentThreads,
+} from "./critic-markup";
+
 export interface CommentAnchorMeasurement {
   commentIds: string[];
   anchorTop: number;
@@ -12,6 +18,21 @@ export interface CommentGroupAnchor {
 }
 
 export interface CommentRailLayout extends CommentGroupAnchor {
+  railTop: number;
+  railBottom: number;
+  height: number;
+}
+
+export interface CommentThreadRailItem {
+  key: string;
+  anchorGroupKey: string;
+  rootCommentId: string;
+  commentIds: string[];
+  anchorTop: number;
+  anchorBottom: number;
+}
+
+export interface CommentThreadRailLayout extends CommentThreadRailItem {
   railTop: number;
   railBottom: number;
   height: number;
@@ -67,6 +88,37 @@ export function getPreferredCommentId(
   }
 
   return commentIds[0] ?? null;
+}
+
+export function getRootThreadIdForCommentId(
+  commentId: string | null,
+  comments: ReadonlyMap<string, CriticComment>,
+): string | null {
+  if (!commentId) return null;
+
+  const visited = new Set<string>();
+  let currentComment = comments.get(commentId);
+
+  while (currentComment) {
+    if (visited.has(currentComment.id)) {
+      break;
+    }
+
+    visited.add(currentComment.id);
+    const parentCommentId = currentComment.parentCommentId;
+
+    if (
+      !parentCommentId ||
+      parentCommentId === currentComment.id ||
+      !comments.has(parentCommentId)
+    ) {
+      return currentComment.id;
+    }
+
+    currentComment = comments.get(parentCommentId);
+  }
+
+  return comments.has(commentId) ? commentId : null;
 }
 
 export function getCommentAnchorMeasurements(
@@ -128,6 +180,38 @@ export function groupCommentAnchorMeasurements(
   );
 }
 
+export function buildCommentThreadRailItems(
+  groups: CommentGroupAnchor[],
+  comments: ReadonlyMap<string, CriticComment>,
+): CommentThreadRailItem[] {
+  const items: CommentThreadRailItem[] = [];
+
+  for (const group of groups) {
+    const visibleComments = group.commentIds
+      .map((commentId) => comments.get(commentId))
+      .filter((comment): comment is CriticComment => Boolean(comment));
+
+    if (visibleComments.length === 0) continue;
+
+    for (const thread of buildCommentThreads(visibleComments)) {
+      const threadComments = flattenCommentThreads([thread]);
+
+      if (threadComments.length === 0) continue;
+
+      items.push({
+        key: thread.comment.id,
+        anchorGroupKey: group.key,
+        rootCommentId: thread.comment.id,
+        commentIds: threadComments.map((comment) => comment.id),
+        anchorTop: group.anchorTop,
+        anchorBottom: group.anchorBottom,
+      });
+    }
+  }
+
+  return items;
+}
+
 export function resolveCommentRailLayouts(
   groups: CommentGroupAnchor[],
   heights: Record<string, number>,
@@ -151,4 +235,70 @@ export function resolveCommentRailLayouts(
       height,
     };
   });
+}
+
+export function resolveCommentThreadRailLayouts(
+  items: CommentThreadRailItem[],
+  heights: Record<string, number>,
+  selectedRootThreadId: string | null,
+  gap = 16,
+): CommentThreadRailLayout[] {
+  if (items.length === 0) return [];
+
+  const activeIndex = Math.max(
+    0,
+    selectedRootThreadId
+      ? items.findIndex((item) => item.rootCommentId === selectedRootThreadId)
+      : 0,
+  );
+
+  const resolved = new Array<CommentThreadRailLayout>(items.length);
+  const getHeight = (item: CommentThreadRailItem) => heights[item.key] ?? 120;
+
+  const activeItem = items[activeIndex] ?? items[0];
+  if (!activeItem) return [];
+
+  const activeHeight = getHeight(activeItem);
+  resolved[activeIndex] = {
+    ...activeItem,
+    railTop: activeItem.anchorTop,
+    railBottom: activeItem.anchorTop + activeHeight,
+    height: activeHeight,
+  };
+
+  for (let index = activeIndex - 1; index >= 0; index -= 1) {
+    const item = items[index];
+    const nextLayout = resolved[index + 1];
+
+    if (!item || !nextLayout) continue;
+
+    const height = getHeight(item);
+    const railTop = Math.min(item.anchorTop, nextLayout.railTop - gap - height);
+
+    resolved[index] = {
+      ...item,
+      railTop,
+      railBottom: railTop + height,
+      height,
+    };
+  }
+
+  for (let index = activeIndex + 1; index < items.length; index += 1) {
+    const item = items[index];
+    const previousLayout = resolved[index - 1];
+
+    if (!item || !previousLayout) continue;
+
+    const height = getHeight(item);
+    const railTop = Math.max(item.anchorTop, previousLayout.railBottom + gap);
+
+    resolved[index] = {
+      ...item,
+      railTop,
+      railBottom: railTop + height,
+      height,
+    };
+  }
+
+  return resolved;
 }

--- a/packages/app/src/markdown.ts
+++ b/packages/app/src/markdown.ts
@@ -40,6 +40,16 @@ export function createMarkedRenderer(options?: MarkdownOptions) {
   const baseRenderer = new marked.Renderer();
   const resolveFileUrl = options?.resolveFileUrl;
 
+  renderer.code = ({ text, lang, escaped }) => {
+    const language = (lang || "").match(/\S+/)?.[0];
+    const content = escaped ? text : escapeHtml(text);
+    const classAttr = language
+      ? ` class="language-${escapeHtml(language)}"`
+      : "";
+
+    return `<pre><code${classAttr}>${content}</code></pre>\n`;
+  };
+
   renderer.link = function ({ href, title, tokens }) {
     const rawHref = href || "";
     const renderedHref = resolveRenderedUrl(rawHref, resolveFileUrl);

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -305,10 +305,6 @@
     border-left-color: rgb(15 23 42);
   }
 
-  .markdown-code-editor .cm-selectionBackground {
-    background-color: rgb(224 242 254) !important;
-  }
-
   @media (min-width: 1100px) {
     .document-page-shell {
       display: grid;

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -43,9 +43,9 @@
 @layer components {
   .tiptap {
     @apply min-h-[120px] text-slate-800 outline-none;
-    --editor-font-size: 15px;
+    --editor-font-size: 16px;
     font-size: var(--editor-font-size);
-    line-height: 1.9;
+    line-height: 1.58;
   }
 
   .tiptap p.is-editor-empty:first-child::before {
@@ -57,26 +57,32 @@
   }
 
   .tiptap h1 {
-    @apply mt-[0.35em] mb-4 font-semibold leading-tight tracking-tight text-slate-950;
-    font-size: 1.905em;
+    @apply mt-[0.1em] mb-[0.7em] font-semibold text-slate-950;
+    font-size: 2.15em;
+    line-height: 1.1;
+    letter-spacing: -0.03em;
   }
 
   .tiptap h2 {
-    @apply mt-6 mb-3 font-semibold leading-tight tracking-tight text-slate-950;
-    font-size: 1.429em;
+    @apply mt-[1.8em] mb-[0.5em] font-semibold text-slate-950;
+    font-size: 1.65em;
+    line-height: 1.2;
+    letter-spacing: -0.02em;
+  }
+
+  .tiptap h3 {
+    @apply mt-[1.45em] mb-[0.35em] font-semibold text-slate-950;
+    font-size: 1.25em;
+    line-height: 1.28;
+    letter-spacing: -0.01em;
   }
 
   .tiptap p {
-    @apply mb-3;
+    margin: 0 0 1.05em;
   }
 
-  .tiptap > p,
-  .tiptap > ul,
-  .tiptap > ol,
-  .tiptap > blockquote,
-  .tiptap > img,
-  .tiptap > pre {
-    @apply mb-3;
+  .tiptap > p {
+    margin-bottom: 1.05em;
   }
 
   .tiptap a {
@@ -90,22 +96,23 @@
   }
 
   .tiptap .comment-decoration {
-    @apply rounded-[0.4rem] bg-amber-100/90 px-0.5 text-inherit ring-1 ring-amber-300/70;
+    @apply px-0.5 text-inherit;
+    background-color: #fff5c7;
     box-decoration-break: clone;
     -webkit-box-decoration-break: clone;
     transition:
       background-color 140ms ease,
-      box-shadow 140ms ease,
-      color 140ms ease,
-      ring-color 140ms ease;
+      color 140ms ease;
   }
 
   .tiptap .comment-decoration.comment-decoration-hovered {
-    @apply bg-amber-200/95 text-slate-900 ring-amber-400/80;
+    @apply text-inherit;
+    background-color: #ffd000;
   }
 
   .tiptap .comment-decoration.comment-decoration-active {
-    @apply bg-amber-300/95 text-slate-950 ring-amber-600;
+    @apply text-inherit;
+    background-color: #ffd000;
   }
 
   .tiptap code {
@@ -113,7 +120,8 @@
   }
 
   .tiptap pre {
-    @apply mb-3 overflow-x-auto rounded-2xl border p-4;
+    @apply overflow-x-auto rounded-2xl border p-4;
+    margin: 1.35em 0;
     background-color: var(--code-block-background);
     border-color: var(--code-block-border);
     color: var(--code-block-foreground);
@@ -124,24 +132,30 @@
   }
 
   .tiptap blockquote {
-    @apply mb-3 border-l-4 border-slate-300 pl-4 text-slate-600;
+    @apply border-l-4 border-slate-300 pl-4 text-slate-600;
+    margin: 1.3em 0;
   }
 
   .tiptap ul {
-    @apply mb-3 list-disc pl-7;
+    @apply list-disc;
+    margin: 0.45em 0 1.05em;
+    padding-left: 1.35em;
   }
 
   .tiptap ol {
-    @apply mb-3 list-decimal pl-7;
+    @apply list-decimal;
+    margin: 0.45em 0 1.05em;
+    padding-left: 1.35em;
   }
 
   .tiptap li > ul,
   .tiptap li > ol {
-    @apply mt-2 pl-8;
+    margin-top: 0.45em;
+    padding-left: 1.35em;
   }
 
   .tiptap li p {
-    margin: 0 0 0.4em 0;
+    margin: 0 0 0.55em 0;
   }
 
   .tiptap li > p:last-child {
@@ -246,9 +260,14 @@
     gap: 1.5rem;
   }
 
+  .document-page-header {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
   .document-page-main {
     width: 100%;
-    max-width: 43.75rem;
+    max-width: 46.5rem;
     min-width: 0;
   }
 
@@ -256,10 +275,44 @@
     display: none;
   }
 
+  .markdown-code-shell {
+    min-height: calc(70vh + 4rem);
+  }
+
+  .markdown-code-editor {
+    color: rgb(15 23 42);
+  }
+
+  .markdown-code-editor .cm-editor {
+    background: transparent;
+  }
+
+  .markdown-code-editor .cm-scroller {
+    overflow: auto;
+  }
+
+  .markdown-code-editor .cm-gutters {
+    flex-shrink: 0;
+  }
+
+  .markdown-code-editor .cm-content,
+  .markdown-code-editor .cm-line {
+    caret-color: rgb(15 23 42);
+  }
+
+  .markdown-code-editor .cm-cursor,
+  .markdown-code-editor .cm-dropCursor {
+    border-left-color: rgb(15 23 42);
+  }
+
+  .markdown-code-editor .cm-selectionBackground {
+    background-color: rgb(224 242 254) !important;
+  }
+
   @media (min-width: 1100px) {
     .document-page-shell {
       display: grid;
-      grid-template-columns: minmax(0, 43.75rem) minmax(26rem, 1fr);
+      grid-template-columns: minmax(0, 46.5rem) minmax(24rem, 1fr);
       gap: 2rem;
       align-items: start;
       justify-content: space-between;
@@ -274,8 +327,13 @@
     }
 
     .document-page-shell.document-page-shell-no-comments {
-      grid-template-columns: minmax(0, 43.75rem);
+      grid-template-columns: minmax(0, 46.5rem);
       justify-content: center;
+    }
+
+    .document-page-header.document-page-header-no-comments {
+      margin-left: auto;
+      margin-right: auto;
     }
   }
 }
@@ -325,23 +383,23 @@
 
 :root {
   --background: #fcfcfc;
-  --foreground: oklch(0.141 0.005 285.823);
+  --foreground: oklch(0.141 0.006 67.1);
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.141 0.005 285.823);
+  --card-foreground: oklch(0.141 0.006 67.1);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(0.21 0.006 285.885);
+  --popover-foreground: oklch(0.141 0.006 67.1);
+  --primary: oklch(0.21 0.006 56.1);
   --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.967 0.001 286.375);
-  --muted-foreground: oklch(0.552 0.016 285.938);
-  --accent: oklch(0.967 0.001 286.375);
-  --accent-foreground: oklch(0.21 0.006 285.885);
+  --secondary: oklch(0.967 0.003 84.7);
+  --secondary-foreground: oklch(0.21 0.006 56.1);
+  --muted: oklch(0.967 0.003 84.7);
+  --muted-foreground: oklch(0.552 0.014 66.4);
+  --accent: oklch(0.967 0.003 84.7);
+  --accent-foreground: oklch(0.21 0.006 56.1);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.92 0.004 286.32);
-  --input: oklch(0.92 0.004 286.32);
-  --ring: oklch(0.705 0.015 286.067);
+  --border: oklch(0.92 0.005 84.2);
+  --input: oklch(0.92 0.005 84.2);
+  --ring: oklch(0.705 0.012 67.8);
   --chart-1: oklch(0.809 0.105 251.813);
   --chart-2: oklch(0.623 0.214 259.815);
   --chart-3: oklch(0.546 0.245 262.881);
@@ -349,51 +407,51 @@
   --chart-5: oklch(0.424 0.199 265.638);
   --radius: 0.45rem;
   --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.141 0.005 285.823);
-  --sidebar-primary: oklch(0.21 0.006 285.885);
+  --sidebar-foreground: oklch(0.141 0.006 67.1);
+  --sidebar-primary: oklch(0.21 0.006 56.1);
   --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.967 0.001 286.375);
-  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
-  --sidebar-border: oklch(0.92 0.004 286.32);
-  --sidebar-ring: oklch(0.705 0.015 286.067);
-  --code-block-background: oklch(0.985 0.001 286.375);
-  --code-block-border: oklch(0.92 0.004 286.32);
-  --code-block-foreground: oklch(0.141 0.005 285.823);
+  --sidebar-accent: oklch(0.967 0.003 84.7);
+  --sidebar-accent-foreground: oklch(0.21 0.006 56.1);
+  --sidebar-border: oklch(0.92 0.005 84.2);
+  --sidebar-ring: oklch(0.705 0.012 67.8);
+  --code-block-background: oklch(0.985 0.002 84.7);
+  --code-block-border: oklch(0.92 0.005 84.2);
+  --code-block-foreground: oklch(0.141 0.006 67.1);
 }
 
 .dark {
-  --background: oklch(0.141 0.005 285.823);
+  --background: oklch(0.141 0.006 67.1);
   --foreground: oklch(0.985 0 0);
-  --card: oklch(0.21 0.006 285.885);
+  --card: oklch(0.21 0.006 56.1);
   --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.21 0.006 285.885);
+  --popover: oklch(0.21 0.006 56.1);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.92 0.004 286.32);
-  --primary-foreground: oklch(0.21 0.006 285.885);
-  --secondary: oklch(0.274 0.006 286.033);
+  --primary: oklch(0.92 0.005 84.2);
+  --primary-foreground: oklch(0.21 0.006 56.1);
+  --secondary: oklch(0.274 0.006 61.4);
   --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.274 0.006 286.033);
-  --muted-foreground: oklch(0.705 0.015 286.067);
-  --accent: oklch(0.274 0.006 286.033);
+  --muted: oklch(0.274 0.006 61.4);
+  --muted-foreground: oklch(0.705 0.012 67.8);
+  --accent: oklch(0.274 0.006 61.4);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.552 0.016 285.938);
+  --ring: oklch(0.552 0.014 66.4);
   --chart-1: oklch(0.809 0.105 251.813);
   --chart-2: oklch(0.623 0.214 259.815);
   --chart-3: oklch(0.546 0.245 262.881);
   --chart-4: oklch(0.488 0.243 264.376);
   --chart-5: oklch(0.424 0.199 265.638);
-  --sidebar: oklch(0.21 0.006 285.885);
+  --sidebar: oklch(0.21 0.006 56.1);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);
   --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.274 0.006 286.033);
+  --sidebar-accent: oklch(0.274 0.006 61.4);
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.552 0.016 285.938);
-  --code-block-background: oklch(0.141 0.005 285.823);
+  --sidebar-ring: oklch(0.552 0.014 66.4);
+  --code-block-background: oklch(0.141 0.006 67.1);
   --code-block-border: oklch(1 0 0 / 10%);
   --code-block-foreground: oklch(0.985 0 0);
 }

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -42,7 +42,10 @@
 
 @layer components {
   .tiptap {
-    @apply min-h-[120px] text-[1.05rem] leading-8 text-slate-800 outline-none;
+    @apply min-h-[120px] text-slate-800 outline-none;
+    --editor-font-size: 15px;
+    font-size: var(--editor-font-size);
+    line-height: 1.9;
   }
 
   .tiptap p.is-editor-empty:first-child::before {
@@ -54,11 +57,13 @@
   }
 
   .tiptap h1 {
-    @apply mt-[0.35em] mb-4 text-[2rem] font-semibold leading-tight tracking-tight text-slate-950;
+    @apply mt-[0.35em] mb-4 font-semibold leading-tight tracking-tight text-slate-950;
+    font-size: 1.905em;
   }
 
   .tiptap h2 {
-    @apply mt-6 mb-3 text-[1.5rem] font-semibold leading-tight tracking-tight text-slate-950;
+    @apply mt-6 mb-3 font-semibold leading-tight tracking-tight text-slate-950;
+    font-size: 1.429em;
   }
 
   .tiptap p {
@@ -267,6 +272,11 @@
     .document-comment-rail {
       display: block;
     }
+
+    .document-page-shell.document-page-shell-no-comments {
+      grid-template-columns: minmax(0, 43.75rem);
+      justify-content: center;
+    }
   }
 }
 
@@ -314,7 +324,7 @@
 }
 
 :root {
-  --background: oklch(1 0 0);
+  --background: #fcfcfc;
   --foreground: oklch(0.141 0.005 285.823);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.141 0.005 285.823);

--- a/packages/app/test/critic-markup.test.ts
+++ b/packages/app/test/critic-markup.test.ts
@@ -66,6 +66,34 @@ describe("CriticMarkup comments", () => {
     expect(output).toContain("*   First item");
   });
 
+  it("does not import a trailing blank line into fenced code blocks", () => {
+    const input = `\`\`\`text
+Use Roughdraft when I want to open, review, comment on, or compare markdown files.
+
+Start it with \`roughdraft start\` if needed.
+Open files or folders with \`roughdraft open "/absolute/path/to/file.md"\`.
+After I finish reviewing in Roughdraft, continue by reading the markdown files from disk and making the requested changes there.
+Use CriticMarkup for inline review feedback in markdown.
+\`\`\`
+`;
+
+    const { doc } = criticMarkdownToEditorState(input);
+    const codeBlock = doc.content?.[0];
+    const textNode = codeBlock?.content?.[0];
+
+    expect(codeBlock?.type).toBe("codeBlock");
+    expect(textNode).toMatchObject({
+      type: "text",
+      text: `Use Roughdraft when I want to open, review, comment on, or compare markdown files.
+
+Start it with \`roughdraft start\` if needed.
+Open files or folders with \`roughdraft open "/absolute/path/to/file.md"\`.
+After I finish reviewing in Roughdraft, continue by reading the markdown files from disk and making the requested changes there.
+Use CriticMarkup for inline review feedback in markdown.`,
+    });
+    expect(editorStateToCriticMarkdown(doc, new Map())).toBe(input);
+  });
+
   it("round-trips an anchored reply thread", () => {
     const input =
       "Please revisit {==this sentence==}{>>Needs a source<<}{@id:c1;by:user;at:2024-01-15T10:30:00.000Z@}{>>I can add one from the intro.<<}{@id:c2;by:AI;at:2024-01-15T10:31:00.000Z;re:c1@}.\n";

--- a/packages/app/test/document-comments.test.ts
+++ b/packages/app/test/document-comments.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it } from "vitest";
+import type { CriticComment } from "../src/critic-markup";
 import {
+  buildCommentThreadRailItems,
   getCommentAnchorMeasurements,
+  getRootThreadIdForCommentId,
   groupCommentAnchorMeasurements,
   normalizeCommentMeasurement,
   resolveCommentRailLayouts,
+  resolveCommentThreadRailLayouts,
 } from "../src/document-comments";
+
+function createCommentsMap(comments: CriticComment[]) {
+  return new Map(comments.map((comment) => [comment.id, comment]));
+}
 
 describe("document comment layout helpers", () => {
   it("maps DOM anchor boxes to positions relative to the editor", () => {
@@ -145,6 +153,261 @@ describe("document comment layout helpers", () => {
         key: "cmt-7",
         railTop: 242,
         railBottom: 322,
+      },
+    ]);
+  });
+
+  it("expands a shared anchor into one rail item per root thread", () => {
+    const comments = createCommentsMap([
+      {
+        id: "c1",
+        content: "First root",
+        createdAt: "2026-04-24T00:00:00.000Z",
+      },
+      {
+        id: "c2",
+        content: "Second root",
+        createdAt: "2026-04-24T00:00:01.000Z",
+      },
+      {
+        id: "c3",
+        content: "Reply",
+        createdAt: "2026-04-24T00:00:02.000Z",
+        parentCommentId: "c2",
+      },
+    ]);
+
+    const items = buildCommentThreadRailItems(
+      [
+        {
+          key: "c1::c2::c3",
+          commentIds: ["c1", "c2", "c3"],
+          anchorTop: 200,
+          anchorBottom: 214,
+        },
+      ],
+      comments,
+    );
+
+    expect(items).toEqual([
+      {
+        key: "c1",
+        anchorGroupKey: "c1::c2::c3",
+        rootCommentId: "c1",
+        commentIds: ["c1"],
+        anchorTop: 200,
+        anchorBottom: 214,
+      },
+      {
+        key: "c2",
+        anchorGroupKey: "c1::c2::c3",
+        rootCommentId: "c2",
+        commentIds: ["c2", "c3"],
+        anchorTop: 200,
+        anchorBottom: 214,
+      },
+    ]);
+  });
+
+  it("aligns the selected secondary root thread to the shared anchor", () => {
+    const layouts = resolveCommentThreadRailLayouts(
+      [
+        {
+          key: "c1",
+          anchorGroupKey: "shared",
+          rootCommentId: "c1",
+          commentIds: ["c1"],
+          anchorTop: 200,
+          anchorBottom: 214,
+        },
+        {
+          key: "c2",
+          anchorGroupKey: "shared",
+          rootCommentId: "c2",
+          commentIds: ["c2"],
+          anchorTop: 200,
+          anchorBottom: 214,
+        },
+      ],
+      {
+        c1: 90,
+        c2: 120,
+      },
+      "c2",
+      16,
+    );
+
+    expect(
+      layouts.map(({ key, railTop, railBottom }) => ({
+        key,
+        railTop,
+        railBottom,
+      })),
+    ).toEqual([
+      {
+        key: "c1",
+        railTop: 94,
+        railBottom: 184,
+      },
+      {
+        key: "c2",
+        railTop: 200,
+        railBottom: 320,
+      },
+    ]);
+  });
+
+  it("resolves reply selection to the parent root thread", () => {
+    const comments = createCommentsMap([
+      {
+        id: "c1",
+        content: "First root",
+        createdAt: "2026-04-24T00:00:00.000Z",
+      },
+      {
+        id: "c2",
+        content: "Second root",
+        createdAt: "2026-04-24T00:00:01.000Z",
+      },
+      {
+        id: "c3",
+        content: "Reply",
+        createdAt: "2026-04-24T00:00:02.000Z",
+        parentCommentId: "c2",
+      },
+    ]);
+
+    expect(getRootThreadIdForCommentId("c3", comments)).toBe("c2");
+
+    const layouts = resolveCommentThreadRailLayouts(
+      buildCommentThreadRailItems(
+        [
+          {
+            key: "c1::c2::c3",
+            commentIds: ["c1", "c2", "c3"],
+            anchorTop: 200,
+            anchorBottom: 214,
+          },
+        ],
+        comments,
+      ),
+      {
+        c1: 90,
+        c2: 120,
+      },
+      getRootThreadIdForCommentId("c3", comments),
+      16,
+    );
+
+    expect(layouts.find((layout) => layout.key === "c2")?.railTop).toBe(200);
+  });
+
+  it("pushes neighboring threads outward from the active thread with the requested gap", () => {
+    const layouts = resolveCommentThreadRailLayouts(
+      [
+        {
+          key: "c1",
+          anchorGroupKey: "g1",
+          rootCommentId: "c1",
+          commentIds: ["c1"],
+          anchorTop: 120,
+          anchorBottom: 134,
+        },
+        {
+          key: "c2",
+          anchorGroupKey: "g2",
+          rootCommentId: "c2",
+          commentIds: ["c2"],
+          anchorTop: 180,
+          anchorBottom: 194,
+        },
+        {
+          key: "c3",
+          anchorGroupKey: "g3",
+          rootCommentId: "c3",
+          commentIds: ["c3"],
+          anchorTop: 220,
+          anchorBottom: 234,
+        },
+      ],
+      {
+        c1: 70,
+        c2: 110,
+        c3: 80,
+      },
+      "c2",
+      24,
+    );
+
+    expect(
+      layouts.map(({ key, railTop, railBottom }) => ({
+        key,
+        railTop,
+        railBottom,
+      })),
+    ).toEqual([
+      {
+        key: "c1",
+        railTop: 86,
+        railBottom: 156,
+      },
+      {
+        key: "c2",
+        railTop: 180,
+        railBottom: 290,
+      },
+      {
+        key: "c3",
+        railTop: 314,
+        railBottom: 394,
+      },
+    ]);
+  });
+
+  it("keeps the selected thread aligned even when earlier threads go negative", () => {
+    const layouts = resolveCommentThreadRailLayouts(
+      [
+        {
+          key: "c1",
+          anchorGroupKey: "shared",
+          rootCommentId: "c1",
+          commentIds: ["c1"],
+          anchorTop: 80,
+          anchorBottom: 94,
+        },
+        {
+          key: "c2",
+          anchorGroupKey: "shared",
+          rootCommentId: "c2",
+          commentIds: ["c2"],
+          anchorTop: 80,
+          anchorBottom: 94,
+        },
+      ],
+      {
+        c1: 100,
+        c2: 120,
+      },
+      "c2",
+      16,
+    );
+
+    expect(
+      layouts.map(({ key, railTop, railBottom }) => ({
+        key,
+        railTop,
+        railBottom,
+      })),
+    ).toEqual([
+      {
+        key: "c1",
+        railTop: -36,
+        railBottom: 64,
+      },
+      {
+        key: "c2",
+        railTop: 80,
+        railBottom: 200,
       },
     ]);
   });

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -171,6 +171,7 @@ function getToolbarButton(container: HTMLElement, label: string) {
 type PageCardTestOptions = Partial<{
   page: Page;
   mode: "canvas" | "document";
+  editorViewMode: "rich-text" | "code";
   selected: boolean;
   focusRequestKey: string | null;
 }>;
@@ -211,12 +212,12 @@ async function renderPageCard(
     focusRequestKey: options.focusRequestKey ?? null,
     canDelete: true,
     mode: options.mode ?? "document",
+    editorViewMode: options.editorViewMode ?? "rich-text",
     onSelect: vi.fn(),
     onSave,
     onReposition,
     onDelete: vi.fn(),
     onSaveStateChange,
-    documentToolbarHost: null,
     backend,
     onEditorReady: (nextEditor: Editor | null) => {
       editor = nextEditor;
@@ -404,6 +405,74 @@ describe("PageCard editor integration", () => {
     expect(rendered.onSaveStateChange.mock.calls.at(-1)?.[0]).toBe("idle");
   });
 
+  it("document code mode shows raw markdown and hides rich text chrome", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-code-1",
+        title: "Doc Code 1",
+        content: "{==alpha==}{>>Comment body<<}\n\n# Heading\n\n`inline`",
+      },
+      mode: "document",
+      editorViewMode: "code",
+      selected: true,
+    });
+
+    expect(rendered.container.textContent).toContain("{==alpha==}");
+    expect(rendered.container.textContent).toContain("{>>Comment body<<}");
+    expect(
+      rendered.container.querySelector('[aria-label="Block type"]'),
+    ).toBeNull();
+    expect(
+      rendered.container
+        .querySelector(".document-comment-rail")
+        ?.classList.contains("invisible"),
+    ).toBe(true);
+  });
+
+  it("document code mode keeps rail space when comments exist", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-code-2",
+        title: "Doc Code 2",
+        content: "{==alpha==}{>>Comment body<<}\n\nParagraph",
+      },
+      mode: "document",
+      editorViewMode: "code",
+      selected: true,
+    });
+
+    expect(
+      rendered.container
+        .querySelector(".document-page-shell")
+        ?.classList.contains("document-page-shell-no-comments"),
+    ).toBe(false);
+    expect(
+      rendered.container.querySelector(".document-comment-rail"),
+    ).not.toBeNull();
+  });
+
+  it("document code mode shows line numbers without the default dotted focus outline", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-code-3",
+        title: "Doc Code 3",
+        content: "# Heading\n\nParagraph",
+      },
+      mode: "document",
+      editorViewMode: "code",
+      selected: true,
+    });
+
+    const editor = rendered.container.querySelector(".cm-editor");
+    expect(editor).not.toBeNull();
+
+    const gutters = rendered.container.querySelector(".cm-gutters");
+    expect(gutters).not.toBeNull();
+    expect(gutters?.textContent).toContain("1");
+    expect(getComputedStyle(gutters as Element).display).not.toBe("none");
+    expect(getComputedStyle(editor as Element).outlineStyle).not.toBe("dotted");
+  });
+
   it("selection updates toolbar state", async () => {
     const rendered = await renderPageCard({
       page: {
@@ -418,11 +487,11 @@ describe("PageCard editor integration", () => {
     const editor = rendered.getEditor();
 
     await selectText(editor, "Heading");
-    expect(getBlockTypeTrigger(rendered.container).textContent).toContain(
-      "Heading 1",
-    );
+    await flushAnimationFrame();
+    expect(rendered.container.textContent).toContain("Comment");
 
     await selectText(editor, "bold");
+    await flushAnimationFrame();
     expect(
       getToolbarButton(rendered.container, "Bold").getAttribute("aria-pressed"),
     ).toBe("true");
@@ -518,6 +587,7 @@ describe("PageCard editor integration", () => {
       rendered.container.querySelector(".document-comment-fallback")
         ?.textContent,
     ).toContain("Comment body");
+    expect(rendered.container.textContent).toContain("Me");
   });
 
   it("centers document layout when there are no comments", async () => {

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -520,6 +520,38 @@ describe("PageCard editor integration", () => {
     ).toContain("Comment body");
   });
 
+  it("centers document layout when there are no comments", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-6",
+        title: "Doc 6",
+        content: "Just text",
+      },
+      mode: "document",
+      selected: true,
+    });
+
+    expect(
+      rendered.container
+        .querySelector(".document-page-shell")
+        ?.classList.contains("document-page-shell-no-comments"),
+    ).toBe(true);
+
+    await rendered.rerender({
+      page: {
+        id: "doc-6",
+        title: "Doc 6",
+        content: "{==alpha==}{>>Comment body<<}\n\nJust text",
+      },
+    });
+
+    expect(
+      rendered.container
+        .querySelector(".document-page-shell")
+        ?.classList.contains("document-page-shell-no-comments"),
+    ).toBe(false);
+  });
+
   it("canvas props churn does not lose editor content or selection", async () => {
     const rendered = await renderPageCard({
       page: {

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -71,6 +71,7 @@ describe("cli", () => {
   let tempDir: string;
   let stateDir: string;
   let projectDir: string;
+  let devFrontendStateFile: string;
   let nextPid: number;
   let runningPids: Set<number>;
   let serverByPid: Map<number, StartedServer>;
@@ -83,6 +84,7 @@ describe("cli", () => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "roughdraft-cli-"));
     stateDir = path.join(tempDir, "state");
     projectDir = path.join(tempDir, "project");
+    devFrontendStateFile = path.join(tempDir, "dev-frontend.json");
     fs.mkdirSync(projectDir, { recursive: true });
     nextPid = 1000;
     runningPids = new Set<number>();
@@ -107,6 +109,7 @@ describe("cli", () => {
       env: {
         ...process.env,
         ROUGHDRAFT_STATE_DIR: stateDir,
+        ROUGHDRAFT_DEV_FRONTEND_STATE_FILE: devFrontendStateFile,
       },
       cwd: projectDir,
       fetchImpl: async (input, init) => {
@@ -214,6 +217,189 @@ describe("cli", () => {
       `http://localhost:${persisted.port}${documentPath}`,
     );
     expect(fs.existsSync(getServerStateFilePath(test.deps.env))).toBeTruthy();
+  });
+
+  it("prefers the live dev frontend URL when it matches this checkout", async () => {
+    const documentPath = path.join(projectDir, "draft.md");
+    fs.writeFileSync(documentPath, "# Draft\n");
+    fs.writeFileSync(
+      devFrontendStateFile,
+      `${JSON.stringify(
+        {
+          apiPort: 3000,
+          appPort: 5173,
+          mode: "full-dev",
+          repoRoot: serverRoot,
+          startedAt: new Date().toISOString(),
+          url: "http://localhost:5173",
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    let lastOpenedUrl: string | null = null;
+    let spawnCount = 0;
+
+    const deps = createCliDependencies({
+      env: {
+        ...process.env,
+        ROUGHDRAFT_STATE_DIR: stateDir,
+        ROUGHDRAFT_DEV_FRONTEND_STATE_FILE: devFrontendStateFile,
+      },
+      cwd: projectDir,
+      fetchImpl: async (input, init) => {
+        const url =
+          input instanceof URL
+            ? input
+            : new URL(
+                typeof input === "string" ? input : input.url,
+                "http://localhost",
+              );
+
+        if (url.pathname === "/api/status" && url.port === "5173") {
+          return new Response(
+            JSON.stringify({
+              backend: "local-files",
+              projectDir,
+              serverRoot,
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        }
+
+        return fetch(input, init);
+      },
+      spawnServerProcess: async () => {
+        spawnCount += 1;
+        throw new Error("should not spawn");
+      },
+      isProcessRunning: (pid) => runningPids.has(pid),
+      stopProcess: async (pid) => {
+        const server = serverByPid.get(pid);
+        if (server) {
+          await server.close();
+        }
+        serverByPid.delete(pid);
+        portByPid.delete(pid);
+        runningPids.delete(pid);
+      },
+      openUrl: (url) => {
+        lastOpenedUrl = url;
+        return "disabled";
+      },
+      log: () => {},
+      error: () => {},
+    });
+
+    const exitCode = await runCli(["open", documentPath], deps);
+
+    expect(exitCode).toBe(0);
+    expect(spawnCount).toBe(0);
+    expect(lastOpenedUrl).toBe(`http://localhost:5173${documentPath}`);
+  });
+
+  it("falls back to the api server URL when the dev frontend hint is stale", async () => {
+    const documentPath = path.join(projectDir, "draft.md");
+    fs.writeFileSync(documentPath, "# Draft\n");
+    fs.writeFileSync(
+      devFrontendStateFile,
+      `${JSON.stringify(
+        {
+          apiPort: 3000,
+          appPort: 5173,
+          mode: "full-dev",
+          repoRoot: serverRoot,
+          startedAt: new Date().toISOString(),
+          url: "http://localhost:5173",
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const test = createTestDependencies();
+    const exitCode = await runCli(["open", documentPath], test.deps);
+    const persisted = JSON.parse(
+      fs.readFileSync(getServerStateFilePath(test.deps.env), "utf8"),
+    ) as { port: number };
+
+    expect(exitCode).toBe(0);
+    expect(test.getSpawnCount()).toBe(1);
+    expect(test.getLastOpenedUrl()).toBe(
+      `http://localhost:${persisted.port}${documentPath}`,
+    );
+  });
+
+  it("uses the preview-web frontend URL when that workflow is active", async () => {
+    const documentPath = path.join(projectDir, "draft.md");
+    fs.writeFileSync(documentPath, "# Draft\n");
+    fs.writeFileSync(
+      devFrontendStateFile,
+      `${JSON.stringify(
+        {
+          apiPort: null,
+          appPort: 5174,
+          mode: "preview-web",
+          repoRoot: serverRoot,
+          startedAt: new Date().toISOString(),
+          url: "http://localhost:5174",
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    let lastOpenedUrl: string | null = null;
+    let spawnCount = 0;
+
+    const deps = createCliDependencies({
+      env: {
+        ...process.env,
+        ROUGHDRAFT_STATE_DIR: stateDir,
+        ROUGHDRAFT_DEV_FRONTEND_STATE_FILE: devFrontendStateFile,
+      },
+      cwd: projectDir,
+      fetchImpl: async (input) => {
+        const url =
+          input instanceof URL
+            ? input
+            : new URL(
+                typeof input === "string" ? input : input.url,
+                "http://localhost",
+              );
+
+        if (url.href === "http://localhost:5174/") {
+          return new Response("<!doctype html><html></html>", {
+            status: 200,
+            headers: { "Content-Type": "text/html" },
+          });
+        }
+
+        throw new Error("connect ECONNREFUSED");
+      },
+      spawnServerProcess: async () => {
+        spawnCount += 1;
+        throw new Error("should not spawn");
+      },
+      isProcessRunning: () => false,
+      stopProcess: async () => {},
+      openUrl: (url) => {
+        lastOpenedUrl = url;
+        return "disabled";
+      },
+      log: () => {},
+      error: () => {},
+    });
+
+    const exitCode = await runCli(["open", documentPath], deps);
+
+    expect(exitCode).toBe(0);
+    expect(spawnCount).toBe(0);
+    expect(lastOpenedUrl).toBe(`http://localhost:5174${documentPath}`);
   });
 
   it("rejects missing markdown files before opening", async () => {

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { createServer as createHttpServer, type Server } from "node:http";
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createApp } from "./index";
 import {
@@ -74,6 +75,9 @@ describe("cli", () => {
   let runningPids: Set<number>;
   let serverByPid: Map<number, StartedServer>;
   let portByPid: Map<number, number>;
+  const serverRoot = path.resolve(
+    fileURLToPath(new URL("../../..", import.meta.url)),
+  );
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "roughdraft-cli-"));
@@ -137,6 +141,7 @@ describe("cli", () => {
         const { app } = createApp({
           port,
           projectDir: nextProjectDir,
+          serverRoot,
           staticDirPath: nextProjectDir,
         });
         const started = await listenOnLoopbackServers(port, app);
@@ -295,6 +300,7 @@ describe("cli", () => {
               backend: "local-files",
               port: 3000,
               projectDir,
+              serverRoot,
             }),
             {
               status: 200,
@@ -363,6 +369,7 @@ describe("cli", () => {
               backend: "local-files",
               port: 3000,
               projectDir,
+              serverRoot,
             }),
             {
               status: 200,
@@ -405,5 +412,96 @@ describe("cli", () => {
     expect(test.logs).toContain(
       "  Comment ids are document-local and usually look like `c1`, `c2`, `c3`.",
     );
+  });
+
+  it("starts a new server when the preferred port belongs to another checkout", async () => {
+    const stateFilePath = path.join(stateDir, "server.json");
+    const otherServerRoot = path.join(tempDir, "other-checkout");
+    let spawnedPort: number | null = null;
+    let spawnedProjectDir: string | null = null;
+    let spawned = false;
+
+    fs.mkdirSync(path.dirname(stateFilePath), { recursive: true });
+    fs.writeFileSync(
+      stateFilePath,
+      JSON.stringify({
+        port: 3000,
+        pid: 424242,
+        startedAt: new Date().toISOString(),
+        url: "http://localhost:3000",
+      }),
+    );
+
+    const deps = createCliDependencies({
+      env: {
+        ...process.env,
+        ROUGHDRAFT_STATE_DIR: stateDir,
+      },
+      cwd: projectDir,
+      fetchImpl: async (input) => {
+        const url =
+          input instanceof URL
+            ? input
+            : new URL(
+                typeof input === "string" ? input : input.url,
+                "http://localhost",
+              );
+
+        if (url.pathname !== "/api/status") {
+          throw new Error("Unexpected request");
+        }
+
+        if (url.port === "3000") {
+          return new Response(
+            JSON.stringify({
+              backend: "local-files",
+              port: 3000,
+              projectDir: path.join(tempDir, "other-project"),
+              serverRoot: otherServerRoot,
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        }
+
+        if (url.port === "3001" && spawned) {
+          return new Response(
+            JSON.stringify({
+              backend: "local-files",
+              port: 3001,
+              projectDir,
+              serverRoot,
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        }
+
+        throw new Error("connect ECONNREFUSED");
+      },
+      findAvailablePortImpl: async () => 3001,
+      spawnServerProcess: async ({ port, projectDir: nextProjectDir }) => {
+        spawned = true;
+        spawnedPort = port;
+        spawnedProjectDir = nextProjectDir;
+        return { pid: 1001 };
+      },
+      isProcessRunning: (pid) => pid === 424242,
+      stopProcess: async () => {},
+      openUrl: () => "disabled",
+      log: () => {},
+      error: () => {},
+    });
+
+    const result = await ensureServerRunning(deps, { projectDir });
+
+    expect(result.reused).toBe(false);
+    expect(spawnedPort).toBe(3001);
+    expect(spawnedProjectDir).toBe(projectDir);
+    expect(result.server.port).toBe(3001);
   });
 });

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -33,6 +33,15 @@ interface StatusPayload {
   port?: number;
 }
 
+interface DevFrontendState {
+  apiPort: number | null;
+  appPort: number;
+  mode?: "full-dev" | "preview-web";
+  repoRoot: string;
+  startedAt: string;
+  url: string;
+}
+
 export interface SpawnedServer {
   pid: number;
 }
@@ -308,13 +317,24 @@ function buildPublicBaseUrl(port: number): string {
   return `http://${ROUGHDRAFT_PUBLIC_HOST}:${port}`;
 }
 
+function getDevFrontendStateFilePath(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const explicitFile = env.ROUGHDRAFT_DEV_FRONTEND_STATE_FILE?.trim();
+  if (explicitFile) {
+    return path.resolve(explicitFile);
+  }
+
+  return path.join(currentServerRoot, ".context", "dev-frontend.json");
+}
+
 function buildLoopbackUrl(host: string, port: number, pathname = "/"): URL {
   const baseHost = host.includes(":") ? `[${host}]` : host;
   return new URL(`http://${baseHost}:${port}${pathname}`);
 }
 
-function buildTargetUrl(port: number, openPath: string): string {
-  const url = new URL(buildPublicBaseUrl(port));
+function buildTargetUrl(baseUrl: string, openPath: string): string {
+  const url = new URL(baseUrl);
 
   if (openPath.includes("\\")) {
     url.searchParams.set("path", openPath);
@@ -401,6 +421,27 @@ function isValidServerState(value: unknown): value is RoughdraftServerState {
   );
 }
 
+function isValidDevFrontendState(value: unknown): value is DevFrontendState {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<DevFrontendState>;
+  return (
+    (candidate.apiPort === null ||
+      (typeof candidate.apiPort === "number" && Number.isFinite(candidate.apiPort))) &&
+    typeof candidate.appPort === "number" &&
+    Number.isFinite(candidate.appPort) &&
+    (candidate.mode === undefined ||
+      candidate.mode === "full-dev" ||
+      candidate.mode === "preview-web") &&
+    typeof candidate.repoRoot === "string" &&
+    candidate.repoRoot.length > 0 &&
+    typeof candidate.startedAt === "string" &&
+    candidate.startedAt.length > 0 &&
+    typeof candidate.url === "string" &&
+    candidate.url.length > 0
+  );
+}
+
 function readServerStateFromDisk(
   stateFilePath: string,
 ): RoughdraftServerState | null {
@@ -415,6 +456,20 @@ function readServerStateFromDisk(
   if (fs.existsSync(stateFilePath)) {
     removeServerStateFile(stateFilePath);
   }
+
+  return null;
+}
+
+function readDevFrontendStateFromDisk(
+  stateFilePath: string,
+): DevFrontendState | null {
+  try {
+    const raw = fs.readFileSync(stateFilePath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (isValidDevFrontendState(parsed)) {
+      return parsed;
+    }
+  } catch {}
 
   return null;
 }
@@ -486,6 +541,70 @@ async function waitForServerToStop(
   }
 
   return false;
+}
+
+async function resolveLiveDevFrontendBaseUrl(
+  deps: CliDependencies,
+): Promise<string | null> {
+  const state = readDevFrontendStateFromDisk(getDevFrontendStateFilePath(deps.env));
+  if (!state) {
+    return null;
+  }
+
+  if (path.resolve(state.repoRoot) !== currentServerRoot) {
+    return null;
+  }
+
+  try {
+    const frontendUrl = new URL(state.url);
+    const mode = state.mode ?? (state.apiPort === null ? "preview-web" : "full-dev");
+
+    if (mode === "preview-web") {
+      const response = await deps.fetchImpl(frontendUrl, {
+        signal: AbortSignal.timeout(STATUS_TIMEOUT_MS),
+      });
+
+      if (!response.ok) {
+        return null;
+      }
+    } else {
+      const statusUrl = new URL("/api/status", frontendUrl);
+      const response = await deps.fetchImpl(statusUrl, {
+        signal: AbortSignal.timeout(STATUS_TIMEOUT_MS),
+      });
+
+      if (!response.ok) {
+        return null;
+      }
+
+      const payload = (await response.json()) as StatusPayload;
+      if (payload.backend !== "local-files") {
+        return null;
+      }
+
+      if (
+        !payload.serverRoot ||
+        path.resolve(payload.serverRoot) !== currentServerRoot
+      ) {
+        return null;
+      }
+
+      if (
+        typeof payload.port === "number" &&
+        state.apiPort !== null &&
+        payload.port !== state.apiPort
+      ) {
+        return null;
+      }
+    }
+
+    frontendUrl.pathname = "/";
+    frontendUrl.search = "";
+    frontendUrl.hash = "";
+    return frontendUrl.toString();
+  } catch {
+    return null;
+  }
 }
 
 async function normalizeTrackedState(
@@ -773,11 +892,20 @@ export async function runCli(
     }
 
     const { projectDir, openPath } = resolvedTarget;
-    const result = await ensureServerRunning(deps, { projectDir });
-    const targetUrl = buildTargetUrl(result.server.port, openPath);
+    const liveDevFrontendUrl = await resolveLiveDevFrontendBaseUrl(deps);
+    let result: EnsureRunningResult | null = null;
+
+    if (!liveDevFrontendUrl) {
+      result = await ensureServerRunning(deps, { projectDir });
+    }
+
+    const targetUrl = buildTargetUrl(
+      liveDevFrontendUrl ?? buildPublicBaseUrl(result!.server.port),
+      openPath,
+    );
     const openMode = deps.openUrl(targetUrl);
 
-    if (result.portChanged) {
+    if (result?.portChanged) {
       deps.log(
         `Preferred port ${parsePort(deps.env.PORT)} is busy, using ${result.server.port}.`,
       );

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -427,7 +427,8 @@ function isValidDevFrontendState(value: unknown): value is DevFrontendState {
   const candidate = value as Partial<DevFrontendState>;
   return (
     (candidate.apiPort === null ||
-      (typeof candidate.apiPort === "number" && Number.isFinite(candidate.apiPort))) &&
+      (typeof candidate.apiPort === "number" &&
+        Number.isFinite(candidate.apiPort))) &&
     typeof candidate.appPort === "number" &&
     Number.isFinite(candidate.appPort) &&
     (candidate.mode === undefined ||
@@ -546,7 +547,9 @@ async function waitForServerToStop(
 async function resolveLiveDevFrontendBaseUrl(
   deps: CliDependencies,
 ): Promise<string | null> {
-  const state = readDevFrontendStateFromDisk(getDevFrontendStateFilePath(deps.env));
+  const state = readDevFrontendStateFromDisk(
+    getDevFrontendStateFilePath(deps.env),
+  );
   if (!state) {
     return null;
   }
@@ -557,7 +560,8 @@ async function resolveLiveDevFrontendBaseUrl(
 
   try {
     const frontendUrl = new URL(state.url);
-    const mode = state.mode ?? (state.apiPort === null ? "preview-web" : "full-dev");
+    const mode =
+      state.mode ?? (state.apiPort === null ? "preview-web" : "full-dev");
 
     if (mode === "preview-web") {
       const response = await deps.fetchImpl(frontendUrl, {
@@ -894,15 +898,16 @@ export async function runCli(
     const { projectDir, openPath } = resolvedTarget;
     const liveDevFrontendUrl = await resolveLiveDevFrontendBaseUrl(deps);
     let result: EnsureRunningResult | null = null;
+    let baseUrl: string;
 
-    if (!liveDevFrontendUrl) {
+    if (liveDevFrontendUrl) {
+      baseUrl = liveDevFrontendUrl;
+    } else {
       result = await ensureServerRunning(deps, { projectDir });
+      baseUrl = buildPublicBaseUrl(result.server.port);
     }
 
-    const targetUrl = buildTargetUrl(
-      liveDevFrontendUrl ?? buildPublicBaseUrl(result!.server.port),
-      openPath,
-    );
+    const targetUrl = buildTargetUrl(baseUrl, openPath);
     const openMode = deps.openUrl(targetUrl);
 
     if (result?.portChanged) {

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -29,6 +29,7 @@ export interface RoughdraftServerState {
 interface StatusPayload {
   backend?: string;
   projectDir?: string;
+  serverRoot?: string;
   port?: number;
 }
 
@@ -79,6 +80,10 @@ interface ReusableServer {
   pid: number | null;
   startedAt: string | null;
 }
+
+const currentServerRoot = path.resolve(
+  fileURLToPath(new URL("../../..", import.meta.url)),
+);
 
 function hasChromeAppMode() {
   if (process.platform !== "darwin") return false;
@@ -501,16 +506,25 @@ async function normalizeTrackedState(
 
 async function findReusableServer(
   deps: CliDependencies,
+  options: { serverRoot?: string } = {},
 ): Promise<ReusableServer | null> {
   const stateFilePath = getServerStateFilePath(deps.env);
   const persistedState = readServerStateFromDisk(stateFilePath);
   const preferredPort = parsePort(deps.env.PORT);
+  const expectedServerRoot = path.resolve(
+    options.serverRoot ?? currentServerRoot,
+  );
+
+  const matchesServerRoot = (payload: StatusPayload | null) =>
+    payload?.serverRoot
+      ? path.resolve(payload.serverRoot) === expectedServerRoot
+      : false;
 
   if (persistedState) {
     const pidRunning = deps.isProcessRunning(persistedState.pid);
     const statusPayload = await getStatusPayload(persistedState.port, deps);
 
-    if (pidRunning && statusPayload) {
+    if (pidRunning && statusPayload && matchesServerRoot(statusPayload)) {
       const normalizedState = await normalizeTrackedState(
         persistedState,
         stateFilePath,
@@ -526,7 +540,7 @@ async function findReusableServer(
 
     removeServerStateFile(stateFilePath);
 
-    if (statusPayload) {
+    if (statusPayload && matchesServerRoot(statusPayload)) {
       return {
         port: persistedState.port,
         url: buildPublicBaseUrl(persistedState.port),
@@ -538,7 +552,7 @@ async function findReusableServer(
   }
 
   const preferredStatus = await getStatusPayload(preferredPort, deps);
-  if (!preferredStatus) {
+  if (!preferredStatus || !matchesServerRoot(preferredStatus)) {
     return null;
   }
 
@@ -554,7 +568,9 @@ async function findReusableServer(
 export async function readRunningServerState(
   deps: CliDependencies,
 ): Promise<RoughdraftServerState | null> {
-  const reusableServer = await findReusableServer(deps);
+  const reusableServer = await findReusableServer(deps, {
+    serverRoot: currentServerRoot,
+  });
   if (
     !reusableServer?.tracked ||
     reusableServer.pid === null ||
@@ -575,7 +591,9 @@ export async function ensureServerRunning(
   deps: CliDependencies,
   options: { projectDir?: string } = {},
 ): Promise<EnsureRunningResult> {
-  const reusableServer = await findReusableServer(deps);
+  const reusableServer = await findReusableServer(deps, {
+    serverRoot: currentServerRoot,
+  });
   if (reusableServer) {
     return { server: reusableServer, reused: true, portChanged: false };
   }

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import request from "supertest";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createApp } from "./index";
@@ -8,6 +9,9 @@ import { createApp } from "./index";
 describe("createApp", () => {
   let projectDir: string;
   let homeDir: string;
+  const serverRoot = path.resolve(
+    fileURLToPath(new URL("../../..", import.meta.url)),
+  );
 
   beforeEach(() => {
     projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "roughdraft-server-"));
@@ -128,6 +132,7 @@ describe("createApp", () => {
     expect(response.body).toEqual({
       backend: "local-files",
       port: 4312,
+      serverRoot,
       stateless: true,
       capabilities: {
         projectPathRequired: true,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -12,6 +12,7 @@ import { resolveUpdateStatus } from "./update-status.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const staticDir = path.resolve(__dirname, "../../app/dist");
+const defaultServerRoot = path.resolve(__dirname, "../../..");
 
 interface PageLayout {
   x: number;
@@ -62,6 +63,7 @@ interface ProjectTreeListing {
 interface CreateAppOptions {
   port?: number;
   projectDir?: string;
+  serverRoot?: string;
   homeDir?: string;
   staticDirPath?: string;
   packageJsonPath?: string;
@@ -302,6 +304,7 @@ function listProjectTree(projectDir: string): ProjectTreeListing {
 export function createApp(options: CreateAppOptions = {}): CreateAppResult {
   const port = options.port ?? 3000;
   const homeDir = options.homeDir ?? os.homedir();
+  const serverRoot = path.resolve(options.serverRoot ?? defaultServerRoot);
   const staticDirPath = options.staticDirPath ?? staticDir;
   const fetchImpl = options.fetchImpl ?? fetch;
   const app = express();
@@ -499,6 +502,10 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
     res.json({
       backend: "local-files",
       port,
+      projectDir: options.projectDir
+        ? path.resolve(options.projectDir)
+        : undefined,
+      serverRoot,
       stateless: true,
       capabilities: {
         projectPathRequired: true,

--- a/packages/server/src/install-dev-cli.test.ts
+++ b/packages/server/src/install-dev-cli.test.ts
@@ -46,13 +46,23 @@ describe("installDevCli", () => {
 
     const wrapperContent = fs.readFileSync(result.wrapperPath, "utf8");
     const mode = fs.statSync(result.wrapperPath).mode & 0o777;
+    const expectedStateDir = path.join(
+      os.homedir(),
+      ".roughdraft",
+      "dev",
+      "roughdraft-dev-lyon-v2",
+    );
 
     expect(result.commandName).toBe("roughdraft-dev-lyon-v2");
     expect(wrapperContent).toContain(`# roughdraft-dev-repo-root=${repoRoot}`);
     expect(wrapperContent).toContain(
+      `if [[ -z "\${ROUGHDRAFT_STATE_DIR:-}" ]]; then export ROUGHDRAFT_STATE_DIR="${expectedStateDir}"; fi`,
+    );
+    expect(wrapperContent).toContain(
       `exec node "${path.join(repoRoot, "packages", "server", "bin", "roughdraft.mjs")}" "$@"`,
     );
     expect(mode).toBe(0o755);
+    expect(result.stateDir).toBe(expectedStateDir);
     expect(warnings).toEqual([]);
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,18 @@ importers:
       '@base-ui/react':
         specifier: ^1.4.1
         version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@codemirror/commands':
+        specifier: ^6.10.3
+        version: 6.10.3
+      '@codemirror/lang-markdown':
+        specifier: ^6.5.0
+        version: 6.5.0
+      '@codemirror/state':
+        specifier: ^6.6.0
+        version: 6.6.0
+      '@codemirror/view':
+        specifier: ^6.41.1
+        version: 6.41.1
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8
@@ -84,6 +96,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      codemirror:
+        specifier: ^6.0.2
+        version: 6.0.2
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.5)
@@ -416,6 +431,39 @@ packages:
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
+
+  '@codemirror/autocomplete@6.20.1':
+    resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
+
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-markdown@6.5.0':
+    resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
+
+  '@codemirror/language@6.12.3':
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/lint@6.9.5':
+    resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
+
+  '@codemirror/search@6.7.0':
+    resolution: {integrity: sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==}
+
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+
+  '@codemirror/view@6.41.1':
+    resolution: {integrity: sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==}
 
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
@@ -861,6 +909,30 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/css@1.3.3':
+    resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@lezer/markdown@1.6.3':
+    resolution: {integrity: sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
@@ -1820,6 +1892,9 @@ packages:
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
+  codemirror@6.0.2:
+    resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1880,6 +1955,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -3049,6 +3127,9 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   superagent@10.3.0:
     resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
     engines: {node: '>=14.18.0'}
@@ -3664,6 +3745,92 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
+  '@codemirror/autocomplete@6.20.1':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.5
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-markdown@6.5.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/markdown': 1.6.3
+
+  '@codemirror/language@6.12.3':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.5':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      crelt: 1.0.6
+
+  '@codemirror/search@6.7.0':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      crelt: 1.0.6
+
+  '@codemirror/state@6.6.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/view@6.41.1':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
   '@csstools/color-helpers@6.0.2': {}
 
   '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
@@ -3935,6 +4102,41 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/css@1.3.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/markdown@1.6.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@mixmark-io/domino@2.2.0': {}
 
@@ -4830,6 +5032,16 @@ snapshots:
 
   code-block-writer@13.0.3: {}
 
+  codemirror@6.0.2:
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/commands': 6.10.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.5
+      '@codemirror/search': 6.7.0
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -4873,6 +5085,8 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
+
+  crelt@1.0.6: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6094,6 +6308,8 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-final-newline@4.0.0: {}
+
+  style-mod@4.1.3: {}
 
   superagent@10.3.0:
     dependencies:

--- a/scripts/dev-frontend-state.mjs
+++ b/scripts/dev-frontend-state.mjs
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const devFrontendStatePath = path.join(repoRoot, ".context", "dev-frontend.json");
+
+export function writeDevFrontendState({
+  apiPort = null,
+  appPort,
+  mode,
+  url = `http://localhost:${appPort}`,
+}) {
+  fs.mkdirSync(path.dirname(devFrontendStatePath), { recursive: true });
+  fs.writeFileSync(
+    devFrontendStatePath,
+    `${JSON.stringify(
+      {
+        apiPort,
+        appPort,
+        mode,
+        repoRoot,
+        startedAt: new Date().toISOString(),
+        url,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+export function removeDevFrontendState() {
+  try {
+    fs.rmSync(devFrontendStatePath, { force: true });
+  } catch {}
+}
+
+export function getDevFrontendStatePath() {
+  return devFrontendStatePath;
+}

--- a/scripts/dev-frontend-state.mjs
+++ b/scripts/dev-frontend-state.mjs
@@ -2,7 +2,11 @@ import fs from "node:fs";
 import path from "node:path";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-const devFrontendStatePath = path.join(repoRoot, ".context", "dev-frontend.json");
+const devFrontendStatePath = path.join(
+  repoRoot,
+  ".context",
+  "dev-frontend.json",
+);
 
 export function writeDevFrontendState({
   apiPort = null,

--- a/scripts/dev-web.mjs
+++ b/scripts/dev-web.mjs
@@ -15,27 +15,16 @@ function spawnPnpm(args, extraEnv = {}) {
 const appPort = await findAvailableLoopbackPort(
   parseInt(process.env.APP_PORT || "3000", 10),
 );
-let apiPort = await findAvailableLoopbackPort(
-  parseInt(process.env.API_PORT || "3001", 10),
-);
-
-if (apiPort === appPort) {
-  apiPort = await findAvailableLoopbackPort(apiPort + 1);
-}
 
 console.log(`Using app port ${appPort}.`);
-console.log(`Using API port ${apiPort}.`);
-console.log(`Open Roughdraft in dev at http://localhost:${appPort}`);
+console.log(`Open Roughdraft web preview at http://localhost:${appPort}`);
 console.log(
   `Open files directly with http://localhost:${appPort}/absolute/path/to/file.md`,
 );
-console.log(`API port ${apiPort} is internal; don't use it as the browser URL.`);
+console.log("This preview uses local storage and does not read local files.");
 
-writeDevFrontendState({ appPort, apiPort, mode: "full-dev" });
+writeDevFrontendState({ appPort, mode: "preview-web" });
 
-const server = spawnPnpm(["--filter", "@roughdraft/server", "dev"], {
-  API_PORT: String(apiPort),
-});
 const app = spawnPnpm(
   [
     "--filter",
@@ -49,7 +38,7 @@ const app = spawnPnpm(
     "--strictPort",
   ],
   {
-    API_PORT: String(apiPort),
+    VITE_PREVIEW_WEB: "1",
   },
 );
 
@@ -61,28 +50,18 @@ function shutdown(signal) {
   removeDevFrontendState();
 
   if (signal) {
-    console.log(`\nStopping dev servers (${signal}).`);
+    console.log(`\nStopping web preview (${signal}).`);
   }
 
-  server.kill("SIGTERM");
   app.kill("SIGTERM");
 }
 
 process.on("SIGINT", () => shutdown("SIGINT"));
 process.on("SIGTERM", () => shutdown("SIGTERM"));
 
-server.on("exit", (code) => {
-  removeDevFrontendState();
-  if (!shuttingDown) {
-    app.kill("SIGTERM");
-    process.exit(code ?? 0);
-  }
-});
-
 app.on("exit", (code) => {
   removeDevFrontendState();
   if (!shuttingDown) {
-    server.kill("SIGTERM");
     process.exit(code ?? 0);
   }
 });

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -29,7 +29,9 @@ console.log(`Open Roughdraft in dev at http://localhost:${appPort}`);
 console.log(
   `Open files directly with http://localhost:${appPort}/absolute/path/to/file.md`,
 );
-console.log(`API port ${apiPort} is internal; don't use it as the browser URL.`);
+console.log(
+  `API port ${apiPort} is internal; don't use it as the browser URL.`,
+);
 
 writeDevFrontendState({ appPort, apiPort, mode: "full-dev" });
 

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -40,18 +40,44 @@ function spawnPnpm(args, extraEnv = {}) {
   });
 }
 
-const apiPort = await findAvailablePort(
+const appPort = await findAvailablePort(
+  parseInt(process.env.APP_PORT || "3000", 10),
+);
+let apiPort = await findAvailablePort(
   parseInt(process.env.API_PORT || "3001", 10),
 );
 
+if (apiPort === appPort) {
+  apiPort = await findAvailablePort(apiPort + 1);
+}
+
+console.log(`Using app port ${appPort}.`);
 console.log(`Using API port ${apiPort}.`);
+console.log(`Open Roughdraft in dev at http://localhost:${appPort}`);
+console.log(
+  `Open files directly with http://localhost:${appPort}/absolute/path/to/file.md`,
+);
+console.log(`API port ${apiPort} is internal; don't use it as the browser URL.`);
 
 const server = spawnPnpm(["--filter", "@roughdraft/server", "dev"], {
   API_PORT: String(apiPort),
 });
-const app = spawnPnpm(["--filter", "@roughdraft/app", "dev"], {
-  API_PORT: String(apiPort),
-});
+const app = spawnPnpm(
+  [
+    "--filter",
+    "@roughdraft/app",
+    "dev",
+    "--",
+    "--host",
+    "localhost",
+    "--port",
+    String(appPort),
+    "--strictPort",
+  ],
+  {
+    API_PORT: String(apiPort),
+  },
+);
 
 let shuttingDown = false;
 

--- a/scripts/find-available-loopback-port.mjs
+++ b/scripts/find-available-loopback-port.mjs
@@ -1,0 +1,55 @@
+import net from "node:net";
+
+const LOOPBACK_HOSTS = ["127.0.0.1", "::1"];
+
+function canListenOnPort(port, host) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+
+    server.unref();
+
+    server.on("error", (error) => {
+      if (error.code === "EAFNOSUPPORT" || error.code === "EADDRNOTAVAIL") {
+        resolve(false);
+        return;
+      }
+
+      if (error.code === "EADDRINUSE") {
+        reject(error);
+        return;
+      }
+
+      reject(error);
+    });
+
+    server.listen(port, host, () => {
+      server.close((closeError) => {
+        if (closeError) {
+          reject(closeError);
+          return;
+        }
+
+        resolve(true);
+      });
+    });
+  });
+}
+
+export async function findAvailableLoopbackPort(preferredPort) {
+  try {
+    const results = await Promise.all(
+      LOOPBACK_HOSTS.map((host) => canListenOnPort(preferredPort, host)),
+    );
+
+    if (results.some(Boolean)) {
+      return preferredPort;
+    }
+  } catch (error) {
+    const errorCode = error?.code;
+    if (errorCode !== "EADDRINUSE") {
+      throw error;
+    }
+  }
+
+  return findAvailableLoopbackPort(preferredPort + 1);
+}

--- a/scripts/install-dev-cli.mjs
+++ b/scripts/install-dev-cli.mjs
@@ -62,16 +62,27 @@ function printHelp(log = console.log) {
   log("");
   log("Environment:");
   log("  ROUGHDRAFT_DEV_BIN_DIR   Override the wrapper install directory.");
+  log(
+    "  ROUGHDRAFT_DEV_STATE_BASE_DIR   Override the per-wrapper state directory root.",
+  );
 }
 
 function getDefaultBinDir(env = process.env) {
   return env.ROUGHDRAFT_DEV_BIN_DIR || path.join(os.homedir(), ".local", "bin");
 }
 
-function buildWrapperContent({ repoRoot, cliEntryPath }) {
+function buildDefaultStateDir(commandName, env = process.env) {
+  const baseDir =
+    env.ROUGHDRAFT_DEV_STATE_BASE_DIR ||
+    path.join(os.homedir(), ".roughdraft", "dev");
+  return path.join(baseDir, commandName);
+}
+
+function buildWrapperContent({ repoRoot, cliEntryPath, stateDir }) {
   return [
     "#!/usr/bin/env bash",
     `# roughdraft-dev-repo-root=${repoRoot}`,
+    `if [[ -z "\${ROUGHDRAFT_STATE_DIR:-}" ]]; then export ROUGHDRAFT_STATE_DIR=${shellDoubleQuote(stateDir)}; fi`,
     `exec node ${shellDoubleQuote(cliEntryPath)} "$@"`,
     "",
   ].join("\n");
@@ -101,8 +112,13 @@ export function installDevCli(options = {}) {
     "roughdraft.mjs",
   );
   const commandName = `roughdraft-dev-${suffix}`;
+  const stateDir = options.stateDir ?? buildDefaultStateDir(commandName, env);
   const wrapperPath = path.join(binDir, commandName);
-  const wrapperContent = buildWrapperContent({ repoRoot, cliEntryPath });
+  const wrapperContent = buildWrapperContent({
+    repoRoot,
+    cliEntryPath,
+    stateDir,
+  });
   const log = options.log ?? console.log;
   const warn = options.warn ?? console.warn;
 
@@ -135,6 +151,7 @@ export function installDevCli(options = {}) {
     binDir,
     commandName,
     repoRoot,
+    stateDir,
     suffix,
     wrapperPath,
   };


### PR DESCRIPTION
Refactor the app shell into shared navigation, sidebar, canvas, and document workspace modules, and add a document rich-text/code toggle backed by CodeMirror. Improve comment thread rendering and rail layout, tighten document/editor styling, and preserve CriticMarkup comments more reliably in markdown conversions. Record per-worktree frontend state for both full dev and preview-web so roughdraft open can reuse the active local frontend instead of always spawning an API server, and update the docs and tests to cover the new flows.