### PR TITLE
Add Roughdraft agent setup prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,9 @@ Then recompute `roughdraft_cmd` and use it.
 
 ## Roughdraft Workflow
 
-Use Roughdraft when the user wants to open, review, comment on, or compare Markdown files.
+Use Roughdraft when the user wants to open, review, or comment on a Markdown file.
+
+The user may refer to Roughdraft as `rd` in natural language. Treat `rd` as shorthand for Roughdraft in user requests, but do not create or modify any shell alias, executable, symlink, or command named `rd`.
 
 Preferred flow:
 
@@ -49,14 +51,13 @@ Preferred flow:
 "$roughdraft_cmd" start
 ```
 
-3. Open the relevant file or folder:
+3. Open the relevant Markdown file:
 
 ```bash
 "$roughdraft_cmd" open "/absolute/path/to/file.md"
-"$roughdraft_cmd" open "/absolute/path/to/folder"
 ```
 
-4. After the user finishes reviewing in Roughdraft, read the markdown files from disk and make the requested changes there.
+4. After the user finishes reviewing in Roughdraft, read the markdown file from disk and make the requested changes there.
 
 Useful commands:
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ A local-first markdown editor and viewer for working with AI.
 
 Open one markdown file on your machine. Review it, comment on it, and suggest edits.
 
+Paste this into your coding agent:
+
+```text
+Install Roughdraft for me using `npm i -g roughdraft`, then read https://roughdraft.page/setup.md and set yourself up to use it.
+```
+
+Or install and open a file yourself:
+
 ```bash
 npm i -g roughdraft
 roughdraft open /absolute/path/to/file.md
@@ -32,6 +40,8 @@ Roughdraft opens a single markdown file directly for CriticMarkup comments and s
 
 ## Quick start
 
+Install Roughdraft and start the local server:
+
 ```bash
 npm i -g roughdraft
 roughdraft start
@@ -54,7 +64,7 @@ roughdraft stop
 
 `roughdraft open` will reuse the running server and auto-start it if needed.
 
-Roughdraft does not edit `~/CLAUDE.md`, `~/AGENTS.md`, or other user-level agent files. If you want your agent to remember the workflow, ask it to update its own guidance.
+Roughdraft does not edit `~/CLAUDE.md`, `~/AGENTS.md`, or other user-level agent files. The setup prompt asks your agent to update its own guidance.
 
 If the local server is already running, you can also open a file directly by URL:
 
@@ -121,18 +131,13 @@ Roughdraft reads and writes the markdown file directly.
 
 ## Agent setup
 
-If you want your local agent to remember the Roughdraft workflow, point it at the commands and review loop explicitly:
+If you want your local agent to remember the Roughdraft workflow, ask it to read the live setup prompt:
 
 ```text
-Use Roughdraft when I want to open, review, or comment on a markdown file.
-
-Start it with `roughdraft start` if needed.
-Open markdown files with `roughdraft open "/absolute/path/to/file.md"`.
-After I finish reviewing in Roughdraft, continue by reading the markdown file from disk and making the requested changes there.
-Use CriticMarkup for inline review feedback in markdown.
+Install Roughdraft for me using `npm i -g roughdraft`, then read https://roughdraft.page/setup.md and set yourself up to use it.
 ```
 
-Use `roughdraft help` or `roughdraft help criticmarkup` if you need a refresher while setting that up.
+Use `roughdraft help`, `roughdraft help agent`, or `roughdraft help criticmarkup` if you need a local refresher.
 
 ## CriticMarkup
 

--- a/packages/app/public/setup.md
+++ b/packages/app/public/setup.md
@@ -1,0 +1,75 @@
+# Roughdraft Agent Setup
+
+You are setting yourself up to use Roughdraft, a local Markdown review tool.
+
+Roughdraft lets you open one Markdown file from disk in a local browser editor so the user can read, edit, comment, and suggest changes. It is currently a single-file Markdown viewer/editor.
+
+## Check Installation
+
+Check whether Roughdraft is available:
+
+```bash
+roughdraft help
+```
+
+If Roughdraft is missing and the user has asked you to install it, install it with:
+
+```bash
+npm i -g roughdraft
+```
+
+If the user did not explicitly ask you to install software, ask before installing a global npm package.
+
+## Update Your Persistent Instructions
+
+Add Roughdraft guidance to the appropriate persistent instruction file for this environment.
+
+Prefer global or user-level persistent instructions, because Roughdraft is a cross-project workflow. Examples may include global Codex instructions, global Claude instructions, `CLAUDE.md`, `AGENTS.md`, Cursor rules, or another configured instruction file.
+
+These are examples, not hard rules. Inspect the user's actual setup and conform to it. If you are unsure where your current version stores persistent instructions, use current official docs or web search before editing.
+
+If global or user-level instructions are unavailable or unclear, fall back to a project-level instruction file and tell the user what you changed.
+
+Add guidance like this:
+
+```text
+Use Roughdraft when the user wants to review or comment on a Markdown file.
+
+The user may refer to Roughdraft as `rd` in natural language. Treat `rd` as shorthand for Roughdraft in user requests, but do not create or modify any shell alias, executable, symlink, or command named `rd`.
+
+When the user asks for a plan, write the plan as a Markdown file on disk before asking them to review it.
+
+When you write or modify a Markdown file and want the user to review or comment on it, open it with:
+
+roughdraft open "/absolute/path/to/file.md"
+
+Roughdraft is currently a single-file Markdown viewer/editor. Open one `.md` file at a time.
+
+If Roughdraft is not running, `roughdraft open` will start it automatically.
+
+After the user finishes reviewing in Roughdraft, read the Markdown file from disk and respond to any CriticMarkup comments or suggested changes.
+
+Use CriticMarkup when reading or writing inline review feedback in Markdown.
+
+Use `roughdraft help` and `roughdraft help criticmarkup` for local command and syntax details.
+```
+
+After updating your instructions, briefly tell the user which file you changed.
+
+## CriticMarkup Reference
+
+Roughdraft uses CriticMarkup for inline comments and suggested changes:
+
+```text
+Comment: `{>>comment<<}`
+Insertion: `{++new text++}`
+Deletion: `{--old text--}`
+Substitution: `{~~old~>new~~}`
+Highlight: `{==text==}`
+```
+
+CriticMarkup inside fenced code blocks is literal example text. Do not treat it as review feedback.
+
+User comments may appear inline in the Markdown file. Suggested insertions, deletions, and substitutions should be interpreted as review feedback unless the user asks you to accept them directly.
+
+Use `roughdraft help criticmarkup` for local syntax examples.

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Check, Copy } from "lucide-react";
 import {
   type DocumentEditorViewMode,
   buildLocationForDocumentEditorViewMode,
@@ -21,6 +22,8 @@ import { UpdateNotice } from "./UpdateNotice";
 
 type SaveState = "idle" | "saving" | "error";
 type DocumentDiskChangeState = "clean" | "changed" | "conflict";
+const AGENT_SETUP_PROMPT =
+  "Install Roughdraft for me using `npm i -g roughdraft`, then read https://roughdraft.page/setup.md and set yourself up to use it.";
 
 function EmptyState({
   message,
@@ -29,21 +32,58 @@ function EmptyState({
   message: string;
   updateStatus: UpdateStatus | null;
 }) {
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">(
+    "idle",
+  );
+
+  const handleCopySetupPrompt = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(AGENT_SETUP_PROMPT);
+      setCopyState("copied");
+      window.setTimeout(() => setCopyState("idle"), 1800);
+    } catch {
+      setCopyState("error");
+    }
+  }, []);
+
   return (
-    <div className="flex min-h-screen items-center justify-center bg-[#FCFCFC] px-6 text-slate-950">
+    <div className="flex min-h-screen items-center justify-center bg-[#FCFCFC] px-6 py-12 text-slate-950">
       {updateStatus ? (
         <div className="absolute top-4 right-4 max-w-sm">
           <UpdateNotice updateStatus={updateStatus} />
         </div>
       ) : null}
-      <div className="max-w-md text-center">
-        <h1 className="text-xl font-semibold tracking-tight">
-          Open a markdown file
+      <div className="w-full max-w-xl">
+        <h1 className="text-3xl font-semibold tracking-tight text-slate-950">
+          Copy this into your coding agent
         </h1>
-        <p className="mt-2 text-sm leading-6 text-slate-500">{message}</p>
-        <code className="mt-5 block rounded-lg border border-slate-200 bg-white px-3 py-2 text-left text-xs text-slate-600">
-          roughdraft open /absolute/path/to/file.md
-        </code>
+        {message ? (
+          <p className="mt-3 text-sm leading-6 text-slate-500">{message}</p>
+        ) : null}
+
+        <div className="mt-5 rounded-lg border border-slate-200 bg-white p-4 shadow-xs">
+          <p className="break-words text-base leading-7 text-slate-800">
+            {AGENT_SETUP_PROMPT}
+          </p>
+          {copyState === "error" ? (
+            <p className="mt-3 text-sm text-red-600">
+              Copy failed. Select the instruction text and copy it manually.
+            </p>
+          ) : null}
+        </div>
+
+        <button
+          className="mt-4 inline-flex h-10 items-center justify-center gap-2 rounded-md bg-slate-950 px-4 text-sm font-medium text-white transition hover:bg-slate-800 focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:outline-none"
+          type="button"
+          onClick={handleCopySetupPrompt}
+        >
+          {copyState === "copied" ? (
+            <Check className="size-4" aria-hidden="true" />
+          ) : (
+            <Copy className="size-4" aria-hidden="true" />
+          )}
+          {copyState === "copied" ? "Copied" : "Copy prompt"}
+        </button>
       </div>
     </div>
   );
@@ -341,7 +381,7 @@ export function App() {
       <EmptyState
         message={
           loadError ??
-          "Use the Roughdraft CLI to open a single markdown file from disk."
+          "Install Roughdraft and set up the review workflow in one step."
         }
         updateStatus={updateStatus}
       />

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -614,6 +614,64 @@ describe("cli", () => {
     expect(test.logs).toContain(
       "  Comment ids are document-local and usually look like `c1`, `c2`, `c3`.",
     );
+    expect(test.logs).toContain(
+      "  Treat CriticMarkup inside fenced code blocks as literal example text.",
+    );
+  });
+
+  it("points general help to agent setup", async () => {
+    const test = createTestDependencies();
+
+    const exitCode = await runCli(["help"], test.deps);
+
+    expect(exitCode).toBe(0);
+    expect(test.logs).toContain("  roughdraft help agent");
+    expect(test.logs).toContain(
+      "Agent setup: https://roughdraft.page/setup.md",
+    );
+    expect(test.logs).toContain(
+      "Use `roughdraft help agent` for a copyable setup prompt.",
+    );
+  });
+
+  it("prints a copyable agent setup prompt", async () => {
+    const test = createTestDependencies();
+
+    const exitCode = await runCli(["help", "agent"], test.deps);
+
+    expect(exitCode).toBe(0);
+    expect(test.logs).toContain(
+      "To set up your coding agent, paste this into it:",
+    );
+    expect(test.logs).toContain(
+      "Install Roughdraft for me using `npm i -g roughdraft`, then read https://roughdraft.page/setup.md and set yourself up to use it.",
+    );
+    expect(test.logs).toContain(
+      "This command only prints setup text. It does not edit agent instruction files.",
+    );
+  });
+
+  it("keeps install deprecated and points to agent setup", async () => {
+    const test = createTestDependencies();
+
+    const exitCode = await runCli(["install"], test.deps);
+
+    expect(exitCode).toBe(1);
+    expect(test.errors).toContain("`roughdraft install` has been removed.");
+    expect(test.logs).toContain(
+      "Install Roughdraft for me using `npm i -g roughdraft`, then read https://roughdraft.page/setup.md and set yourself up to use it.",
+    );
+  });
+
+  it("supports agent-setup as a direct setup helper", async () => {
+    const test = createTestDependencies();
+
+    const exitCode = await runCli(["agent-setup"], test.deps);
+
+    expect(exitCode).toBe(0);
+    expect(test.logs).toContain(
+      "Live setup instructions: https://roughdraft.page/setup.md",
+    );
   });
 
   it("starts a new server when the preferred port belongs to another checkout", async () => {

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -12,6 +12,8 @@ import {
 import { findAvailablePort } from "./ports.js";
 
 const DEFAULT_PORT = 3000;
+const AGENT_SETUP_URL = "https://roughdraft.page/setup.md";
+const AGENT_SETUP_PROMPT = `Install Roughdraft for me using \`npm i -g roughdraft\`, then read ${AGENT_SETUP_URL} and set yourself up to use it.`;
 const STATUS_PATH = "/api/status";
 const STATUS_TIMEOUT_MS = 750;
 const SERVER_WAIT_ATTEMPTS = 40;
@@ -245,13 +247,16 @@ function printHelp(log: (message: string) => void) {
   log("  roughdraft status");
   log("  roughdraft stop");
   log("  roughdraft help");
+  log("  roughdraft help agent");
   log("  roughdraft help criticmarkup");
   log("");
-  log("Start the local server once:");
-  log("  roughdraft start");
-  log("");
-  log("Open a markdown file:");
+  log("Open one markdown file:");
   log("  roughdraft open /absolute/path/to/file.md");
+  log("  Relative paths also work; absolute paths are best for agents.");
+  log("");
+  log("Server:");
+  log("  `roughdraft open` starts the server if needed.");
+  log("  Use `roughdraft status` or `roughdraft stop` to manage it.");
   log("");
   log("Review loop:");
   log("  1. Open a markdown file in Roughdraft.");
@@ -262,7 +267,22 @@ function printHelp(log: (message: string) => void) {
   log("  {>>comment<<}  {++inserted++}  {--deleted--}");
   log("  {~~old~>new~~}  {==highlighted==}");
   log("");
+  log(`Agent setup: ${AGENT_SETUP_URL}`);
+  log("Use `roughdraft help agent` for a copyable setup prompt.");
+  log("");
   log("Use `roughdraft help criticmarkup` for examples.");
+}
+
+function printAgentHelp(log: (message: string) => void) {
+  log("To set up your coding agent, paste this into it:");
+  log("");
+  log(AGENT_SETUP_PROMPT);
+  log("");
+  log(`Live setup instructions: ${AGENT_SETUP_URL}`);
+  log("");
+  log(
+    "This command only prints setup text. It does not edit agent instruction files.",
+  );
 }
 
 function printCriticMarkupHelp(log: (message: string) => void) {
@@ -292,6 +312,11 @@ function printCriticMarkupHelp(log: (message: string) => void) {
   log(
     "  Comment ids are document-local and usually look like `c1`, `c2`, `c3`.",
   );
+  log("");
+  log("Code blocks:");
+  log(
+    "  Treat CriticMarkup inside fenced code blocks as literal example text.",
+  );
 }
 
 function printInstallDeprecation(
@@ -299,12 +324,13 @@ function printInstallDeprecation(
   error: (message: string) => void,
 ) {
   error("`roughdraft install` has been removed.");
-  log("Install Roughdraft with:");
-  log("  npm i -g roughdraft");
+  log("To set up your coding agent, paste this into it:");
   log("");
-  log(
-    "Roughdraft no longer edits `~/CLAUDE.md`, `~/AGENTS.md`, or other user-level agent files.",
-  );
+  log(AGENT_SETUP_PROMPT);
+  log("");
+  log(`Live setup instructions: ${AGENT_SETUP_URL}`);
+  log("");
+  log("Roughdraft no longer edits user-level agent files directly.");
 }
 
 function parsePort(value: string | undefined): number {
@@ -767,6 +793,11 @@ export async function runCli(
     command === "--help" ||
     command === "-h"
   ) {
+    if (rest[0] === "agent") {
+      printAgentHelp(deps.log);
+      return 0;
+    }
+
     if (rest[0] === "criticmarkup") {
       printCriticMarkupHelp(deps.log);
       return 0;
@@ -778,6 +809,11 @@ export async function runCli(
 
   if (command === "criticmarkup") {
     printCriticMarkupHelp(deps.log);
+    return 0;
+  }
+
+  if (command === "agent-setup") {
+    printAgentHelp(deps.log);
     return 0;
   }
 


### PR DESCRIPTION
Adds a copyable agent setup prompt to the empty app state and CLI help, including `roughdraft help agent` and `agent-setup`. Publishes `/setup.md` with live setup guidance and updates the README/AGENTS workflow around single-file Markdown review and `rd` shorthand. Keeps `roughdraft install` deprecated while pointing users to the new setup prompt. Tests: `pnpm test`.