### PR TITLE
Use attribute metadata for CriticMarkup comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ This is {++inserted++} text.
 This is {~~old~>new~~} substituted text.
 This is {>>a comment<<} in the margin.
 This is {==highlighted==} text.
+This is {==anchored text==}{>>a threaded comment<<}{id="c1" by="user" at="2026-04-23T18:00:00.000Z"}.
 ```
 
 This matters because the main workflow is often:

--- a/packages/app/src/critic-markup/index.ts
+++ b/packages/app/src/critic-markup/index.ts
@@ -38,7 +38,10 @@ interface CriticCommentToken {
 
 const extensions = createEditorExtensions("");
 const criticCommentAnchorPattern = /^\{==([\s\S]+?)==\}/;
-const criticCommentBlockPattern = /^\{>>([\s\S]*?)<<\}(?:\{@([\s\S]+?)@\})?/;
+const criticCommentBlockPattern =
+  /^\{>>([\s\S]*?)<<\}(?:(\{@([\s\S]+?)@\})|(\{(?:\s*[A-Za-z][A-Za-z0-9_-]*="(?:\\[\s\S]|[^"\\])*")+\s*\}))?/;
+const metadataAttributePattern =
+  /([A-Za-z][A-Za-z0-9_-]*)="((?:\\[\s\S]|[^"\\])*)"/g;
 
 function escapeHtml(value: string): string {
   return value
@@ -48,7 +51,7 @@ function escapeHtml(value: string): string {
     .replaceAll('"', "&quot;");
 }
 
-function parseMetadata(
+function parseLegacyMetadata(
   metadataText?: string,
 ): Partial<Omit<CriticComment, "content">> {
   const fields = new Map<string, string>();
@@ -73,18 +76,64 @@ function parseMetadata(
   };
 }
 
+function unescapeMetadataAttributeValue(value: string): string {
+  return value.replaceAll(/\\([\s\S])/g, "$1");
+}
+
+function escapeMetadataAttributeValue(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+}
+
+function parseAttributeMetadata(
+  metadataText?: string,
+): Partial<Omit<CriticComment, "content">> {
+  if (!metadataText?.startsWith("{") || !metadataText.endsWith("}")) {
+    return {};
+  }
+
+  const fields = new Map<string, string>();
+  const content = metadataText.slice(1, -1);
+
+  for (const match of content.matchAll(metadataAttributePattern)) {
+    fields.set(match[1], unescapeMetadataAttributeValue(match[2]));
+  }
+
+  const author = fields.get("by") ?? "user";
+
+  return {
+    id: fields.get("id"),
+    createdAt: fields.get("at") ?? new Date().toISOString(),
+    authorType: author.toUpperCase() === "AI" ? "ai" : "user",
+    authorId: author.toUpperCase() === "AI" ? null : author,
+    parentCommentId: fields.get("re") ?? null,
+  };
+}
+
+function parseMetadata(
+  legacyMetadataText?: string,
+  attributeMetadataText?: string,
+): Partial<Omit<CriticComment, "content">> {
+  if (attributeMetadataText) {
+    return parseAttributeMetadata(attributeMetadataText);
+  }
+
+  return parseLegacyMetadata(legacyMetadataText);
+}
+
 function serializeMetadata(comment: CriticComment): string {
   const fields = [
-    `id:${comment.id}`,
-    `by:${comment.authorType === "ai" ? "AI" : comment.authorId || "user"}`,
-    `at:${comment.createdAt || new Date().toISOString()}`,
+    ["id", comment.id],
+    ["by", comment.authorType === "ai" ? "AI" : comment.authorId || "user"],
+    ["at", comment.createdAt || new Date().toISOString()],
   ];
 
   if (comment.parentCommentId) {
-    fields.push(`re:${comment.parentCommentId}`);
+    fields.push(["re", comment.parentCommentId]);
   }
 
-  return `{@${fields.join(";")}@}`;
+  return `{${fields
+    .map(([key, value]) => `${key}="${escapeMetadataAttributeValue(value)}"`)
+    .join(" ")}}`;
 }
 
 export function createNextCommentId(
@@ -249,10 +298,11 @@ function tokenizeCriticCommentAnchor(
     const nextMatch = src.slice(offset).match(criticCommentBlockPattern);
     if (!nextMatch) break;
 
-    const [, commentText, metadataText] = nextMatch;
+    const [, commentText, , legacyMetadataText, attributeMetadataText] =
+      nextMatch;
     const comment = createCommentWithContext(
       {
-        ...parseMetadata(metadataText),
+        ...parseMetadata(legacyMetadataText, attributeMetadataText),
         content: commentText,
       },
       [...existingComments, ...parsedComments],

--- a/packages/app/test/critic-markup.test.ts
+++ b/packages/app/test/critic-markup.test.ts
@@ -9,7 +9,7 @@ import {
 describe("CriticMarkup comments", () => {
   it("round-trips a highlighted comment anchor", () => {
     const input =
-      "This is {==highlighted==}{>>comment text<<}{@id:cmt1;by:AI;at:2024-01-15T10:30:00.000Z@} text.\n";
+      'This is {==highlighted==}{>>comment text<<}{id="cmt1" by="AI" at="2024-01-15T10:30:00.000Z"} text.\n';
 
     const { doc, comments } = criticMarkdownToEditorState(input);
 
@@ -23,7 +23,7 @@ describe("CriticMarkup comments", () => {
 
   it("preserves formatting nested inside a comment anchor", () => {
     const input =
-      "The {==**important**==}{>>Review this phrasing<<}{@id:cmt2;by:user@example.com;at:2024-01-15T10:31:00.000Z@} section stays bold.\n";
+      'The {==**important**==}{>>Review this phrasing<<}{id="cmt2" by="user@example.com" at="2024-01-15T10:31:00.000Z"} section stays bold.\n';
 
     const { doc, comments } = criticMarkdownToEditorState(input);
 
@@ -32,7 +32,7 @@ describe("CriticMarkup comments", () => {
 
   it("keeps the anchor attached when nearby text changes", () => {
     const input =
-      "Before {==target==}{>>Check this<<}{@id:cmt3;by:AI;at:2024-01-15T10:32:00.000Z@} after.\n";
+      'Before {==target==}{>>Check this<<}{id="cmt3" by="AI" at="2024-01-15T10:32:00.000Z"} after.\n';
     const { doc, comments } = criticMarkdownToEditorState(input);
     const nextDoc = structuredClone(doc);
     const firstParagraph = nextDoc.content?.[0];
@@ -45,7 +45,7 @@ describe("CriticMarkup comments", () => {
     firstTextNode.text = "Before nearby ";
 
     expect(editorStateToCriticMarkdown(nextDoc, comments)).toBe(
-      "Before nearby {==target==}{>>Check this<<}{@id:cmt3;by:AI;at:2024-01-15T10:32:00.000Z@} after.\n",
+      'Before nearby {==target==}{>>Check this<<}{id="cmt3" by="AI" at="2024-01-15T10:32:00.000Z"} after.\n',
     );
   });
 
@@ -53,7 +53,7 @@ describe("CriticMarkup comments", () => {
     const input = `## Sprint Notes
 
 * First item
-* {==Second item==}{>>Needs review<<}{@id:cmt4;by:AI;at:2024-01-15T10:33:00.000Z@}
+* {==Second item==}{>>Needs review<<}{id="cmt4" by="AI" at="2024-01-15T10:33:00.000Z"}
 `;
 
     const { doc, comments } = criticMarkdownToEditorState(input);
@@ -61,7 +61,7 @@ describe("CriticMarkup comments", () => {
 
     expect(output).toContain("## Sprint Notes");
     expect(output).toContain(
-      "{==Second item==}{>>Needs review<<}{@id:cmt4;by:AI;at:2024-01-15T10:33:00.000Z@}",
+      '{==Second item==}{>>Needs review<<}{id="cmt4" by="AI" at="2024-01-15T10:33:00.000Z"}',
     );
     expect(output).toContain("*   First item");
   });
@@ -96,7 +96,7 @@ Use CriticMarkup for inline review feedback in markdown.`,
 
   it("round-trips an anchored reply thread", () => {
     const input =
-      "Please revisit {==this sentence==}{>>Needs a source<<}{@id:c1;by:user;at:2024-01-15T10:30:00.000Z@}{>>I can add one from the intro.<<}{@id:c2;by:AI;at:2024-01-15T10:31:00.000Z;re:c1@}.\n";
+      'Please revisit {==this sentence==}{>>Needs a source<<}{id="c1" by="user" at="2024-01-15T10:30:00.000Z"}{>>I can add one from the intro.<<}{id="c2" by="AI" at="2024-01-15T10:31:00.000Z" re="c1"}.\n';
 
     const { doc, comments } = criticMarkdownToEditorState(input);
 
@@ -110,13 +110,42 @@ Use CriticMarkup for inline review feedback in markdown.`,
 
   it("round-trips nested replies in preorder", () => {
     const input =
-      "Please revisit {==this sentence==}{>>Needs a source<<}{@id:c1;by:user;at:2024-01-15T10:30:00.000Z@}{>>I can add one from the intro.<<}{@id:c2;by:AI;at:2024-01-15T10:31:00.000Z;re:c1@}{>>Use the market report too.<<}{@id:c3;by:user;at:2024-01-15T10:32:00.000Z;re:c2@}.\n";
+      'Please revisit {==this sentence==}{>>Needs a source<<}{id="c1" by="user" at="2024-01-15T10:30:00.000Z"}{>>I can add one from the intro.<<}{id="c2" by="AI" at="2024-01-15T10:31:00.000Z" re="c1"}{>>Use the market report too.<<}{id="c3" by="user" at="2024-01-15T10:32:00.000Z" re="c2"}.\n';
 
     const { doc, comments } = criticMarkdownToEditorState(input);
 
     expect(comments.get("c3")).toMatchObject({
       id: "c3",
       parentCommentId: "c2",
+    });
+    expect(editorStateToCriticMarkdown(doc, comments)).toBe(input);
+  });
+
+  it("migrates legacy metadata to attribute metadata on save", () => {
+    const input =
+      "Please revisit {==this sentence==}{>>Needs a source<<}{@id:c1;by:user;at:2024-01-15T10:30:00.000Z@}.\n";
+
+    const { doc, comments } = criticMarkdownToEditorState(input);
+
+    expect(comments.get("c1")).toMatchObject({
+      id: "c1",
+      content: "Needs a source",
+      authorType: "user",
+      authorId: "user",
+    });
+    expect(editorStateToCriticMarkdown(doc, comments)).toBe(
+      'Please revisit {==this sentence==}{>>Needs a source<<}{id="c1" by="user" at="2024-01-15T10:30:00.000Z"}.\n',
+    );
+  });
+
+  it("round-trips escaped attribute metadata values", () => {
+    const input =
+      'Please revisit {==this sentence==}{>>Needs a source<<}{id="c1" by="user\\\\\\"name" at="2024-01-15T10:30:00.000Z"}.\n';
+
+    const { doc, comments } = criticMarkdownToEditorState(input);
+
+    expect(comments.get("c1")).toMatchObject({
+      authorId: 'user\\"name',
     });
     expect(editorStateToCriticMarkdown(doc, comments)).toBe(input);
   });

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -593,7 +593,7 @@ describe("cli", () => {
     expect(exitCode).toBe(0);
     expect(test.logs).toContain("Reply to an existing comment:");
     expect(test.logs).toContain(
-      "  Use explicit `id:` and `re:` metadata for replies.",
+      '  Use explicit `id="..."` and `re="..."` metadata for replies.',
     );
     expect(test.logs).toContain(
       "  Comment ids are document-local and usually look like `c1`, `c2`, `c3`.",

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -280,16 +280,16 @@ function printCriticMarkupHelp(log: (message: string) => void) {
   log("");
   log("Anchored comment with id:");
   log(
-    "  Review {==this sentence==}{>>Needs a source<<}{@id:c1;by:user;at:2026-04-23T18:00:00.000Z@}.",
+    '  Review {==this sentence==}{>>Needs a source<<}{id="c1" by="user" at="2026-04-23T18:00:00.000Z"}.',
   );
   log("");
   log("Reply to an existing comment:");
   log(
-    "  Review {==this sentence==}{>>Needs a source<<}{@id:c1;by:user;at:2026-04-23T18:00:00.000Z@}{>>I can add one from the intro.<<}{@id:c2;by:AI;at:2026-04-23T18:05:00.000Z;re:c1@}.",
+    '  Review {==this sentence==}{>>Needs a source<<}{id="c1" by="user" at="2026-04-23T18:00:00.000Z"}{>>I can add one from the intro.<<}{id="c2" by="AI" at="2026-04-23T18:05:00.000Z" re="c1"}.',
   );
   log("");
   log("Reply guidance:");
-  log("  Use explicit `id:` and `re:` metadata for replies.");
+  log('  Use explicit `id="..."` and `re="..."` metadata for replies.');
   log(
     "  Comment ids are document-local and usually look like `c1`, `c2`, `c3`.",
   );


### PR DESCRIPTION
## Summary
- Switch CriticMarkup comment metadata serialization to quoted attributes like `{id="c1" by="user" at="..."}`.
- Keep parsing legacy `{@id:...@}` metadata and migrate it on save.
- Update CLI help, README examples, and round-trip coverage for replies and escaped attribute values.

## Tests
- `pnpm test`