### PR TITLE
Fix comments on inline code spans

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -19,6 +19,7 @@
     "@joplin/turndown-plugin-gfm": "^1.0.64",
     "@pierre/trees": "1.0.0-beta.3",
     "@tiptap/core": "^3.22.4",
+    "@tiptap/extension-code": "^3.22.4",
     "@tiptap/extension-image": "^3.22.4",
     "@tiptap/extension-link": "^3.22.4",
     "@tiptap/extension-placeholder": "^3.22.4",

--- a/packages/app/src/editor-extensions.ts
+++ b/packages/app/src/editor-extensions.ts
@@ -1,4 +1,5 @@
 import { Extension, Mark, mergeAttributes } from "@tiptap/core";
+import Code from "@tiptap/extension-code";
 import Image from "@tiptap/extension-image";
 import Link from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
@@ -8,13 +9,13 @@ import { TableHeader } from "@tiptap/extension-table-header";
 import { TableRow } from "@tiptap/extension-table-row";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
-import StarterKit from "@tiptap/starter-kit";
 import type {
   Mark as ProseMirrorMark,
   Node as ProseMirrorNode,
 } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import StarterKit from "@tiptap/starter-kit";
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
@@ -257,6 +258,10 @@ const MarkdownLink = Link.extend({
   },
 });
 
+const MarkdownCode = Code.extend({
+  excludes: "bold italic strike link",
+});
+
 const MarkdownImage = Image.extend({
   addAttributes() {
     return {
@@ -279,6 +284,7 @@ export function createEditorExtensions(placeholder: string) {
       heading: {
         levels: [1, 2, 3],
       },
+      code: false,
       link: false,
     }),
     Placeholder.configure({
@@ -289,6 +295,7 @@ export function createEditorExtensions(placeholder: string) {
       openOnClick: false,
       linkOnPaste: true,
     }),
+    MarkdownCode,
     Table.configure({
       resizable: true,
     }),

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -119,6 +119,12 @@
     @apply rounded bg-slate-100 px-1.5 py-0.5 text-[0.9em] text-slate-900;
   }
 
+  .tiptap .comment-decoration code,
+  .tiptap .comment-anchor code {
+    @apply bg-transparent;
+    box-shadow: inset 0 0 0 1px rgb(15 23 42 / 12%);
+  }
+
   .tiptap pre {
     @apply overflow-x-auto rounded-2xl border p-4;
     margin: 1.35em 0;

--- a/packages/app/test/critic-markup.test.ts
+++ b/packages/app/test/critic-markup.test.ts
@@ -30,6 +30,28 @@ describe("CriticMarkup comments", () => {
     expect(editorStateToCriticMarkdown(doc, comments)).toBe(input);
   });
 
+  it("preserves inline code nested inside a comment anchor", () => {
+    const input =
+      "Check {==`roughdraft open`==}{>>Make sure this command is visible<<}{@id:cmt-code;by:user;at:2024-01-15T10:31:00.000Z@} before sharing.\n";
+
+    const { doc, comments } = criticMarkdownToEditorState(input);
+    const paragraph = doc.content?.[0];
+    const codeNode = paragraph?.content?.[1];
+
+    expect(codeNode).toMatchObject({
+      type: "text",
+      text: "roughdraft open",
+      marks: expect.arrayContaining([
+        expect.objectContaining({
+          type: "commentRef",
+          attrs: { commentIds: ["cmt-code"] },
+        }),
+        expect.objectContaining({ type: "code" }),
+      ]),
+    });
+    expect(editorStateToCriticMarkdown(doc, comments)).toBe(input);
+  });
+
   it("keeps the anchor attached when nearby text changes", () => {
     const input =
       'Before {==target==}{>>Check this<<}{id="cmt3" by="AI" at="2024-01-15T10:32:00.000Z"} after.\n';

--- a/packages/app/test/critic-markup.test.ts
+++ b/packages/app/test/critic-markup.test.ts
@@ -32,7 +32,7 @@ describe("CriticMarkup comments", () => {
 
   it("preserves inline code nested inside a comment anchor", () => {
     const input =
-      "Check {==`roughdraft open`==}{>>Make sure this command is visible<<}{@id:cmt-code;by:user;at:2024-01-15T10:31:00.000Z@} before sharing.\n";
+      'Check {==`roughdraft open`==}{>>Make sure this command is visible<<}{id="cmt-code" by="user" at="2024-01-15T10:31:00.000Z"} before sharing.\n';
 
     const { doc, comments } = criticMarkdownToEditorState(input);
     const paragraph = doc.content?.[0];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@tiptap/core':
         specifier: ^3.22.4
         version: 3.22.4(@tiptap/pm@3.22.4)
+      '@tiptap/extension-code':
+        specifier: ^3.22.4
+        version: 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))
       '@tiptap/extension-image':
         specifier: ^3.22.4
         version: 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))


### PR DESCRIPTION
## Summary
- Allow comment reference marks to coexist with inline code marks so comments anchored on code spans are preserved.
- Make inline code backgrounds transparent inside comment highlights while keeping code visually outlined.
- Add regression coverage for CriticMarkup comments over inline code.

## Verification
- pnpm --filter @roughdraft/app test
- pnpm --filter @roughdraft/app build
- pnpm exec biome check packages/app/src/editor-extensions.ts packages/app/src/style.css packages/app/test/critic-markup.test.ts packages/app/package.json