### PR TITLE
Add npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,126 @@
+name: Publish to npm
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: publish-npm
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.repository == 'Lex-Inc/roughdraft'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run repo checks
+        run: pnpm check
+
+      - name: Decide whether to publish
+        id: release
+        run: |
+          set -euo pipefail
+
+          package_name="$(node -p "require('./package.json').name")"
+          package_version="$(node -p "require('./package.json').version")"
+          tag="v${package_version}"
+
+          current_version="$(npm view "$package_name" version 2>/dev/null || true)"
+
+          should_publish=false
+          if [ -z "$current_version" ]; then
+            echo "No published version found for $package_name."
+            should_publish=true
+          elif npm view "${package_name}@${package_version}" version >/dev/null 2>&1; then
+            echo "$package_name@$package_version is already published."
+          elif node - "$package_version" "$current_version" <<'NODE'
+          const [nextVersion, currentVersion] = process.argv.slice(2);
+
+          function parseSemver(version) {
+            const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+.+)?$/.exec(version);
+            if (!match) {
+              throw new Error(`Invalid semver version: ${version}`);
+            }
+
+            return {
+              major: Number(match[1]),
+              minor: Number(match[2]),
+              patch: Number(match[3]),
+              prerelease: match[4] ?? "",
+            };
+          }
+
+          function compareSemver(left, right) {
+            return (
+              left.major - right.major ||
+              left.minor - right.minor ||
+              left.patch - right.patch ||
+              comparePrerelease(left.prerelease, right.prerelease)
+            );
+          }
+
+          function comparePrerelease(left, right) {
+            if (left === right) return 0;
+            if (left === "") return 1;
+            if (right === "") return -1;
+            return left.localeCompare(right, undefined, { numeric: true });
+          }
+
+          process.exit(compareSemver(parseSemver(nextVersion), parseSemver(currentVersion)) > 0 ? 0 : 1);
+          NODE
+          then
+            echo "$package_name@$package_version is newer than npm latest $current_version."
+            should_publish=true
+          else
+            echo "::notice::$package_name@$package_version is not newer than npm latest $current_version; skipping publish."
+          fi
+
+          if [ "$should_publish" = true ] && git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "::error::Release tag $tag already exists, but $package_name@$package_version is not published."
+            exit 1
+          fi
+
+          {
+            echo "package_name=$package_name"
+            echo "package_version=$package_version"
+            echo "should_publish=$should_publish"
+            echo "tag=$tag"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish package
+        if: steps.release.outputs.should_publish == 'true'
+        run: npm publish
+
+      - name: Create release tag
+        if: steps.release.outputs.should_publish == 'true'
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.release.outputs.tag }}" -m "${{ steps.release.outputs.package_name }} ${{ steps.release.outputs.package_version }}"
+          git push origin "${{ steps.release.outputs.tag }}"

--- a/README.md
+++ b/README.md
@@ -119,6 +119,29 @@ pnpm check
 
 `pnpm check` is the same command the pull request workflow runs before merge.
 
+## Publishing
+
+Roughdraft publishes from `main` when the root `package.json` version is newer than the current npm `latest` version.
+
+Release flow:
+
+1.  Bump the root `package.json` version in a pull request.
+    
+2.  Merge the pull request to `main`.
+    
+3.  The `Publish to npm` GitHub Actions workflow runs `pnpm check`, publishes the package if that exact version is not already on npm and is newer than `latest`, then creates a `v<version>` git tag.
+    
+
+The workflow uses npm trusted publishing, so npm must be configured with this trusted publisher:
+
+```text
+Owner: Lex-Inc
+Repository: roughdraft
+Workflow filename: publish.yml
+```
+
+No `NPM_TOKEN` secret is required.
+
 ## Files on disk
 
 ```

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "A local markdown review app",
   "license": "MIT",
   "author": "Nathan Baschez",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Lex-Inc/roughdraft.git"
+  },
   "bin": {
     "roughdraft": "./packages/server/bin/roughdraft.mjs"
   },


### PR DESCRIPTION
Adds a GitHub Actions workflow that publishes Roughdraft to npm from main when the root package version is newer than npm latest. The workflow runs pnpm check first, uses npm trusted publishing via OIDC, and tags successful releases as v<version>. Adds the repository metadata npm needs for provenance and documents the release process in the README.