### PR TITLE
Add CriticMarkup suggestion workflow

### DIFF
--- a/packages/app/src/DocumentReviewRail.tsx
+++ b/packages/app/src/DocumentReviewRail.tsx
@@ -54,24 +54,6 @@ interface DocumentReviewRailProps {
   onAutoFocusComment?: (commentId: string) => void;
 }
 
-type ReviewRailEntry =
-  | {
-      type: "suggestion";
-      key: string;
-      anchorTop: number;
-      anchorBottom: number;
-      suggestion: CriticChangeRailItem;
-    }
-  | {
-      type: "comment";
-      key: string;
-      anchorTop: number;
-      anchorBottom: number;
-      thread: CommentThreadRailItem & {
-        visibleComments: CriticComment[];
-      };
-    };
-
 function getSuggestionTypeLabel(kind: CriticChangeKind) {
   if (kind === "addition") return "Insertion";
   if (kind === "deletion") return "Deletion";
@@ -199,25 +181,22 @@ export function DocumentReviewRail({
     [selectedCommentId, suggestions],
   );
 
-  const layouts = useMemo(
-    () => {
-      const entries = [...suggestionEntries, ...commentEntries].sort(
-        (left, right) => left.anchorTop - right.anchorTop,
-      );
-      const activeKey =
-        selectedChangeId ?? activeSuggestionIdForComment ?? activeRootThreadId;
+  const layouts = useMemo(() => {
+    const entries = [...suggestionEntries, ...commentEntries].sort(
+      (left, right) => left.anchorTop - right.anchorTop,
+    );
+    const activeKey =
+      selectedChangeId ?? activeSuggestionIdForComment ?? activeRootThreadId;
 
-      return resolveAnchoredRailLayouts(entries, itemHeights, activeKey);
-    },
-    [
-      activeRootThreadId,
-      activeSuggestionIdForComment,
-      commentEntries,
-      itemHeights,
-      selectedChangeId,
-      suggestionEntries,
-    ],
-  );
+    return resolveAnchoredRailLayouts(entries, itemHeights, activeKey);
+  }, [
+    activeRootThreadId,
+    activeSuggestionIdForComment,
+    commentEntries,
+    itemHeights,
+    selectedChangeId,
+    suggestionEntries,
+  ]);
 
   const setItemRef = useCallback((key: string, node: HTMLDivElement | null) => {
     if (node) {

--- a/packages/app/src/DocumentReviewRail.tsx
+++ b/packages/app/src/DocumentReviewRail.tsx
@@ -1,0 +1,456 @@
+import { Check, Reply, X } from "lucide-react";
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { CommentEditorList } from "./CommentEditorList";
+import type {
+  CriticChangeAttrs,
+  CriticChangeKind,
+  CriticComment,
+} from "./critic-markup";
+import {
+  buildCommentThreadRailItems,
+  type CommentGroupAnchor,
+  type CommentThreadRailItem,
+  getPreferredCommentId,
+  getRootThreadIdForCommentId,
+  normalizeCommentMeasurement,
+  resolveAnchoredRailLayouts,
+} from "./document-comments";
+import { cn } from "./lib/utils";
+
+export interface CriticChangeRailItem {
+  changeId: string;
+  change: CriticChangeAttrs;
+  kind: CriticChangeKind;
+  oldText: string;
+  newText: string;
+  commentIds: string[];
+  anchorTop: number;
+  anchorBottom: number;
+}
+
+interface DocumentReviewRailProps {
+  commentGroups: CommentGroupAnchor[];
+  comments: Map<string, CriticComment>;
+  suggestions: CriticChangeRailItem[];
+  selectedCommentId: string | null;
+  hoveredCommentId: string | null;
+  selectedChangeId: string | null;
+  hoveredChangeId: string | null;
+  contentHeight: number;
+  className?: string;
+  onDeleteComment: (commentId: string) => void;
+  onUpdateComment: (commentId: string, nextContent: string) => void;
+  onReplyComment: (commentId: string) => void;
+  onSelectComment: (commentId: string) => void;
+  onFocusComment: (commentId: string) => void;
+  onHoverComment: (commentId: string | null) => void;
+  onAcceptSuggestion: (changeId: string) => void;
+  onRejectSuggestion: (changeId: string) => void;
+  onReplySuggestion: (changeId: string) => void;
+  onSelectSuggestion: (changeId: string) => void;
+  onFocusSuggestion: (changeId: string) => void;
+  onHoverSuggestion: (changeId: string | null) => void;
+  pendingFocusCommentId?: string | null;
+  onAutoFocusComment?: (commentId: string) => void;
+}
+
+type ReviewRailEntry =
+  | {
+      type: "suggestion";
+      key: string;
+      anchorTop: number;
+      anchorBottom: number;
+      suggestion: CriticChangeRailItem;
+    }
+  | {
+      type: "comment";
+      key: string;
+      anchorTop: number;
+      anchorBottom: number;
+      thread: CommentThreadRailItem & {
+        visibleComments: CriticComment[];
+      };
+    };
+
+function getSuggestionTypeLabel(kind: CriticChangeKind) {
+  if (kind === "addition") return "Insertion";
+  if (kind === "deletion") return "Deletion";
+  return "Replacement";
+}
+
+function getSuggestionPreview(suggestion: CriticChangeRailItem) {
+  const oldText = suggestion.oldText.trim();
+  const newText = suggestion.newText.trim();
+
+  if (suggestion.kind === "addition") return newText || "Inserted text";
+  if (suggestion.kind === "deletion") return oldText || "Deleted text";
+  if (oldText && newText) return `${oldText} -> ${newText}`;
+  return oldText || newText || "Changed text";
+}
+
+function getSuggestionAuthor(change: CriticChangeAttrs) {
+  return change.authorType === "ai" ? "AI" : change.authorId || "Me";
+}
+
+export function DocumentReviewRail({
+  commentGroups,
+  comments,
+  suggestions,
+  selectedCommentId,
+  hoveredCommentId,
+  selectedChangeId,
+  hoveredChangeId,
+  contentHeight,
+  className,
+  onDeleteComment,
+  onUpdateComment,
+  onReplyComment,
+  onSelectComment,
+  onFocusComment,
+  onHoverComment,
+  onAcceptSuggestion,
+  onRejectSuggestion,
+  onReplySuggestion,
+  onSelectSuggestion,
+  onFocusSuggestion,
+  onHoverSuggestion,
+  pendingFocusCommentId = null,
+  onAutoFocusComment,
+}: DocumentReviewRailProps) {
+  const itemRefs = useRef(new Map<string, HTMLDivElement>());
+  const [itemHeights, setItemHeights] = useState<Record<string, number>>({});
+
+  const activeRootThreadId = useMemo(
+    () => getRootThreadIdForCommentId(selectedCommentId, comments),
+    [comments, selectedCommentId],
+  );
+
+  const suggestionCommentIds = useMemo(
+    () => new Set(suggestions.flatMap((suggestion) => suggestion.commentIds)),
+    [suggestions],
+  );
+
+  const visibleCommentThreads = useMemo(
+    () =>
+      buildCommentThreadRailItems(
+        commentGroups
+          .map((group) => ({
+            ...group,
+            commentIds: group.commentIds.filter(
+              (commentId) => !suggestionCommentIds.has(commentId),
+            ),
+          }))
+          .filter((group) => group.commentIds.length > 0),
+        comments,
+      )
+        .map((item) => {
+          const visibleComments = item.commentIds
+            .map((commentId) => comments.get(commentId))
+            .filter((comment): comment is CriticComment => Boolean(comment));
+
+          if (visibleComments.length === 0) return null;
+
+          return {
+            ...item,
+            visibleComments,
+          };
+        })
+        .filter(
+          (
+            item,
+          ): item is CommentThreadRailItem & {
+            visibleComments: CriticComment[];
+          } => Boolean(item),
+        ),
+    [commentGroups, comments, suggestionCommentIds],
+  );
+
+  const commentEntries = useMemo(
+    () =>
+      visibleCommentThreads.map((thread) => ({
+        type: "comment" as const,
+        key: thread.key,
+        anchorTop: thread.anchorTop,
+        anchorBottom: thread.anchorBottom,
+        thread,
+      })),
+    [visibleCommentThreads],
+  );
+
+  const suggestionEntries = useMemo(
+    () =>
+      suggestions.map((suggestion) => ({
+        type: "suggestion" as const,
+        key: suggestion.changeId,
+        anchorTop: suggestion.anchorTop,
+        anchorBottom: suggestion.anchorBottom,
+        suggestion,
+      })),
+    [suggestions],
+  );
+
+  const activeSuggestionIdForComment = useMemo(
+    () =>
+      selectedCommentId
+        ? (suggestions.find((suggestion) =>
+            suggestion.commentIds.includes(selectedCommentId),
+          )?.changeId ?? null)
+        : null,
+    [selectedCommentId, suggestions],
+  );
+
+  const layouts = useMemo(
+    () => {
+      const entries = [...suggestionEntries, ...commentEntries].sort(
+        (left, right) => left.anchorTop - right.anchorTop,
+      );
+      const activeKey =
+        selectedChangeId ?? activeSuggestionIdForComment ?? activeRootThreadId;
+
+      return resolveAnchoredRailLayouts(entries, itemHeights, activeKey);
+    },
+    [
+      activeRootThreadId,
+      activeSuggestionIdForComment,
+      commentEntries,
+      itemHeights,
+      selectedChangeId,
+      suggestionEntries,
+    ],
+  );
+
+  const setItemRef = useCallback((key: string, node: HTMLDivElement | null) => {
+    if (node) {
+      itemRefs.current.set(key, node);
+    } else {
+      itemRefs.current.delete(key);
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    if (layouts.length === 0) {
+      setItemHeights((current) =>
+        Object.keys(current).length === 0 ? current : {},
+      );
+      return;
+    }
+
+    const updateHeights = () => {
+      setItemHeights((current) => {
+        const next: Record<string, number> = {};
+        let changed = false;
+
+        for (const layout of layouts) {
+          const element = itemRefs.current.get(layout.key);
+          const measuredHeight = Math.ceil(
+            element?.getBoundingClientRect().height ?? 0,
+          );
+          const height =
+            measuredHeight > 0
+              ? Math.ceil(normalizeCommentMeasurement(measuredHeight, 1))
+              : (current[layout.key] ?? 0);
+          next[layout.key] = height;
+          if (current[layout.key] !== height) {
+            changed = true;
+          }
+        }
+
+        if (
+          !changed &&
+          Object.keys(current).length === Object.keys(next).length
+        ) {
+          return current;
+        }
+
+        return next;
+      });
+    };
+
+    updateHeights();
+
+    const resizeObserver = new ResizeObserver(() => {
+      updateHeights();
+    });
+
+    for (const layout of layouts) {
+      const element = itemRefs.current.get(layout.key);
+      if (element) {
+        resizeObserver.observe(element);
+      }
+    }
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [layouts]);
+
+  const railHeight =
+    Math.max(contentHeight, layouts.at(-1)?.railBottom ?? 0) + 24;
+
+  if (layouts.length === 0) {
+    return <aside className={cn("min-w-0", className)} aria-hidden="true" />;
+  }
+
+  return (
+    <aside className={cn("min-w-0", className)}>
+      <div className="relative" style={{ minHeight: railHeight }}>
+        {layouts.map((layout) => {
+          if (layout.type === "comment") {
+            const isSelected =
+              !!activeRootThreadId &&
+              layout.thread.rootCommentId === activeRootThreadId;
+            const isExpanded = isSelected;
+            const primaryCommentId =
+              getPreferredCommentId(
+                layout.thread.commentIds,
+                selectedCommentId,
+              ) ?? layout.thread.visibleComments[0]?.id;
+
+            return (
+              <div
+                key={layout.key}
+                ref={(node) => setItemRef(layout.key, node)}
+                data-comment-thread-container="true"
+                className={cn(
+                  "absolute left-0 right-0 rounded-xl border border-transparent bg-transparent shadow-none transition-all duration-200 ease-out will-change-transform",
+                  isSelected
+                    ? "border-[#DFDFDC] bg-white shadow-[0_20px_48px_rgba(57,47,38,0.14)]"
+                    : "",
+                  isSelected && "-translate-x-2",
+                  isExpanded ? "cursor-default" : "cursor-pointer",
+                )}
+                style={{ top: layout.railTop }}
+                onMouseEnter={() => {
+                  if (primaryCommentId) {
+                    onHoverComment(primaryCommentId);
+                  }
+                }}
+                onMouseLeave={() => onHoverComment(null)}
+                onClick={() => {
+                  if (isExpanded || !primaryCommentId) return;
+                  onFocusComment(primaryCommentId);
+                }}
+              >
+                <CommentEditorList
+                  comments={layout.thread.visibleComments}
+                  variant="rail"
+                  className={cn(!isExpanded && "pointer-events-none")}
+                  interactive={isExpanded}
+                  selectedCommentId={selectedCommentId}
+                  hoveredCommentId={hoveredCommentId}
+                  onDeleteComment={onDeleteComment}
+                  onUpdateComment={onUpdateComment}
+                  onReplyComment={onReplyComment}
+                  onSelectComment={onSelectComment}
+                  onFocusComment={onFocusComment}
+                  onHoverComment={onHoverComment}
+                  pendingFocusCommentId={pendingFocusCommentId}
+                  onAutoFocusComment={onAutoFocusComment}
+                />
+              </div>
+            );
+          }
+
+          const suggestion = layout.suggestion;
+          const isSelected = selectedChangeId === suggestion.changeId;
+          const isHovered = hoveredChangeId === suggestion.changeId;
+          const isExpanded = isSelected || suggestion.commentIds.length > 0;
+          const suggestionComments = suggestion.commentIds
+            .map((commentId) => comments.get(commentId))
+            .filter((comment): comment is CriticComment => Boolean(comment));
+
+          return (
+            <div
+              key={layout.key}
+              ref={(node) => setItemRef(layout.key, node)}
+              data-suggestion-thread-container="true"
+              className={cn(
+                "absolute left-0 right-0 rounded-xl border border-transparent bg-transparent px-4 py-3 shadow-none transition-all duration-200 ease-out will-change-transform",
+                isSelected
+                  ? "-translate-x-2 border-[#DFDFDC] bg-white shadow-[0_20px_48px_rgba(57,47,38,0.14)]"
+                  : "",
+                isHovered && !isSelected && "cursor-pointer",
+              )}
+              style={{ top: layout.railTop }}
+              onMouseEnter={() => onHoverSuggestion(suggestion.changeId)}
+              onMouseLeave={() => onHoverSuggestion(null)}
+              onPointerDown={() => onSelectSuggestion(suggestion.changeId)}
+              onClick={() => {
+                if (isSelected) return;
+                onFocusSuggestion(suggestion.changeId);
+              }}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-[11px] font-semibold tracking-[0.08em] text-stone-500 uppercase">
+                    {getSuggestionTypeLabel(suggestion.kind)}
+                  </div>
+                  <div className="mt-1 text-sm leading-5 text-slate-800">
+                    {getSuggestionPreview(suggestion)}
+                  </div>
+                  <div className="mt-1 truncate text-[11px] text-stone-400">
+                    {getSuggestionAuthor(suggestion.change)}
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-1">
+                  <button
+                    type="button"
+                    className="flex size-7 items-center justify-center rounded-full text-emerald-700 transition hover:bg-emerald-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
+                    aria-label="Accept suggestion"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onAcceptSuggestion(suggestion.changeId);
+                    }}
+                  >
+                    <Check className="size-4" />
+                  </button>
+                  <button
+                    type="button"
+                    className="flex size-7 items-center justify-center rounded-full text-rose-700 transition hover:bg-rose-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-300"
+                    aria-label="Reject suggestion"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onRejectSuggestion(suggestion.changeId);
+                    }}
+                  >
+                    <X className="size-4" />
+                  </button>
+                </div>
+              </div>
+              {isExpanded && suggestionComments.length > 0 ? (
+                <CommentEditorList
+                  comments={suggestionComments}
+                  variant="rail"
+                  className="mt-3 border-t border-slate-200/80 px-0 pt-3"
+                  selectedCommentId={selectedCommentId}
+                  hoveredCommentId={hoveredCommentId}
+                  onDeleteComment={onDeleteComment}
+                  onUpdateComment={onUpdateComment}
+                  onReplyComment={onReplyComment}
+                  onSelectComment={onSelectComment}
+                  onFocusComment={onFocusComment}
+                  onHoverComment={onHoverComment}
+                  pendingFocusCommentId={pendingFocusCommentId}
+                  onAutoFocusComment={onAutoFocusComment}
+                />
+              ) : null}
+              {isExpanded ? (
+                <button
+                  type="button"
+                  className="mt-3 inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium text-stone-500 transition hover:bg-[#DED8CE]/45 hover:text-stone-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-stone-300"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onReplySuggestion(suggestion.changeId);
+                  }}
+                >
+                  <Reply className="size-3.5" />
+                  Reply
+                </button>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </aside>
+  );
+}

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import type { DocumentEditorViewMode } from "./app-navigation";
 import { Button } from "./components/ui/button";
 import { cn } from "./lib/utils";
-import { PageCard } from "./PageCard";
+import { PageCard, type DocumentInteractionMode } from "./PageCard";
 import type { Page, StorageBackend } from "./storage";
 
 type SaveState = "idle" | "saving" | "error";
@@ -42,12 +42,23 @@ export function DocumentWorkspace({
   onOverwriteDocumentOnDisk,
   backend,
 }: DocumentWorkspaceProps) {
+  const [documentInteractionMode, setDocumentInteractionMode] =
+    useState<DocumentInteractionMode>("editing");
   const [documentHasComments, setDocumentHasComments] = useState(
-    () => !!documentPage?.content.includes("{>>"),
+    () =>
+      !!documentPage?.content.includes("{>>") ||
+      !!documentPage?.content.includes("{++") ||
+      !!documentPage?.content.includes("{--") ||
+      !!documentPage?.content.includes("{~~"),
   );
 
   useEffect(() => {
-    setDocumentHasComments(!!documentPage?.content.includes("{>>"));
+    setDocumentHasComments(
+      !!documentPage?.content.includes("{>>") ||
+        !!documentPage?.content.includes("{++") ||
+        !!documentPage?.content.includes("{--") ||
+        !!documentPage?.content.includes("{~~"),
+    );
   }, [documentPage]);
 
   return (
@@ -104,8 +115,25 @@ export function DocumentWorkspace({
             >
               {documentFilenameLabel}
             </div>
+            <label className="ml-auto flex shrink-0 items-center gap-1.5 rounded-[8px] border border-[#DFDFDC] bg-[#FFFDFC] px-2 py-1 text-[0.68rem] text-stone-600">
+              <span>Mode</span>
+              <select
+                value={documentInteractionMode}
+                className="bg-transparent text-[0.68rem] font-medium text-stone-800 outline-none"
+                aria-label="Document mode"
+                onChange={(event) =>
+                  setDocumentInteractionMode(
+                    event.target.value as DocumentInteractionMode,
+                  )
+                }
+              >
+                <option value="viewing">Viewing</option>
+                <option value="suggesting">Suggesting</option>
+                <option value="editing">Editing</option>
+              </select>
+            </label>
             {documentDiskChangeState !== "clean" ? (
-              <div className="ml-auto flex max-w-full shrink-0 items-center gap-1.5 rounded-[8px] border border-amber-200 bg-amber-50 px-2 py-1 text-[0.68rem] text-amber-900">
+              <div className="flex max-w-full shrink-0 items-center gap-1.5 rounded-[8px] border border-amber-200 bg-amber-50 px-2 py-1 text-[0.68rem] text-amber-900">
                 <span className="whitespace-nowrap">
                   {documentDiskChangeState === "conflict"
                     ? "Save conflict"
@@ -144,6 +172,7 @@ export function DocumentWorkspace({
               onSave={onSaveDocument}
               onSaveStateChange={onDocumentSaveStateChange}
               editorViewMode={documentEditorViewMode}
+              interactionMode={documentInteractionMode}
               backend={backend}
               onCommentRailPresenceChange={setDocumentHasComments}
               onDirtyStateChange={onDocumentDirtyStateChange}

--- a/packages/app/src/EditorContextMenu.tsx
+++ b/packages/app/src/EditorContextMenu.tsx
@@ -5,14 +5,19 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Bold,
   Code2,
+  Check,
   ExternalLink,
   Italic,
   Link2,
   List,
   ListOrdered,
   MessageSquarePlus,
+  Minus,
+  Plus,
   Quote,
+  Replace,
   Trash2,
+  X,
 } from "lucide-react";
 import {
   getAddCommentShortcutLabel,
@@ -25,6 +30,9 @@ interface EditorContextMenuProps {
   editor: Editor | null;
   backend: StorageBackend;
   onAddComment?: () => void;
+  onSuggestDeletion?: () => void;
+  onSuggestReplacement?: () => void;
+  onSuggestInsertion?: () => void;
   children: ReactNode;
 }
 
@@ -175,6 +183,9 @@ export function EditorContextMenu({
   editor,
   backend,
   onAddComment,
+  onSuggestDeletion,
+  onSuggestReplacement,
+  onSuggestInsertion,
   children,
 }: EditorContextMenuProps) {
   const [position, setPosition] = useState<MenuPosition | null>(null);
@@ -198,6 +209,10 @@ export function EditorContextMenu({
       isOrderedListActive: currentEditor?.isActive("orderedList") ?? false,
       isBlockquoteActive: currentEditor?.isActive("blockquote") ?? false,
       isLinkActive: currentEditor?.isActive("link") ?? false,
+      activeCriticChangeId:
+        (currentEditor?.getAttributes("criticChange").changeId as
+          | string
+          | null) ?? null,
       canToggleBold:
         currentEditor?.can().chain().focus().toggleBold().run() ?? false,
       canToggleItalic:
@@ -219,6 +234,7 @@ export function EditorContextMenu({
     isOrderedListActive: false,
     isBlockquoteActive: false,
     isLinkActive: false,
+    activeCriticChangeId: null,
     canToggleBold: false,
     canToggleItalic: false,
     canToggleCode: false,
@@ -237,10 +253,8 @@ export function EditorContextMenu({
 
   const updateSelectionActionPosition = useCallback(() => {
     if (
-      !editor ||
-      !onAddComment ||
-      !editor.isFocused ||
-      editor.state.selection.empty
+      !editor?.isFocused ||
+      (editor.state.selection.empty && !onSuggestInsertion)
     ) {
       setSelectionActionPosition(null);
       return;
@@ -274,7 +288,7 @@ export function EditorContextMenu({
       left: nextLeft,
       top: nextTop,
     });
-  }, [editor, onAddComment]);
+  }, [editor, onSuggestInsertion]);
 
   const updateLinkPopover = useCallback(() => {
     if (!editor || !containerRef.current || !editor.isActive("link")) {
@@ -602,11 +616,92 @@ export function EditorContextMenu({
               active={selectionMenuState.isLinkActive}
               onClick={openLinkPopover}
             />
+            <SelectionMenuButton
+              label="Suggest insertion"
+              icon={<Plus className="size-4" />}
+              disabled={!onSuggestInsertion}
+              onClick={() => {
+                onSuggestInsertion?.();
+                setSelectionActionPosition(null);
+              }}
+            />
+            <SelectionMenuButton
+              label="Suggest deletion"
+              icon={<Minus className="size-4" />}
+              disabled={!onSuggestDeletion || editor?.state.selection.empty}
+              onClick={() => {
+                onSuggestDeletion?.();
+                setSelectionActionPosition(null);
+              }}
+            />
+            <SelectionMenuButton
+              label="Suggest replacement"
+              icon={<Replace className="size-4" />}
+              disabled={!onSuggestReplacement || editor?.state.selection.empty}
+              onClick={() => {
+                onSuggestReplacement?.();
+                setSelectionActionPosition(null);
+              }}
+            />
           </div>
           <div className="my-2 h-px bg-slate-200/80" aria-hidden="true" />
+          {selectionMenuState.activeCriticChangeId ? (
+            <>
+              <div className="grid grid-cols-2 gap-1">
+                <button
+                  type="button"
+                  className="inline-flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-emerald-700 transition hover:bg-emerald-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                  }}
+                  onClick={() => {
+                    if (selectionMenuState.activeCriticChangeId) {
+                      editor
+                        ?.chain()
+                        .focus()
+                        .acceptCriticChange(
+                          selectionMenuState.activeCriticChangeId,
+                        )
+                        .run();
+                    }
+                    setSelectionActionPosition(null);
+                  }}
+                >
+                  <Check className="size-4" />
+                  <span>Accept</span>
+                </button>
+                <button
+                  type="button"
+                  className="inline-flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-rose-700 transition hover:bg-rose-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-300"
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                  }}
+                  onClick={() => {
+                    if (selectionMenuState.activeCriticChangeId) {
+                      editor
+                        ?.chain()
+                        .focus()
+                        .rejectCriticChange(
+                          selectionMenuState.activeCriticChangeId,
+                        )
+                        .run();
+                    }
+                    setSelectionActionPosition(null);
+                  }}
+                >
+                  <X className="size-4" />
+                  <span>Reject</span>
+                </button>
+              </div>
+              <div className="my-2 h-px bg-slate-200/80" aria-hidden="true" />
+            </>
+          ) : null}
           <button
             type="button"
             className="flex w-full items-center justify-between gap-3 rounded-xl px-3 py-2 text-left text-sm font-medium text-slate-700 transition hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
+            disabled={!onAddComment || editor?.state.selection.empty}
             onMouseDown={(event) => {
               event.preventDefault();
               event.stopPropagation();
@@ -726,6 +821,80 @@ export function EditorContextMenu({
               {shortcutLabel}
             </span>
           </button>
+          <button
+            type="button"
+            className="block w-full rounded-xl px-3 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={!editor || !onSuggestInsertion}
+            onClick={() => {
+              onSuggestInsertion?.();
+              close();
+            }}
+          >
+            Suggest insertion
+          </button>
+          <button
+            type="button"
+            className="block w-full rounded-xl px-3 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={!editor || editor.state.selection.empty}
+            onClick={() => {
+              onSuggestDeletion?.();
+              close();
+            }}
+          >
+            Suggest deletion
+          </button>
+          <button
+            type="button"
+            className="block w-full rounded-xl px-3 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={!editor || editor.state.selection.empty}
+            onClick={() => {
+              onSuggestReplacement?.();
+              close();
+            }}
+          >
+            Suggest replacement
+          </button>
+          {selectionMenuState.activeCriticChangeId ? (
+            <>
+              <div className="my-1 h-px bg-slate-100" aria-hidden="true" />
+              <button
+                type="button"
+                className="block w-full rounded-xl px-3 py-2 text-left text-sm text-emerald-700 transition hover:bg-emerald-50"
+                onClick={() => {
+                  if (selectionMenuState.activeCriticChangeId) {
+                    editor
+                      ?.chain()
+                      .focus()
+                      .acceptCriticChange(
+                        selectionMenuState.activeCriticChangeId,
+                      )
+                      .run();
+                  }
+                  close();
+                }}
+              >
+                Accept suggestion
+              </button>
+              <button
+                type="button"
+                className="block w-full rounded-xl px-3 py-2 text-left text-sm text-rose-700 transition hover:bg-rose-50"
+                onClick={() => {
+                  if (selectionMenuState.activeCriticChangeId) {
+                    editor
+                      ?.chain()
+                      .focus()
+                      .rejectCriticChange(
+                        selectionMenuState.activeCriticChangeId,
+                      )
+                      .run();
+                  }
+                  close();
+                }}
+              >
+                Reject suggestion
+              </button>
+            </>
+          ) : null}
           <button
             type="button"
             className="block w-full rounded-xl px-3 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-50"

--- a/packages/app/src/MarkdownCodeEditor.tsx
+++ b/packages/app/src/MarkdownCodeEditor.tsx
@@ -8,12 +8,14 @@ interface MarkdownCodeEditorProps {
   value: string;
   onChange: (value: string) => void;
   autoFocus?: boolean;
+  readOnly?: boolean;
 }
 
 export function MarkdownCodeEditor({
   value,
   onChange,
   autoFocus = false,
+  readOnly = false,
 }: MarkdownCodeEditorProps) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const editorViewRef = useRef<EditorView | null>(null);
@@ -37,6 +39,8 @@ export function MarkdownCodeEditor({
           basicSetup,
           markdown(),
           EditorView.lineWrapping,
+          EditorState.readOnly.of(readOnly),
+          EditorView.editable.of(!readOnly),
           EditorView.updateListener.of((update) => {
             if (!update.docChanged) return;
 
@@ -107,7 +111,7 @@ export function MarkdownCodeEditor({
       editorViewRef.current = null;
       view.destroy();
     };
-  }, [autoFocus]);
+  }, [autoFocus, readOnly]);
 
   useEffect(() => {
     const view = editorViewRef.current;

--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -3,13 +3,19 @@ import type { Editor } from "@tiptap/react";
 import { EditorContent, useEditor, useEditorState } from "@tiptap/react";
 import { TextSelection } from "@tiptap/pm/state";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Check, X } from "lucide-react";
 import { CommentEditorList } from "./CommentEditorList";
-import { DocumentCommentRail } from "./DocumentCommentRail";
 import {
+  DocumentReviewRail,
+  type CriticChangeRailItem,
+} from "./DocumentReviewRail";
+import {
+  createCriticChange,
   createCriticComment,
   criticMarkdownToEditorState,
   editorStateToCriticMarkdown,
   getCommentDescendantIds,
+  type CriticChangeAttrs,
   type CriticComment,
 } from "./critic-markup";
 import { getPreferredCommentId, parseCommentIds } from "./document-comments";
@@ -17,6 +23,7 @@ import { EditorContextMenu } from "./EditorContextMenu";
 import {
   commentHighlightPluginKey,
   createEditorExtensions,
+  criticChangeHighlightPluginKey,
 } from "./editor-extensions";
 import { cn } from "./lib/utils";
 import { MarkdownCodeEditor } from "./MarkdownCodeEditor";
@@ -26,6 +33,7 @@ import { useCommentAnchorLayout } from "./useCommentAnchorLayout";
 
 type SaveState = "idle" | "saving" | "error";
 type EditorViewMode = "rich-text" | "code";
+export type DocumentInteractionMode = "viewing" | "suggesting" | "editing";
 
 interface PageCardProps {
   page: Page;
@@ -34,6 +42,7 @@ interface PageCardProps {
   onSave: (id: string, content: string) => Promise<void>;
   onSaveStateChange?: (state: SaveState) => void;
   editorViewMode?: EditorViewMode;
+  interactionMode?: DocumentInteractionMode;
   backend: StorageBackend;
   onEditorReady?: (editor: Editor | null) => void;
   onCommentRailPresenceChange?: (hasCommentRailSpace: boolean) => void;
@@ -50,6 +59,7 @@ interface PageCardEditorSurfaceProps {
   onSave: (id: string, content: string) => Promise<void>;
   onSaveStateChange: (state: SaveState) => void;
   editorViewMode: EditorViewMode;
+  interactionMode: DocumentInteractionMode;
   backend: StorageBackend;
   onEditorReady?: (editor: Editor | null) => void;
   onCommentRailPresenceChange?: (hasCommentRailSpace: boolean) => void;
@@ -65,6 +75,7 @@ interface RichTextEditorSurfaceProps {
   focusRequestKey: string | null;
   sourceMarkdown: string;
   onMarkdownChange: (markdown: string) => void;
+  interactionMode: DocumentInteractionMode;
   backend: StorageBackend;
   onEditorReady?: (editor: Editor | null) => void;
   onCommentRailPresenceChange?: (hasCommentRailSpace: boolean) => void;
@@ -73,7 +84,16 @@ interface RichTextEditorSurfaceProps {
 interface CodeEditorSurfaceProps {
   markdown: string;
   hasCommentRailSpace: boolean;
+  interactionMode: DocumentInteractionMode;
   onMarkdownChange: (markdown: string) => void;
+}
+
+interface DraftSuggestionState {
+  type: "insertion" | "replacement";
+  from: number;
+  to: number;
+  sourceText: string;
+  text: string;
 }
 
 function areCommentIdListsEqual(
@@ -238,11 +258,221 @@ function addCommentIdsToAnchor(
   return nextCommentIds;
 }
 
+function getDocumentCriticChanges(
+  editor: Editor,
+): Array<Pick<CriticChangeAttrs, "changeId">> {
+  const changes = new Map<string, Pick<CriticChangeAttrs, "changeId">>();
+
+  editor.state.doc.descendants((node) => {
+    if (!node.isText) return;
+
+    for (const mark of node.marks) {
+      if (mark.type.name !== "criticChange") continue;
+      if (typeof mark.attrs.changeId !== "string") continue;
+
+      changes.set(mark.attrs.changeId, { changeId: mark.attrs.changeId });
+    }
+  });
+
+  return [...changes.values()];
+}
+
+function getDocumentCriticChangeRailItems(
+  editor: Editor | null,
+  comments: ReadonlyMap<string, CriticComment>,
+): CriticChangeRailItem[] {
+  if (!editor) return [];
+
+  const changes = new Map<string, CriticChangeRailItem>();
+  const anchors = new Map<
+    string,
+    {
+      anchorTop: number;
+      anchorBottom: number;
+    }
+  >();
+  let editorElement: HTMLElement;
+
+  try {
+    editorElement = editor.view.dom as HTMLElement;
+  } catch {
+    return [];
+  }
+
+  const changeElements = editorElement.querySelectorAll<HTMLElement>(
+    ".critic-change[data-critic-change-id]",
+  );
+  const editorRect = editorElement.getBoundingClientRect();
+
+  for (const element of changeElements) {
+    const changeId = element.dataset.criticChangeId;
+    if (!changeId) continue;
+
+    const rect = element.getBoundingClientRect();
+    const existing = anchors.get(changeId);
+    const anchorTop = rect.top - editorRect.top;
+    const anchorBottom = rect.bottom - editorRect.top;
+
+    if (existing) {
+      existing.anchorTop = Math.min(existing.anchorTop, anchorTop);
+      existing.anchorBottom = Math.max(existing.anchorBottom, anchorBottom);
+    } else {
+      anchors.set(changeId, {
+        anchorTop,
+        anchorBottom,
+      });
+    }
+  }
+
+  editor.state.doc.descendants((node) => {
+    if (!node.isText || !node.text) return;
+
+    const changeMark = node.marks.find(
+      (mark) =>
+        mark.type.name === "criticChange" &&
+        typeof mark.attrs.changeId === "string",
+    );
+    if (!changeMark) return;
+
+    const change = changeMark.attrs as CriticChangeAttrs;
+    const changeId = change.changeId;
+    const kind =
+      change.kind === "substitution-new" ? "substitution-old" : change.kind;
+    const existing =
+      changes.get(changeId) ??
+      ({
+        changeId,
+        change,
+        kind,
+        oldText: "",
+        newText: "",
+        commentIds: [],
+        anchorTop: anchors.get(changeId)?.anchorTop ?? 0,
+        anchorBottom: anchors.get(changeId)?.anchorBottom ?? 24,
+      } satisfies CriticChangeRailItem);
+
+    existing.change = {
+      ...change,
+      kind,
+    };
+    existing.kind = kind;
+
+    if (change.kind === "addition" || change.kind === "substitution-new") {
+      existing.newText += node.text;
+    } else {
+      existing.oldText += node.text;
+    }
+
+    for (const mark of node.marks) {
+      if (mark.type.name !== "commentRef") continue;
+      if (!Array.isArray(mark.attrs.commentIds)) continue;
+
+      existing.commentIds = [
+        ...new Set([...existing.commentIds, ...mark.attrs.commentIds]),
+      ];
+    }
+
+    changes.set(changeId, existing);
+  });
+
+  for (const change of changes.values()) {
+    const rootCommentIds = [...comments.values()]
+      .filter((comment) => comment.parentCommentId === change.changeId)
+      .map((comment) => comment.id);
+    const descendantIds = rootCommentIds.flatMap((commentId) =>
+      getCommentDescendantIds(commentId, comments),
+    );
+
+    change.commentIds = [
+      ...new Set([...change.commentIds, ...rootCommentIds, ...descendantIds]),
+    ];
+  }
+
+  return [...changes.values()].sort(
+    (left, right) => left.anchorTop - right.anchorTop,
+  );
+}
+
+function getCriticChangeRange(editor: Editor | null, changeId: string) {
+  if (!editor) return null;
+
+  let from: number | null = null;
+  let to: number | null = null;
+
+  editor.state.doc.descendants((node, pos) => {
+    if (!node.isText) return;
+
+    const hasChange = node.marks.some(
+      (mark) =>
+        mark.type.name === "criticChange" && mark.attrs.changeId === changeId,
+    );
+    if (!hasChange) return;
+
+    from = from == null ? pos : Math.min(from, pos);
+    to = to == null ? pos + node.nodeSize : Math.max(to, pos + node.nodeSize);
+  });
+
+  if (from == null || to == null) return null;
+
+  return { from, to };
+}
+
+function addCommentIdsToCriticChange(
+  editor: Editor | null,
+  changeId: string,
+  commentIdsToAdd: string[],
+) {
+  if (!editor) return false;
+
+  const commentMarkType = editor.state.schema.marks.commentRef;
+  if (!commentMarkType) return false;
+
+  let found = false;
+  const tr = editor.state.tr;
+
+  editor.state.doc.descendants((node, pos) => {
+    if (!node.isText) return;
+
+    const hasChange = node.marks.some(
+      (mark) =>
+        mark.type.name === "criticChange" && mark.attrs.changeId === changeId,
+    );
+    if (!hasChange) return;
+
+    found = true;
+    const existingMark = node.marks.find(
+      (mark) => mark.type === commentMarkType,
+    );
+    const existingCommentIds = Array.isArray(existingMark?.attrs.commentIds)
+      ? existingMark.attrs.commentIds
+      : [];
+    const nextCommentIds = [
+      ...new Set([...existingCommentIds, ...commentIdsToAdd]),
+    ];
+    const from = pos;
+    const to = pos + node.nodeSize;
+
+    if (existingMark) {
+      tr.removeMark(from, to, commentMarkType);
+    }
+    tr.addMark(
+      from,
+      to,
+      commentMarkType.create({ commentIds: nextCommentIds }),
+    );
+  });
+
+  if (!found) return false;
+
+  editor.view.dispatch(tr);
+  return true;
+}
+
 export function shouldDismissCommentThread(target: EventTarget | null) {
   if (!(target instanceof Element)) return true;
 
   return !target.closest(
-    '[data-comment-thread-container="true"], .comment-anchor[data-comment-ids]',
+    '[data-comment-thread-container="true"], [data-suggestion-thread-container="true"], .comment-anchor[data-comment-ids], .critic-change[data-critic-change-id]',
   );
 }
 
@@ -252,18 +482,29 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
   focusRequestKey,
   sourceMarkdown,
   onMarkdownChange,
+  interactionMode,
   backend,
   onEditorReady,
   onCommentRailPresenceChange,
 }: RichTextEditorSurfaceProps) {
   const editorRef = useRef<Editor | null>(null);
+  const criticChangeFrameRef = useRef<number | null>(null);
+  const interactionModeRef = useRef<DocumentInteractionMode>(interactionMode);
   const commentsRef = useRef<Map<string, CriticComment>>(new Map());
   const lastFocusRequestKeyRef = useRef<string | null>(null);
   const selectedCommentIdRef = useRef<string | null>(null);
+  const selectedChangeIdRef = useRef<string | null>(null);
   const [selectedCommentId, setSelectedCommentId] = useState<string | null>(
     null,
   );
   const [hoveredCommentId, setHoveredCommentId] = useState<string | null>(null);
+  const [selectedChangeId, setSelectedChangeId] = useState<string | null>(null);
+  const [hoveredChangeId, setHoveredChangeId] = useState<string | null>(null);
+  const [criticChanges, setCriticChanges] = useState<CriticChangeRailItem[]>(
+    [],
+  );
+  const [draftSuggestion, setDraftSuggestion] =
+    useState<DraftSuggestionState | null>(null);
   const [pendingFocusCommentId, setPendingFocusCommentId] = useState<
     string | null
   >(null);
@@ -289,8 +530,14 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
   }, [comments]);
 
   useEffect(() => {
-    onCommentRailPresenceChange?.(comments.size > 0);
-  }, [comments.size, onCommentRailPresenceChange]);
+    interactionModeRef.current = interactionMode;
+  }, [interactionMode]);
+
+  useEffect(() => {
+    onCommentRailPresenceChange?.(
+      comments.size > 0 || criticChanges.length > 0,
+    );
+  }, [comments.size, criticChanges.length, onCommentRailPresenceChange]);
 
   const emitMarkdownChange = useCallback(
     (doc?: JSONContent, nextComments?: Map<string, CriticComment>) => {
@@ -339,6 +586,30 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
     [backend, resolveFileUrl],
   );
 
+  const refreshCriticChanges = useCallback(() => {
+    if (criticChangeFrameRef.current != null) {
+      cancelAnimationFrame(criticChangeFrameRef.current);
+    }
+
+    criticChangeFrameRef.current = requestAnimationFrame(() => {
+      criticChangeFrameRef.current = null;
+      setCriticChanges(
+        getDocumentCriticChangeRailItems(
+          editorRef.current,
+          commentsRef.current,
+        ),
+      );
+    });
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (criticChangeFrameRef.current != null) {
+        cancelAnimationFrame(criticChangeFrameRef.current);
+      }
+    };
+  }, []);
+
   const editor = useEditor(
     {
       extensions: createEditorExtensions("Start writing..."),
@@ -363,9 +634,92 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
           void insertFiles(files);
           return true;
         },
+        handleTextInput: (view, from, to, text) => {
+          if (interactionModeRef.current !== "suggesting") return false;
+          if (!text) return false;
+
+          const currentEditor = editorRef.current;
+          if (!currentEditor) return false;
+
+          const tr = view.state.tr;
+
+          if (from !== to) {
+            const oldChange = createCriticChange(
+              "substitution-old",
+              undefined,
+              {
+                existingChanges: getDocumentCriticChanges(currentEditor),
+              },
+            );
+            tr.addMark(
+              from,
+              to,
+              view.state.schema.marks.criticChange.create(oldChange),
+            );
+            tr.insert(
+              to,
+              view.state.schema.text(text, [
+                view.state.schema.marks.criticChange.create({
+                  ...oldChange,
+                  kind: "substitution-new",
+                }),
+              ]),
+            );
+          } else {
+            const change = createCriticChange("addition", undefined, {
+              existingChanges: getDocumentCriticChanges(currentEditor),
+            });
+            tr.insert(
+              from,
+              view.state.schema.text(text, [
+                view.state.schema.marks.criticChange.create(change),
+              ]),
+            );
+          }
+
+          view.dispatch(tr.scrollIntoView());
+          return true;
+        },
+        handleKeyDown: (view, event) => {
+          if (interactionModeRef.current !== "suggesting") return false;
+          if (event.key !== "Backspace" && event.key !== "Delete") return false;
+
+          const currentEditor = editorRef.current;
+          if (!currentEditor) return false;
+
+          const { selection } = view.state;
+          let from = selection.from;
+          let to = selection.to;
+
+          if (selection.empty) {
+            if (event.key === "Backspace") {
+              from = Math.max(1, selection.from - 1);
+            } else {
+              to = Math.min(view.state.doc.content.size, selection.to + 1);
+            }
+          }
+
+          if (from === to) return false;
+
+          event.preventDefault();
+          const change = createCriticChange("deletion", undefined, {
+            existingChanges: getDocumentCriticChanges(currentEditor),
+          });
+          view.dispatch(
+            view.state.tr
+              .addMark(
+                from,
+                to,
+                view.state.schema.marks.criticChange.create(change),
+              )
+              .scrollIntoView(),
+          );
+          return true;
+        },
       },
       onUpdate: ({ editor: currentEditor }) => {
         emitMarkdownChange(currentEditor.getJSON());
+        refreshCriticChanges();
       },
     },
     [page.id],
@@ -373,6 +727,11 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
 
   editorRef.current = editor;
   selectedCommentIdRef.current = selectedCommentId;
+  selectedChangeIdRef.current = selectedChangeId;
+
+  useEffect(() => {
+    editor?.setEditable(interactionMode !== "viewing", false);
+  }, [editor, interactionMode]);
 
   const activeCommentIds =
     useEditorState({
@@ -401,19 +760,23 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
 
   useEffect(() => {
     if (!editor) return;
-    if (editor.isFocused) return;
 
     commentsRef.current = parsedContent.comments;
     setComments(parsedContent.comments);
     setSelectedCommentId(null);
     setHoveredCommentId(null);
+    setSelectedChangeId(null);
+    setHoveredChangeId(null);
+    setDraftSuggestion(null);
     setPendingFocusCommentId(null);
 
     const nextDoc = parsedContent.doc;
     if (JSON.stringify(editor.getJSON()) !== JSON.stringify(nextDoc)) {
       editor.commands.setContent(nextDoc, { emitUpdate: false });
     }
-  }, [editor, parsedContent]);
+
+    refreshCriticChanges();
+  }, [editor, parsedContent, refreshCriticChanges]);
 
   useEffect(() => {
     if (!editor || !selected || !focusRequestKey) return;
@@ -433,7 +796,8 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
     if (hoveredCommentId && !comments.has(hoveredCommentId)) {
       setHoveredCommentId(null);
     }
-  }, [comments, hoveredCommentId, selectedCommentId]);
+    refreshCriticChanges();
+  }, [comments, hoveredCommentId, refreshCriticChanges, selectedCommentId]);
 
   useEffect(() => {
     if (!editor) return;
@@ -449,6 +813,19 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
       }),
     );
   }, [editor, hoveredCommentId, selectedCommentId]);
+
+  useEffect(() => {
+    if (!editor) return;
+
+    const effectiveHoveredChangeId = selectedChangeId ? hoveredChangeId : null;
+
+    editor.view.dispatch(
+      editor.state.tr.setMeta(criticChangeHighlightPluginKey, {
+        selectedChangeId,
+        hoveredChangeId: effectiveHoveredChangeId,
+      }),
+    );
+  }, [editor, hoveredChangeId, selectedChangeId]);
 
   useEffect(() => {
     if (!editor) return;
@@ -506,12 +883,57 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
   }, [editor]);
 
   useEffect(() => {
+    if (!editor) return;
+
+    const changeElements = editor.view.dom.querySelectorAll<HTMLElement>(
+      ".critic-change[data-critic-change-id]",
+    );
+    const cleanupCallbacks: Array<() => void> = [];
+
+    for (const element of changeElements) {
+      const changeId = element.dataset.criticChangeId;
+      if (!changeId) continue;
+
+      const handleMouseEnter = () => {
+        setHoveredChangeId(changeId);
+      };
+
+      const handleMouseLeave = () => {
+        setHoveredChangeId((current) =>
+          current === changeId ? null : current,
+        );
+      };
+
+      const handleClick = () => {
+        setSelectedChangeId(changeId);
+      };
+
+      element.addEventListener("mouseenter", handleMouseEnter);
+      element.addEventListener("mouseleave", handleMouseLeave);
+      element.addEventListener("click", handleClick);
+      cleanupCallbacks.push(() => {
+        element.removeEventListener("mouseenter", handleMouseEnter);
+        element.removeEventListener("mouseleave", handleMouseLeave);
+        element.removeEventListener("click", handleClick);
+      });
+    }
+
+    return () => {
+      for (const cleanup of cleanupCallbacks) {
+        cleanup();
+      }
+    };
+  }, [editor]);
+
+  useEffect(() => {
     const handleDocumentPointerDown = (event: PointerEvent) => {
-      if (!selectedCommentIdRef.current) return;
+      if (!selectedCommentIdRef.current && !selectedChangeIdRef.current) return;
       if (!shouldDismissCommentThread(event.target)) return;
 
       setSelectedCommentId(null);
       setHoveredCommentId(null);
+      setSelectedChangeId(null);
+      setHoveredChangeId(null);
       setPendingFocusCommentId(null);
     };
 
@@ -552,6 +974,124 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
       measureLayout();
     });
   }, [emitMarkdownChange, measureLayout]);
+
+  const handleSuggestDeletion = useCallback(() => {
+    const currentEditor = editorRef.current;
+    if (!currentEditor || currentEditor.state.selection.empty) return;
+
+    const change = createCriticChange("deletion", undefined, {
+      existingChanges: getDocumentCriticChanges(currentEditor),
+    });
+
+    currentEditor.chain().focus().setCriticChange(change).run();
+    emitMarkdownChange(currentEditor.getJSON());
+    refreshCriticChanges();
+  }, [emitMarkdownChange, refreshCriticChanges]);
+
+  const handleSuggestReplacement = useCallback(() => {
+    const currentEditor = editorRef.current;
+    if (!currentEditor || currentEditor.state.selection.empty) return;
+
+    const { from, to } = currentEditor.state.selection;
+    setDraftSuggestion({
+      type: "replacement",
+      from,
+      to,
+      sourceText: currentEditor.state.doc.textBetween(from, to, "\n"),
+      text: "",
+    });
+  }, []);
+
+  const applyDraftSuggestion = useCallback(() => {
+    const currentEditor = editorRef.current;
+    if (!currentEditor || !draftSuggestion) return;
+
+    const nextText = draftSuggestion.text;
+    if (!nextText) {
+      setDraftSuggestion(null);
+      return;
+    }
+
+    if (draftSuggestion.type === "insertion") {
+      const change = createCriticChange("addition", undefined, {
+        existingChanges: getDocumentCriticChanges(currentEditor),
+      });
+
+      currentEditor
+        .chain()
+        .focus()
+        .insertContentAt(draftSuggestion.from, {
+          type: "text",
+          text: nextText,
+          marks: [
+            {
+              type: "criticChange",
+              attrs: change,
+            },
+          ],
+        })
+        .run();
+      setSelectedChangeId(change.changeId);
+      setDraftSuggestion(null);
+      emitMarkdownChange(currentEditor.getJSON());
+      refreshCriticChanges();
+      return;
+    }
+
+    const change = createCriticChange("substitution-old", undefined, {
+      existingChanges: getDocumentCriticChanges(currentEditor),
+    });
+    const replacementChange: CriticChangeAttrs = {
+      ...change,
+      kind: "substitution-new",
+    };
+
+    currentEditor
+      .chain()
+      .focus()
+      .setTextSelection({ from: draftSuggestion.from, to: draftSuggestion.to })
+      .setCriticChange(change)
+      .insertContentAt(draftSuggestion.to, {
+        type: "text",
+        text: nextText,
+        marks: [
+          {
+            type: "criticChange",
+            attrs: replacementChange,
+          },
+        ],
+      })
+      .run();
+    setSelectedChangeId(change.changeId);
+    setDraftSuggestion(null);
+    emitMarkdownChange(currentEditor.getJSON());
+    refreshCriticChanges();
+  }, [draftSuggestion, emitMarkdownChange, refreshCriticChanges]);
+
+  const handleSuggestInsertion = useCallback(() => {
+    const currentEditor = editorRef.current;
+    if (!currentEditor) return;
+
+    const { from } = currentEditor.state.selection;
+    const before = currentEditor.state.doc.textBetween(
+      Math.max(1, from - 24),
+      from,
+      " ",
+    );
+    const after = currentEditor.state.doc.textBetween(
+      from,
+      Math.min(currentEditor.state.doc.content.size, from + 24),
+      " ",
+    );
+
+    setDraftSuggestion({
+      type: "insertion",
+      from,
+      to: from,
+      sourceText: `${before}▮${after}`.trim(),
+      text: "",
+    });
+  }, []);
 
   const updateComment = useCallback(
     (commentId: string, updater: (comment: CriticComment) => CriticComment) => {
@@ -602,6 +1142,102 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
     [emitMarkdownChange, measureLayout],
   );
 
+  const removeSuggestionComments = useCallback(
+    (changeId: string, currentEditor: Editor) => {
+      const directCommentIds = [...commentsRef.current.values()]
+        .filter((comment) => comment.parentCommentId === changeId)
+        .map((comment) => comment.id);
+      const commentIdsToDelete = [
+        ...directCommentIds,
+        ...directCommentIds.flatMap((commentId) =>
+          getCommentDescendantIds(commentId, commentsRef.current),
+        ),
+      ];
+
+      if (commentIdsToDelete.length === 0) return commentsRef.current;
+
+      const nextComments = new Map(commentsRef.current);
+      for (const id of commentIdsToDelete) {
+        nextComments.delete(id);
+      }
+
+      const chain = currentEditor.chain().focus();
+      for (const id of commentIdsToDelete) {
+        chain.removeCommentId(id);
+      }
+      chain.run();
+
+      commentsRef.current = nextComments;
+      setComments(nextComments);
+      return nextComments;
+    },
+    [],
+  );
+
+  const acceptSuggestion = useCallback(
+    (changeId: string) => {
+      const currentEditor = editorRef.current;
+      if (!currentEditor) return;
+
+      currentEditor.chain().focus().acceptCriticChange(changeId).run();
+      const nextComments = removeSuggestionComments(changeId, currentEditor);
+      setSelectedChangeId((current) => (current === changeId ? null : current));
+      setHoveredChangeId((current) => (current === changeId ? null : current));
+      emitMarkdownChange(currentEditor.getJSON(), nextComments);
+      refreshCriticChanges();
+    },
+    [emitMarkdownChange, refreshCriticChanges, removeSuggestionComments],
+  );
+
+  const rejectSuggestion = useCallback(
+    (changeId: string) => {
+      const currentEditor = editorRef.current;
+      if (!currentEditor) return;
+
+      currentEditor.chain().focus().rejectCriticChange(changeId).run();
+      const nextComments = removeSuggestionComments(changeId, currentEditor);
+      setSelectedChangeId((current) => (current === changeId ? null : current));
+      setHoveredChangeId((current) => (current === changeId ? null : current));
+      emitMarkdownChange(currentEditor.getJSON(), nextComments);
+      refreshCriticChanges();
+    },
+    [emitMarkdownChange, refreshCriticChanges, removeSuggestionComments],
+  );
+
+  const replyToSuggestion = useCallback(
+    (changeId: string) => {
+      const currentEditor = editorRef.current;
+      if (!currentEditor) return;
+
+      const comment = createCriticComment(
+        {
+          parentCommentId: changeId,
+        },
+        {
+          existingComments: commentsRef.current.values(),
+        },
+      );
+      if (!addCommentIdsToCriticChange(currentEditor, changeId, [comment.id])) {
+        return;
+      }
+
+      const nextComments = new Map(commentsRef.current);
+      nextComments.set(comment.id, comment);
+      commentsRef.current = nextComments;
+      setComments(nextComments);
+      setSelectedChangeId(changeId);
+      setSelectedCommentId(comment.id);
+      setHoveredCommentId(null);
+      setPendingFocusCommentId(comment.id);
+      emitMarkdownChange(currentEditor.getJSON(), nextComments);
+      refreshCriticChanges();
+      requestAnimationFrame(() => {
+        measureLayout();
+      });
+    },
+    [emitMarkdownChange, measureLayout, refreshCriticChanges],
+  );
+
   const deleteComment = useCallback(
     (commentId: string) => {
       const currentEditor = editorRef.current;
@@ -646,6 +1282,11 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
     setSelectedCommentId(commentId);
   }, []);
 
+  const selectSuggestion = useCallback((changeId: string) => {
+    setSelectedChangeId(changeId);
+    setSelectedCommentId(null);
+  }, []);
+
   const focusComment = useCallback((commentId: string) => {
     const currentEditor = editorRef.current;
     if (!currentEditor) return;
@@ -668,7 +1309,25 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
     currentEditor.commands.focus(undefined, { scrollIntoView: false });
   }, []);
 
-  const hasComments = comments.size > 0;
+  const focusSuggestion = useCallback((changeId: string) => {
+    const currentEditor = editorRef.current;
+    if (!currentEditor) return;
+
+    setSelectedChangeId(changeId);
+    setSelectedCommentId(null);
+
+    const range = getCriticChangeRange(currentEditor, changeId);
+    if (!range) return;
+
+    currentEditor.commands.focus(undefined, { scrollIntoView: false });
+    currentEditor.view.dispatch(
+      currentEditor.state.tr.setSelection(
+        TextSelection.create(currentEditor.state.doc, range.from, range.to),
+      ),
+    );
+  }, []);
+
+  const hasReviewRail = comments.size > 0 || criticChanges.length > 0;
   const activeComments = activeCommentIds
     .map((commentId) => comments.get(commentId))
     .filter((comment): comment is CriticComment => Boolean(comment));
@@ -680,7 +1339,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
       <div
         className={cn(
           "document-page-shell",
-          !hasComments && "document-page-shell-no-comments",
+          !hasReviewRail && "document-page-shell-no-comments",
         )}
       >
         <div className="document-page-main min-w-0">
@@ -709,25 +1368,119 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
             />
           ) : null}
           <div className="pb-24">
+            {draftSuggestion ? (
+              <div
+                data-suggestion-thread-container="true"
+                className="mb-3 rounded-[0.75rem] border border-[#DFDFDC] bg-white px-4 py-3 shadow-[0_16px_40px_rgba(57,47,38,0.08)]"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="text-[11px] font-semibold tracking-[0.08em] text-stone-500 uppercase">
+                      {draftSuggestion.type === "replacement"
+                        ? "Replacement"
+                        : "Insertion"}
+                    </div>
+                    <div className="mt-1 text-sm leading-5 text-slate-700">
+                      {draftSuggestion.sourceText || "Current cursor position"}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    className="flex size-7 shrink-0 items-center justify-center rounded-full text-stone-500 transition hover:bg-stone-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-stone-300"
+                    aria-label="Cancel suggestion"
+                    onClick={() => setDraftSuggestion(null)}
+                  >
+                    <X className="size-4" />
+                  </button>
+                </div>
+                <textarea
+                  value={draftSuggestion.text}
+                  rows={2}
+                  className="mt-3 min-h-16 w-full resize-y rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm leading-6 text-slate-800 outline-none transition focus:border-emerald-300 focus:ring-2 focus:ring-emerald-100"
+                  placeholder={
+                    draftSuggestion.type === "replacement"
+                      ? "Replacement text"
+                      : "Inserted text"
+                  }
+                  onChange={(event) => {
+                    setDraftSuggestion((current) =>
+                      current
+                        ? {
+                            ...current,
+                            text: event.target.value,
+                          }
+                        : current,
+                    );
+                  }}
+                  onKeyDown={(event) => {
+                    if (
+                      (event.metaKey || event.ctrlKey) &&
+                      event.key.toLowerCase() === "enter"
+                    ) {
+                      event.preventDefault();
+                      applyDraftSuggestion();
+                    }
+                  }}
+                />
+                <div className="mt-3 flex justify-end gap-2">
+                  <button
+                    type="button"
+                    className="inline-flex h-8 items-center gap-1 rounded-lg px-3 text-sm font-medium text-stone-600 transition hover:bg-stone-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-stone-300"
+                    onClick={() => setDraftSuggestion(null)}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    className="inline-flex h-8 items-center gap-1 rounded-lg bg-emerald-600 px-3 text-sm font-medium text-white transition hover:bg-emerald-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 disabled:cursor-not-allowed disabled:opacity-50"
+                    disabled={!draftSuggestion.text}
+                    onClick={applyDraftSuggestion}
+                  >
+                    <Check className="size-4" />
+                    Suggest
+                  </button>
+                </div>
+              </div>
+            ) : null}
             <div
               className={cn(contentCardClass, "px-10 py-10 sm:px-14 sm:py-14")}
             >
               <EditorContextMenu
                 editor={editor}
                 backend={backend}
-                onAddComment={handleAddComment}
+                onAddComment={
+                  interactionMode === "viewing" ? undefined : handleAddComment
+                }
+                onSuggestDeletion={
+                  interactionMode === "viewing"
+                    ? undefined
+                    : handleSuggestDeletion
+                }
+                onSuggestReplacement={
+                  interactionMode === "viewing"
+                    ? undefined
+                    : handleSuggestReplacement
+                }
+                onSuggestInsertion={
+                  interactionMode === "viewing"
+                    ? undefined
+                    : handleSuggestInsertion
+                }
               >
                 <EditorContent editor={editor} />
               </EditorContextMenu>
             </div>
           </div>
         </div>
-        <DocumentCommentRail
+        <DocumentReviewRail
           className="document-comment-rail"
           commentGroups={commentGroups}
           comments={comments}
+          suggestions={criticChanges}
           selectedCommentId={selectedCommentId}
           hoveredCommentId={hoveredCommentId}
+          selectedChangeId={selectedChangeId}
+          hoveredChangeId={hoveredChangeId}
           contentHeight={contentHeight}
           onDeleteComment={deleteComment}
           onUpdateComment={(commentId, nextContent) => {
@@ -740,6 +1493,12 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
           onSelectComment={selectComment}
           onFocusComment={focusComment}
           onHoverComment={setHoveredCommentId}
+          onAcceptSuggestion={acceptSuggestion}
+          onRejectSuggestion={rejectSuggestion}
+          onReplySuggestion={replyToSuggestion}
+          onSelectSuggestion={selectSuggestion}
+          onFocusSuggestion={focusSuggestion}
+          onHoverSuggestion={setHoveredChangeId}
           pendingFocusCommentId={pendingFocusCommentId}
           onAutoFocusComment={(commentId) => {
             setPendingFocusCommentId((current) =>
@@ -755,6 +1514,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
 const CodeEditorSurface = memo(function CodeEditorSurface({
   markdown,
   hasCommentRailSpace,
+  interactionMode,
   onMarkdownChange,
 }: CodeEditorSurfaceProps) {
   return (
@@ -771,6 +1531,7 @@ const CodeEditorSurface = memo(function CodeEditorSurface({
               <MarkdownCodeEditor
                 value={markdown}
                 onChange={onMarkdownChange}
+                readOnly={interactionMode === "viewing"}
                 autoFocus
               />
             </div>
@@ -794,6 +1555,7 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
   onSave,
   onSaveStateChange,
   editorViewMode,
+  interactionMode,
   backend,
   onEditorReady,
   onCommentRailPresenceChange,
@@ -921,7 +1683,11 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
     };
   }, []);
 
-  const hasCommentRailSpace = markdown.includes("{>>");
+  const hasCommentRailSpace =
+    markdown.includes("{>>") ||
+    markdown.includes("{++") ||
+    markdown.includes("{--") ||
+    markdown.includes("{~~");
 
   useEffect(() => {
     if (editorViewMode !== "code") return;
@@ -933,19 +1699,26 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
       <CodeEditorSurface
         markdown={markdown}
         hasCommentRailSpace={hasCommentRailSpace}
+        interactionMode={interactionMode}
         onMarkdownChange={handleMarkdownChange}
       />
     );
   }
 
+  const effectiveRichTextSourceMarkdown =
+    !localDirtyRef.current && !recentMarkdownRef.current.has(page.content)
+      ? page.content
+      : richTextSourceMarkdown;
+
   return (
     <RichTextEditorSurface
-      key={`${page.id}:${richTextSourceVersion}`}
+      key={`${page.id}:${richTextSourceVersion}:${effectiveRichTextSourceMarkdown}`}
       page={page}
       selected={selected}
       focusRequestKey={focusRequestKey}
-      sourceMarkdown={richTextSourceMarkdown}
+      sourceMarkdown={effectiveRichTextSourceMarkdown}
       onMarkdownChange={handleMarkdownChange}
+      interactionMode={interactionMode}
       onCommentRailPresenceChange={onCommentRailPresenceChange}
       backend={backend}
       onEditorReady={onEditorReady}
@@ -960,6 +1733,7 @@ export function PageCard({
   onSave,
   onSaveStateChange,
   editorViewMode = "rich-text",
+  interactionMode = "editing",
   backend,
   onEditorReady,
   onCommentRailPresenceChange,
@@ -983,6 +1757,7 @@ export function PageCard({
         onSave={onSave}
         onSaveStateChange={setSaveState}
         editorViewMode={editorViewMode}
+        interactionMode={interactionMode}
         backend={backend}
         onEditorReady={onEditorReady}
         onCommentRailPresenceChange={onCommentRailPresenceChange}

--- a/packages/app/src/critic-markup/index.ts
+++ b/packages/app/src/critic-markup/index.ts
@@ -8,7 +8,11 @@ import {
   type Tokens,
 } from "marked";
 import type TurndownService from "turndown";
-import { createEditorExtensions } from "../editor-extensions";
+import {
+  createEditorExtensions,
+  type CriticChangeAttrs,
+  type CriticChangeKind,
+} from "../editor-extensions";
 import {
   createMarkedRenderer,
   createTurndownService,
@@ -29,6 +33,8 @@ export interface CriticCommentThread {
   replies: CriticCommentThread[];
 }
 
+export type { CriticChangeAttrs, CriticChangeKind };
+
 interface CriticCommentToken {
   type: "criticCommentAnchor";
   raw: string;
@@ -36,10 +42,25 @@ interface CriticCommentToken {
   tokens: Token[];
 }
 
+interface CriticChangeToken {
+  type: "criticChange";
+  raw: string;
+  change: CriticChangeAttrs;
+  commentIds: string[];
+  tokens?: Token[];
+  oldTokens?: Token[];
+  newTokens?: Token[];
+}
+
 const extensions = createEditorExtensions("");
 const criticCommentAnchorPattern = /^\{==([\s\S]+?)==\}/;
 const criticCommentBlockPattern =
   /^\{>>([\s\S]*?)<<\}(?:(\{@([\s\S]+?)@\})|(\{(?:\s*[A-Za-z][A-Za-z0-9_-]*="(?:\\[\s\S]|[^"\\])*")+\s*\}))?/;
+const criticAdditionPattern = /^\{\+\+([\s\S]+?)\+\+\}/;
+const criticDeletionPattern = /^\{--([\s\S]+?)--\}/;
+const criticSubstitutionPattern = /^\{~~([\s\S]+?)~>([\s\S]+?)~~\}/;
+const attributeMetadataBlockPattern =
+  /^\{(?:\s*[A-Za-z][A-Za-z0-9_-]*="(?:\\[\s\S]|[^"\\])*")+\s*\}/;
 const metadataAttributePattern =
   /([A-Za-z][A-Za-z0-9_-]*)="((?:\\[\s\S]|[^"\\])*)"/g;
 
@@ -136,6 +157,16 @@ function serializeMetadata(comment: CriticComment): string {
     .join(" ")}}`;
 }
 
+function serializeChangeMetadata(change: CriticChangeAttrs): string {
+  return serializeMetadata({
+    id: change.changeId,
+    content: "",
+    createdAt: change.createdAt,
+    authorType: change.authorType,
+    authorId: change.authorId,
+  });
+}
+
 export function createNextCommentId(
   existingComments: Iterable<Pick<CriticComment, "id">>,
 ): string {
@@ -154,6 +185,24 @@ export function createNextCommentId(
   return `c${maxId + 1}`;
 }
 
+export function createNextChangeId(
+  existingChanges: Iterable<Pick<CriticChangeAttrs, "changeId">>,
+): string {
+  let maxId = 0;
+
+  for (const change of existingChanges) {
+    const match = change.changeId.match(/^s(\d+)$/);
+    if (!match) continue;
+
+    const parsed = Number.parseInt(match[1] || "0", 10);
+    if (parsed > maxId) {
+      maxId = parsed;
+    }
+  }
+
+  return `s${maxId + 1}`;
+}
+
 function createCommentWithContext(
   partial?: Partial<CriticComment>,
   existingComments: Iterable<Pick<CriticComment, "id">> = [],
@@ -167,6 +216,35 @@ function createCommentWithContext(
     authorType,
     authorId: partial?.authorId ?? (authorType === "ai" ? null : "user"),
     parentCommentId: partial?.parentCommentId ?? null,
+  };
+}
+
+function createChangeWithContext(
+  kind: CriticChangeKind,
+  partial?: Partial<CriticChangeAttrs>,
+  existingChanges: Iterable<Pick<CriticChangeAttrs, "changeId">> = [],
+): CriticChangeAttrs {
+  const authorType = partial?.authorType ?? "user";
+
+  return {
+    kind,
+    changeId: partial?.changeId ?? createNextChangeId(existingChanges),
+    createdAt: partial?.createdAt ?? new Date().toISOString(),
+    authorType,
+    authorId: partial?.authorId ?? (authorType === "ai" ? null : "user"),
+  };
+}
+
+function parseChangeMetadata(
+  metadataText?: string,
+): Partial<CriticChangeAttrs> {
+  const parsed = parseAttributeMetadata(metadataText);
+
+  return {
+    changeId: parsed.id,
+    createdAt: parsed.createdAt,
+    authorType: parsed.authorType,
+    authorId: parsed.authorId,
   };
 }
 
@@ -236,6 +314,20 @@ function getOrderedAnchorComments(
     .filter((comment): comment is CriticComment => Boolean(comment));
 
   return flattenCommentThreads(buildCommentThreads(visibleComments));
+}
+
+function serializeCommentBlocks(
+  commentIds: string[],
+  comments: ReadonlyMap<string, CriticComment>,
+): string {
+  const orderedComments = getOrderedAnchorComments(commentIds, comments);
+  let result = "";
+
+  for (const comment of orderedComments) {
+    result += `{>>${comment.content}<<}${serializeMetadata(comment)}`;
+  }
+
+  return result;
 }
 
 export function getCommentDescendantIds(
@@ -325,6 +417,179 @@ function tokenizeCriticCommentAnchor(
   };
 }
 
+function getTrailingAttributeMetadata(src: string, offset: number) {
+  const match = src.slice(offset).match(attributeMetadataBlockPattern);
+
+  if (!match) {
+    return {
+      metadataText: undefined,
+      raw: "",
+    };
+  }
+
+  return {
+    metadataText: match[0],
+    raw: match[0],
+  };
+}
+
+function tokenizeCriticCommentBlocks(
+  src: string,
+  offset: number,
+  existingComments: Iterable<Pick<CriticComment, "id">>,
+) {
+  let raw = "";
+  let nextOffset = offset;
+  const parsedComments: CriticComment[] = [];
+
+  while (nextOffset < src.length) {
+    const nextMatch = src.slice(nextOffset).match(criticCommentBlockPattern);
+    if (!nextMatch) break;
+
+    const [, commentText, , legacyMetadataText, attributeMetadataText] =
+      nextMatch;
+    const comment = createCommentWithContext(
+      {
+        ...parseMetadata(legacyMetadataText, attributeMetadataText),
+        content: commentText,
+      },
+      [...existingComments, ...parsedComments],
+    );
+    parsedComments.push(comment);
+    raw += nextMatch[0];
+    nextOffset += nextMatch[0].length;
+  }
+
+  return {
+    raw,
+    comments: parsedComments,
+  };
+}
+
+function tokenizeCriticChange(
+  lexer: TokenizerThis["lexer"],
+  src: string,
+  existingChanges: Iterable<Pick<CriticChangeAttrs, "changeId">>,
+  existingComments: Iterable<Pick<CriticComment, "id">>,
+):
+  | {
+      token: CriticChangeToken;
+      comments: CriticComment[];
+    }
+  | undefined {
+  const additionMatch = src.match(criticAdditionPattern);
+
+  if (additionMatch) {
+    const [, text] = additionMatch;
+    const metadata = getTrailingAttributeMetadata(src, additionMatch[0].length);
+    const trailingComments = tokenizeCriticCommentBlocks(
+      src,
+      additionMatch[0].length + metadata.raw.length,
+      existingComments,
+    );
+    const change = createChangeWithContext(
+      "addition",
+      parseChangeMetadata(metadata.metadataText),
+      existingChanges,
+    );
+
+    return {
+      token: {
+        type: "criticChange",
+        raw: additionMatch[0] + metadata.raw + trailingComments.raw,
+        change,
+        commentIds: trailingComments.comments.map((comment) => comment.id),
+        tokens: lexer.inlineTokens(text),
+      },
+      comments: trailingComments.comments,
+    };
+  }
+
+  const deletionMatch = src.match(criticDeletionPattern);
+
+  if (deletionMatch) {
+    const [, text] = deletionMatch;
+    const metadata = getTrailingAttributeMetadata(src, deletionMatch[0].length);
+    const trailingComments = tokenizeCriticCommentBlocks(
+      src,
+      deletionMatch[0].length + metadata.raw.length,
+      existingComments,
+    );
+    const change = createChangeWithContext(
+      "deletion",
+      parseChangeMetadata(metadata.metadataText),
+      existingChanges,
+    );
+
+    return {
+      token: {
+        type: "criticChange",
+        raw: deletionMatch[0] + metadata.raw + trailingComments.raw,
+        change,
+        commentIds: trailingComments.comments.map((comment) => comment.id),
+        tokens: lexer.inlineTokens(text),
+      },
+      comments: trailingComments.comments,
+    };
+  }
+
+  const substitutionMatch = src.match(criticSubstitutionPattern);
+
+  if (substitutionMatch) {
+    const [, oldText, newText] = substitutionMatch;
+    const metadata = getTrailingAttributeMetadata(
+      src,
+      substitutionMatch[0].length,
+    );
+    const trailingComments = tokenizeCriticCommentBlocks(
+      src,
+      substitutionMatch[0].length + metadata.raw.length,
+      existingComments,
+    );
+    const change = createChangeWithContext(
+      "substitution-old",
+      parseChangeMetadata(metadata.metadataText),
+      existingChanges,
+    );
+
+    return {
+      token: {
+        type: "criticChange",
+        raw: substitutionMatch[0] + metadata.raw + trailingComments.raw,
+        change,
+        commentIds: trailingComments.comments.map((comment) => comment.id),
+        oldTokens: lexer.inlineTokens(oldText),
+        newTokens: lexer.inlineTokens(newText),
+      },
+      comments: trailingComments.comments,
+    };
+  }
+
+  return undefined;
+}
+
+function renderCriticChangeSpan(
+  change: CriticChangeAttrs,
+  content: string,
+  kind: CriticChangeKind = change.kind,
+  commentIds: string[] = [],
+) {
+  const by = change.authorType === "ai" ? "AI" : change.authorId || "user";
+  const changeSpan = `<span data-critic-change-kind="${escapeHtml(kind)}" data-critic-change-id="${escapeHtml(
+    change.changeId,
+  )}" data-critic-change-by="${escapeHtml(by)}" data-critic-change-at="${escapeHtml(
+    change.createdAt,
+  )}">${content}</span>`;
+
+  if (commentIds.length === 0) {
+    return changeSpan;
+  }
+
+  return `<span data-comment-ids="${escapeHtml(
+    JSON.stringify(commentIds),
+  )}">${changeSpan}</span>`;
+}
+
 function addCriticCommentRule(
   service: TurndownService,
   comments: Map<string, CriticComment>,
@@ -348,23 +613,169 @@ function addCriticCommentRule(
         return content;
       }
 
-      const orderedComments = getOrderedAnchorComments(commentIds, comments);
-      if (orderedComments.length === 0) return content;
-
-      const [firstComment, ...remainingComments] = orderedComments;
-      let result = `{==${content}==}{>>${firstComment.content}<<}${serializeMetadata(firstComment)}`;
-
-      for (const comment of remainingComments) {
-        result += `{>>${comment.content}<<}${serializeMetadata(comment)}`;
+      const criticChangeElement = (node as HTMLElement).querySelector(
+        "span[data-critic-change-kind]",
+      );
+      if (criticChangeElement instanceof HTMLElement) {
+        return serializeCriticChangeElement(
+          service,
+          criticChangeElement,
+          service.turndown(criticChangeElement.innerHTML).trim(),
+          comments,
+          commentIds,
+        );
       }
 
-      return result;
+      const commentBlocks = serializeCommentBlocks(commentIds, comments);
+      if (!commentBlocks) return content;
+
+      return `{==${content}==}${commentBlocks}`;
+    },
+  });
+}
+
+function getElementChangeAttrs(element: HTMLElement): CriticChangeAttrs | null {
+  const kind = element.getAttribute("data-critic-change-kind");
+  const changeId = element.getAttribute("data-critic-change-id");
+  const createdAt = element.getAttribute("data-critic-change-at");
+
+  if (
+    kind !== "addition" &&
+    kind !== "deletion" &&
+    kind !== "substitution-old" &&
+    kind !== "substitution-new"
+  ) {
+    return null;
+  }
+
+  if (!changeId || !createdAt) return null;
+
+  const rawBy = element.getAttribute("data-critic-change-by") || "user";
+  const authorType = rawBy.toUpperCase() === "AI" ? "ai" : "user";
+
+  return {
+    kind,
+    changeId,
+    createdAt,
+    authorType,
+    authorId: authorType === "ai" ? null : rawBy,
+  };
+}
+
+function isPairedSubstitutionElement(
+  element: Element | null,
+  kind: CriticChangeKind,
+  changeId: string,
+) {
+  return (
+    element instanceof HTMLElement &&
+    element.getAttribute("data-critic-change-kind") === kind &&
+    element.getAttribute("data-critic-change-id") === changeId
+  );
+}
+
+function getElementCommentIds(element: HTMLElement): string[] {
+  const commentIdsText = element.getAttribute("data-comment-ids");
+  if (!commentIdsText) return [];
+
+  try {
+    const parsed = JSON.parse(commentIdsText) as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((id): id is string => typeof id === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function getChangeCommentBlocks(
+  element: HTMLElement,
+  comments: Map<string, CriticComment>,
+  extraCommentIds: string[] = [],
+) {
+  return serializeCommentBlocks(
+    [...new Set([...getElementCommentIds(element), ...extraCommentIds])],
+    comments,
+  );
+}
+
+function serializeCriticChangeElement(
+  service: TurndownService,
+  element: HTMLElement,
+  content: string,
+  comments: Map<string, CriticComment>,
+  extraCommentIds: string[] = [],
+) {
+  const change = getElementChangeAttrs(element);
+
+  if (!change) return content;
+
+  const commentBlocks = getChangeCommentBlocks(
+    element,
+    comments,
+    extraCommentIds,
+  );
+  const metadata = serializeChangeMetadata(change);
+
+  if (change.kind === "addition") {
+    return `{++${content}++}${metadata}${commentBlocks}`;
+  }
+
+  if (change.kind === "deletion") {
+    return `{--${content}--}${metadata}${commentBlocks}`;
+  }
+
+  if (change.kind === "substitution-new") {
+    return isPairedSubstitutionElement(
+      element.previousElementSibling,
+      "substitution-old",
+      change.changeId,
+    )
+      ? ""
+      : `{++${content}++}${serializeChangeMetadata({
+          ...change,
+          kind: "addition",
+        })}${commentBlocks}`;
+  }
+
+  const nextElement = element.nextElementSibling;
+
+  if (
+    nextElement instanceof HTMLElement &&
+    isPairedSubstitutionElement(
+      nextElement,
+      "substitution-new",
+      change.changeId,
+    )
+  ) {
+    const replacement = service.turndown(nextElement.innerHTML).trim();
+    return `{~~${content}~>${replacement}~~}${metadata}${commentBlocks}`;
+  }
+
+  return `{--${content}--}${serializeChangeMetadata({
+    ...change,
+    kind: "deletion",
+  })}${commentBlocks}`;
+}
+
+function addCriticChangeRule(
+  service: TurndownService,
+  comments: Map<string, CriticComment>,
+) {
+  service.addRule("criticChange", {
+    filter: (node) =>
+      node.nodeName === "SPAN" &&
+      (node as HTMLElement).hasAttribute("data-critic-change-kind"),
+    replacement(content, node) {
+      const element = node as HTMLElement;
+      return serializeCriticChangeElement(service, element, content, comments);
     },
   });
 }
 
 function createCriticMarked(markdownOptions?: MarkdownOptions) {
   const comments = new Map<string, CriticComment>();
+  const changes = new Map<string, CriticChangeAttrs>();
   const renderer = createMarkedRenderer(markdownOptions);
   const parser = new Marked({
     gfm: true,
@@ -401,6 +812,69 @@ function createCriticMarked(markdownOptions?: MarkdownOptions) {
         },
         childTokens: ["tokens"],
       } satisfies TokenizerAndRendererExtension,
+      {
+        name: "criticChange",
+        level: "inline",
+        start(src: string) {
+          const starts = ["{++", "{--", "{~~"]
+            .map((marker) => src.indexOf(marker))
+            .filter((index) => index >= 0);
+
+          return starts.length > 0 ? Math.min(...starts) : undefined;
+        },
+        tokenizer(this: TokenizerThis, src: string) {
+          const result = tokenizeCriticChange(
+            this.lexer,
+            src,
+            changes.values(),
+            comments.values(),
+          );
+          if (!result) return undefined;
+
+          for (const comment of result.comments) {
+            comments.set(comment.id, comment);
+          }
+          changes.set(result.token.change.changeId, result.token.change);
+          return result.token;
+        },
+        renderer(this: RendererThis, token: Tokens.Generic) {
+          const criticToken = token as CriticChangeToken;
+
+          if (criticToken.change.kind === "substitution-old") {
+            const oldContent = this.parser.parseInline(
+              criticToken.oldTokens ?? [],
+            );
+            const newContent = this.parser.parseInline(
+              criticToken.newTokens ?? [],
+            );
+            const substitutionHtml = `${renderCriticChangeSpan(
+              criticToken.change,
+              oldContent,
+              "substitution-old",
+            )}${renderCriticChangeSpan(
+              criticToken.change,
+              newContent,
+              "substitution-new",
+            )}`;
+
+            if (criticToken.commentIds.length === 0) {
+              return substitutionHtml;
+            }
+
+            return `<span data-comment-ids="${escapeHtml(
+              JSON.stringify(criticToken.commentIds),
+            )}">${substitutionHtml}</span>`;
+          }
+
+          return renderCriticChangeSpan(
+            criticToken.change,
+            this.parser.parseInline(criticToken.tokens ?? []),
+            criticToken.change.kind,
+            criticToken.commentIds,
+          );
+        },
+        childTokens: ["tokens", "oldTokens", "newTokens"],
+      } satisfies TokenizerAndRendererExtension,
     ],
   });
 
@@ -425,6 +899,7 @@ export function editorStateToCriticMarkdown(
   const html = generateHTML(doc, extensions);
   const service = createTurndownService();
   addCriticCommentRule(service, comments);
+  addCriticChangeRule(service, comments);
   return `${service.turndown(html).trimEnd()}\n`;
 }
 
@@ -435,4 +910,14 @@ export function createCriticComment(
   },
 ): CriticComment {
   return createCommentWithContext(partial, options?.existingComments);
+}
+
+export function createCriticChange(
+  kind: CriticChangeKind,
+  partial?: Partial<CriticChangeAttrs>,
+  options?: {
+    existingChanges?: Iterable<Pick<CriticChangeAttrs, "changeId">>;
+  },
+): CriticChangeAttrs {
+  return createChangeWithContext(kind, partial, options?.existingChanges);
 }

--- a/packages/app/src/document-comments.ts
+++ b/packages/app/src/document-comments.ts
@@ -38,6 +38,18 @@ interface CommentThreadRailLayout extends CommentThreadRailItem {
   height: number;
 }
 
+interface AnchoredRailItem {
+  key: string;
+  anchorTop: number;
+  anchorBottom: number;
+}
+
+export type AnchoredRailLayout<T extends AnchoredRailItem> = T & {
+  railTop: number;
+  railBottom: number;
+  height: number;
+};
+
 interface CommentAnchorElementLike {
   dataset: {
     commentIds?: string;
@@ -237,23 +249,22 @@ export function resolveCommentRailLayouts(
   });
 }
 
-export function resolveCommentThreadRailLayouts(
-  items: CommentThreadRailItem[],
+export function resolveAnchoredRailLayouts<T extends AnchoredRailItem>(
+  items: T[],
   heights: Record<string, number>,
-  selectedRootThreadId: string | null,
+  activeKey: string | null,
   gap = 16,
-): CommentThreadRailLayout[] {
+  defaultHeight = 120,
+): Array<AnchoredRailLayout<T>> {
   if (items.length === 0) return [];
 
   const activeIndex = Math.max(
     0,
-    selectedRootThreadId
-      ? items.findIndex((item) => item.rootCommentId === selectedRootThreadId)
-      : 0,
+    activeKey ? items.findIndex((item) => item.key === activeKey) : 0,
   );
 
-  const resolved = new Array<CommentThreadRailLayout>(items.length);
-  const getHeight = (item: CommentThreadRailItem) => heights[item.key] ?? 120;
+  const resolved = new Array<AnchoredRailLayout<T>>(items.length);
+  const getHeight = (item: T) => heights[item.key] ?? defaultHeight;
 
   const activeItem = items[activeIndex] ?? items[0];
   if (!activeItem) return [];
@@ -301,4 +312,24 @@ export function resolveCommentThreadRailLayouts(
   }
 
   return resolved;
+}
+
+export function resolveCommentThreadRailLayouts(
+  items: CommentThreadRailItem[],
+  heights: Record<string, number>,
+  selectedRootThreadId: string | null,
+  gap = 16,
+): CommentThreadRailLayout[] {
+  const activeItem =
+    selectedRootThreadId == null
+      ? null
+      : (items.find((item) => item.rootCommentId === selectedRootThreadId) ??
+        null);
+
+  return resolveAnchoredRailLayouts(
+    items,
+    heights,
+    activeItem?.key ?? null,
+    gap,
+  );
 }

--- a/packages/app/src/editor-extensions.ts
+++ b/packages/app/src/editor-extensions.ts
@@ -24,7 +24,27 @@ declare module "@tiptap/core" {
       removeCommentId: (commentId: string) => ReturnType;
       unsetCommentRef: () => ReturnType;
     };
+    criticChange: {
+      setCriticChange: (attributes: CriticChangeAttrs) => ReturnType;
+      unsetCriticChange: () => ReturnType;
+      acceptCriticChange: (changeId: string) => ReturnType;
+      rejectCriticChange: (changeId: string) => ReturnType;
+    };
   }
+}
+
+export type CriticChangeKind =
+  | "addition"
+  | "deletion"
+  | "substitution-old"
+  | "substitution-new";
+
+export interface CriticChangeAttrs {
+  kind: CriticChangeKind;
+  changeId: string;
+  authorType?: "user" | "ai";
+  authorId?: string | null;
+  createdAt: string;
 }
 
 const CommentRef = Mark.create({
@@ -126,6 +146,215 @@ const CommentRef = Mark.create({
   },
 });
 
+function isCriticChangeKind(value: unknown): value is CriticChangeKind {
+  return (
+    value === "addition" ||
+    value === "deletion" ||
+    value === "substitution-old" ||
+    value === "substitution-new"
+  );
+}
+
+function readCriticChangeAttrs(element: HTMLElement): CriticChangeAttrs | null {
+  const kind = element.getAttribute("data-critic-change-kind");
+  const changeId = element.getAttribute("data-critic-change-id");
+  const createdAt = element.getAttribute("data-critic-change-at");
+
+  if (!isCriticChangeKind(kind) || !changeId || !createdAt) {
+    return null;
+  }
+
+  const rawBy = element.getAttribute("data-critic-change-by") || "user";
+  const authorType = rawBy.toUpperCase() === "AI" ? "ai" : "user";
+
+  return {
+    kind,
+    changeId,
+    authorType,
+    authorId: authorType === "ai" ? null : rawBy,
+    createdAt,
+  };
+}
+
+function collectCriticChangeRanges(doc: ProseMirrorNode, changeId: string) {
+  const markType = doc.type.schema.marks.criticChange;
+  const ranges: Array<{
+    from: number;
+    to: number;
+    kind: CriticChangeKind;
+    mark: ProseMirrorMark;
+  }> = [];
+
+  if (!markType) return ranges;
+
+  doc.descendants((node, pos) => {
+    if (!node.isText) return;
+
+    const mark = node.marks.find(
+      (candidate) =>
+        candidate.type === markType &&
+        candidate.attrs.changeId === changeId &&
+        isCriticChangeKind(candidate.attrs.kind),
+    );
+
+    if (!mark) return;
+
+    const kind = mark.attrs.kind as CriticChangeKind;
+    const previous = ranges[ranges.length - 1];
+
+    if (
+      previous &&
+      previous.to === pos &&
+      previous.kind === kind &&
+      previous.mark.eq(mark)
+    ) {
+      previous.to = pos + node.nodeSize;
+      return;
+    }
+
+    ranges.push({
+      from: pos,
+      to: pos + node.nodeSize,
+      kind,
+      mark,
+    });
+  });
+
+  return ranges;
+}
+
+const CriticChange = Mark.create({
+  name: "criticChange",
+  priority: 1090,
+  inclusive: false,
+  spanning: true,
+
+  addAttributes() {
+    return {
+      kind: {
+        default: "addition",
+        parseHTML: (element) =>
+          readCriticChangeAttrs(element as HTMLElement)?.kind ?? "addition",
+        renderHTML: (attributes) => ({
+          "data-critic-change-kind": attributes.kind,
+        }),
+      },
+      changeId: {
+        default: null,
+        parseHTML: (element) =>
+          readCriticChangeAttrs(element as HTMLElement)?.changeId ?? null,
+        renderHTML: (attributes) =>
+          attributes.changeId
+            ? { "data-critic-change-id": attributes.changeId }
+            : {},
+      },
+      authorType: {
+        default: "user",
+        parseHTML: (element) =>
+          readCriticChangeAttrs(element as HTMLElement)?.authorType ?? "user",
+        renderHTML: () => ({}),
+      },
+      authorId: {
+        default: "user",
+        parseHTML: (element) =>
+          readCriticChangeAttrs(element as HTMLElement)?.authorId ?? "user",
+        renderHTML: (attributes) => ({
+          "data-critic-change-by":
+            attributes.authorType === "ai"
+              ? "AI"
+              : attributes.authorId || "user",
+        }),
+      },
+      createdAt: {
+        default: null,
+        parseHTML: (element) =>
+          readCriticChangeAttrs(element as HTMLElement)?.createdAt ?? null,
+        renderHTML: (attributes) =>
+          attributes.createdAt
+            ? { "data-critic-change-at": attributes.createdAt }
+            : {},
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "span[data-critic-change-kind]" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "span",
+      mergeAttributes(HTMLAttributes, {
+        class: `critic-change critic-change-${HTMLAttributes["data-critic-change-kind"]}`,
+      }),
+      0,
+    ];
+  },
+
+  addCommands() {
+    return {
+      setCriticChange:
+        (attributes) =>
+        ({ commands }) =>
+          commands.setMark(this.name, attributes),
+      unsetCriticChange:
+        () =>
+        ({ commands }) =>
+          commands.unsetMark(this.name),
+      acceptCriticChange:
+        (changeId) =>
+        ({ state, dispatch }) => {
+          const markType = state.schema.marks.criticChange;
+          if (!markType) return false;
+
+          const ranges = collectCriticChangeRanges(state.doc, changeId);
+          if (ranges.length === 0) return false;
+
+          const tr = state.tr;
+
+          for (const range of [...ranges].reverse()) {
+            if (
+              range.kind === "deletion" ||
+              range.kind === "substitution-old"
+            ) {
+              tr.delete(range.from, range.to);
+            } else {
+              tr.removeMark(range.from, range.to, markType);
+            }
+          }
+
+          if (dispatch) dispatch(tr);
+          return true;
+        },
+      rejectCriticChange:
+        (changeId) =>
+        ({ state, dispatch }) => {
+          const markType = state.schema.marks.criticChange;
+          if (!markType) return false;
+
+          const ranges = collectCriticChangeRanges(state.doc, changeId);
+          if (ranges.length === 0) return false;
+
+          const tr = state.tr;
+
+          for (const range of [...ranges].reverse()) {
+            if (
+              range.kind === "addition" ||
+              range.kind === "substitution-new"
+            ) {
+              tr.delete(range.from, range.to);
+            } else {
+              tr.removeMark(range.from, range.to, markType);
+            }
+          }
+
+          if (dispatch) dispatch(tr);
+          return true;
+        },
+    };
+  },
+});
+
 interface CommentHighlightMeta {
   selectedCommentId: string | null;
   hoveredCommentId: string | null;
@@ -135,8 +364,19 @@ interface CommentHighlightPluginState extends CommentHighlightMeta {
   decorations: DecorationSet;
 }
 
+interface CriticChangeHighlightMeta {
+  selectedChangeId: string | null;
+  hoveredChangeId: string | null;
+}
+
+interface CriticChangeHighlightPluginState extends CriticChangeHighlightMeta {
+  decorations: DecorationSet;
+}
+
 export const commentHighlightPluginKey =
   new PluginKey<CommentHighlightPluginState>("commentHighlight");
+export const criticChangeHighlightPluginKey =
+  new PluginKey<CriticChangeHighlightPluginState>("criticChangeHighlight");
 
 function createCommentHighlightDecorations(
   doc: ProseMirrorNode,
@@ -144,6 +384,7 @@ function createCommentHighlightDecorations(
   hoveredCommentId: string | null,
 ) {
   const commentMarkType = doc.type.schema.marks.commentRef;
+  const changeMarkType = doc.type.schema.marks.criticChange;
   const decorations: Decoration[] = [];
 
   if (!commentMarkType) {
@@ -175,6 +416,13 @@ function createCommentHighlightDecorations(
       classNames.push("comment-decoration-active");
     } else if (isHovered) {
       classNames.push("comment-decoration-hovered");
+    }
+
+    if (
+      changeMarkType &&
+      node.marks.some((mark) => mark.type === changeMarkType)
+    ) {
+      classNames.push("comment-decoration-on-critic-change");
     }
 
     decorations.push(
@@ -236,6 +484,107 @@ const CommentHighlight = Extension.create({
         props: {
           decorations: (state) =>
             commentHighlightPluginKey.getState(state)?.decorations ?? null,
+        },
+      }),
+    ];
+  },
+});
+
+function createCriticChangeHighlightDecorations(
+  doc: ProseMirrorNode,
+  selectedChangeId: string | null,
+  hoveredChangeId: string | null,
+) {
+  const changeMarkType = doc.type.schema.marks.criticChange;
+  const decorations: Decoration[] = [];
+
+  if (!changeMarkType) {
+    return DecorationSet.create(doc, decorations);
+  }
+
+  doc.descendants((node: ProseMirrorNode, pos: number) => {
+    if (!node.isText) return;
+
+    const changeIds = [
+      ...new Set(
+        node.marks.flatMap((mark: ProseMirrorMark) =>
+          mark.type === changeMarkType &&
+          typeof mark.attrs.changeId === "string"
+            ? [mark.attrs.changeId]
+            : [],
+        ),
+      ),
+    ];
+
+    if (changeIds.length === 0) return;
+
+    const isSelected =
+      !!selectedChangeId && changeIds.includes(selectedChangeId);
+    const isHovered = !!hoveredChangeId && changeIds.includes(hoveredChangeId);
+
+    if (!isSelected && !isHovered) return;
+
+    decorations.push(
+      Decoration.inline(pos, pos + node.nodeSize, {
+        class: isSelected
+          ? "critic-change-decoration-active"
+          : "critic-change-decoration-hovered",
+      }),
+    );
+  });
+
+  return DecorationSet.create(doc, decorations);
+}
+
+const CriticChangeHighlight = Extension.create({
+  name: "criticChangeHighlight",
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin<CriticChangeHighlightPluginState>({
+        key: criticChangeHighlightPluginKey,
+        state: {
+          init: (_, state) => ({
+            selectedChangeId: null,
+            hoveredChangeId: null,
+            decorations: createCriticChangeHighlightDecorations(
+              state.doc,
+              null,
+              null,
+            ),
+          }),
+          apply: (tr, pluginState) => {
+            const meta = tr.getMeta(criticChangeHighlightPluginKey) as
+              | CriticChangeHighlightMeta
+              | undefined;
+
+            if (!meta && !tr.docChanged) {
+              return pluginState;
+            }
+
+            const selectedChangeId =
+              meta !== undefined
+                ? meta.selectedChangeId
+                : pluginState.selectedChangeId;
+            const hoveredChangeId =
+              meta !== undefined
+                ? meta.hoveredChangeId
+                : pluginState.hoveredChangeId;
+
+            return {
+              selectedChangeId,
+              hoveredChangeId,
+              decorations: createCriticChangeHighlightDecorations(
+                tr.doc,
+                selectedChangeId,
+                hoveredChangeId,
+              ),
+            };
+          },
+        },
+        props: {
+          decorations: (state) =>
+            criticChangeHighlightPluginKey.getState(state)?.decorations ?? null,
         },
       }),
     ];
@@ -307,7 +656,9 @@ export function createEditorExtensions(placeholder: string) {
       nested: true,
     }),
     CommentRef,
+    CriticChange,
     CommentHighlight,
+    CriticChangeHighlight,
     MarkdownImage.configure({
       allowBase64: true,
       inline: false,

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -115,12 +115,45 @@
     background-color: #ffd000;
   }
 
+  .tiptap .comment-decoration.comment-decoration-on-critic-change {
+    background-color: transparent;
+  }
+
+  .tiptap .critic-change {
+    box-decoration-break: clone;
+    -webkit-box-decoration-break: clone;
+  }
+
+  .tiptap .critic-change-addition,
+  .tiptap .critic-change-substitution-new {
+    @apply rounded-sm px-0.5 text-emerald-950;
+    background-color: rgb(209 250 229 / 0.9);
+    text-decoration: underline;
+    text-decoration-color: rgb(16 185 129 / 0.75);
+    text-underline-offset: 0.16em;
+  }
+
+  .tiptap .critic-change-deletion,
+  .tiptap .critic-change-substitution-old {
+    @apply rounded-sm px-0.5 text-rose-950;
+    background-color: rgb(255 228 230 / 0.95);
+    text-decoration: line-through;
+    text-decoration-color: rgb(225 29 72 / 0.75);
+  }
+
+  .tiptap .critic-change-decoration-hovered,
+  .tiptap .critic-change-decoration-active {
+    @apply ring-2 ring-emerald-300/80;
+    border-radius: 0.2rem;
+  }
+
   .tiptap code {
     @apply rounded bg-slate-100 px-1.5 py-0.5 text-[0.9em] text-slate-900;
   }
 
   .tiptap .comment-decoration code,
-  .tiptap .comment-anchor code {
+  .tiptap .comment-anchor code,
+  .tiptap .critic-change code {
     @apply bg-transparent;
     box-shadow: inset 0 0 0 1px rgb(15 23 42 / 12%);
   }

--- a/packages/app/src/useCommentAnchorLayout.ts
+++ b/packages/app/src/useCommentAnchorLayout.ts
@@ -32,7 +32,13 @@ export function useCommentAnchorLayout(editor: Editor | null, enabled = true) {
     }
 
     frameRef.current = requestAnimationFrame(() => {
-      const editorElement = editor?.view.dom as HTMLElement | undefined;
+      let editorElement: HTMLElement | undefined;
+
+      try {
+        editorElement = editor?.view.dom as HTMLElement | undefined;
+      } catch {
+        editorElement = undefined;
+      }
 
       if (!editorElement) {
         setLayoutState({

--- a/packages/app/test/critic-markup.test.ts
+++ b/packages/app/test/critic-markup.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { Editor } from "@tiptap/core";
 import {
+  createCriticChange,
+  createNextChangeId,
   createNextCommentId,
   criticMarkdownToEditorState,
   editorStateToCriticMarkdown,
@@ -221,6 +223,215 @@ Use CriticMarkup for inline review feedback in markdown.`,
     expect(
       createNextCommentId([{ id: "c2" }, { id: "note-1" }, { id: "c7" }]),
     ).toBe("c8");
+  });
+
+  it("allocates simple document-local suggestion ids", () => {
+    expect(
+      createNextChangeId([
+        { changeId: "s2" },
+        { changeId: "suggestion-1" },
+        { changeId: "s7" },
+      ]),
+    ).toBe("s8");
+  });
+
+  it("round-trips an insertion suggestion with metadata", () => {
+    const input =
+      'Add {++new text++}{id="s1" by="user" at="2024-01-15T10:30:00.000Z"} here.\n';
+
+    const { doc, comments } = criticMarkdownToEditorState(input);
+
+    expect(editorStateToCriticMarkdown(doc, comments)).toBe(input);
+  });
+
+  it("round-trips a deletion suggestion with metadata", () => {
+    const input =
+      'Remove {--old text--}{id="s2" by="AI" at="2024-01-15T10:31:00.000Z"} here.\n';
+
+    const { doc, comments } = criticMarkdownToEditorState(input);
+
+    expect(editorStateToCriticMarkdown(doc, comments)).toBe(input);
+  });
+
+  it("round-trips a substitution suggestion with metadata", () => {
+    const input =
+      'Use {~~old text~>new text~~}{id="s3" by="user@example.com" at="2024-01-15T10:32:00.000Z"} here.\n';
+
+    const { doc, comments } = criticMarkdownToEditorState(input);
+
+    expect(editorStateToCriticMarkdown(doc, comments)).toBe(input);
+  });
+
+  it("imports suggestions without metadata and serializes generated metadata", () => {
+    const { doc, comments } = criticMarkdownToEditorState(
+      "Add {++new text++} here.\n",
+    );
+
+    expect(editorStateToCriticMarkdown(doc, comments)).toMatch(
+      /^Add \{\+\+new text\+\+\}\{id="s1" by="user" at="[^"]+"\} here\.\n$/,
+    );
+  });
+
+  it("preserves Markdown formatting inside suggested changes", () => {
+    const input =
+      'Use {++**bold** and `code`++}{id="s1" by="user" at="2024-01-15T10:30:00.000Z"} here.\n';
+
+    const { doc, comments } = criticMarkdownToEditorState(input);
+
+    expect(editorStateToCriticMarkdown(doc, comments)).toBe(input);
+  });
+
+  it("preserves suggested changes next to comments", () => {
+    const input =
+      'Add {++new text++}{id="s1" by="user" at="2024-01-15T10:30:00.000Z"} near {==this==}{>>Check it<<}{id="c1" by="AI" at="2024-01-15T10:31:00.000Z"}.\n';
+
+    const { doc, comments } = criticMarkdownToEditorState(input);
+
+    expect(editorStateToCriticMarkdown(doc, comments)).toBe(input);
+  });
+
+  it("round-trips a comment whose parent points to a suggestion id", () => {
+    const input =
+      '{==New wording==}{>>Why this wording?<<}{id="c1" by="user" at="2024-01-15T10:31:00.000Z" re="s1"} follows {++new text++}{id="s1" by="AI" at="2024-01-15T10:30:00.000Z"}.\n';
+
+    const { doc, comments } = criticMarkdownToEditorState(input);
+
+    expect(comments.get("c1")).toMatchObject({
+      parentCommentId: "s1",
+    });
+    expect(editorStateToCriticMarkdown(doc, comments)).toBe(input);
+  });
+
+  it("round-trips a comment attached directly to a suggestion", () => {
+    const input =
+      '{++new text++}{id="s1" by="AI" at="2024-01-15T10:30:00.000Z"}{>>Why this wording?<<}{id="c1" by="user" at="2024-01-15T10:31:00.000Z" re="s1"}\n';
+
+    const { doc, comments } = criticMarkdownToEditorState(input);
+
+    expect(comments.get("c1")).toMatchObject({
+      parentCommentId: "s1",
+    });
+    expect(editorStateToCriticMarkdown(doc, comments)).toBe(input);
+  });
+
+  it("preserves suggested changes in headings and list items", () => {
+    const input = `## Use {++new title++}{id="s1" by="user" at="2024-01-15T10:30:00.000Z"}
+
+* Keep {--old item--}{id="s2" by="user" at="2024-01-15T10:31:00.000Z"}
+`;
+
+    const { doc, comments } = criticMarkdownToEditorState(input);
+    const output = editorStateToCriticMarkdown(doc, comments);
+
+    expect(output).toContain(
+      '## Use {++new title++}{id="s1" by="user" at="2024-01-15T10:30:00.000Z"}',
+    );
+    expect(output).toContain(
+      '*   Keep {--old item--}{id="s2" by="user" at="2024-01-15T10:31:00.000Z"}',
+    );
+  });
+
+  it("accepts and rejects insertion suggestions", () => {
+    const input =
+      'Add {++new text++}{id="s1" by="user" at="2024-01-15T10:30:00.000Z"} here.\n';
+    const accepted = criticMarkdownToEditorState(input);
+    const rejected = criticMarkdownToEditorState(input);
+    const acceptEditor = new Editor({
+      extensions: createEditorExtensions(""),
+      content: accepted.doc,
+    });
+    const rejectEditor = new Editor({
+      extensions: createEditorExtensions(""),
+      content: rejected.doc,
+    });
+
+    try {
+      acceptEditor.commands.acceptCriticChange("s1");
+      rejectEditor.commands.rejectCriticChange("s1");
+
+      expect(
+        editorStateToCriticMarkdown(acceptEditor.getJSON(), accepted.comments),
+      ).toBe("Add new text here.\n");
+      expect(
+        editorStateToCriticMarkdown(rejectEditor.getJSON(), rejected.comments),
+      ).toBe("Add here.\n");
+    } finally {
+      acceptEditor.destroy();
+      rejectEditor.destroy();
+    }
+  });
+
+  it("accepts and rejects deletion suggestions", () => {
+    const input =
+      'Remove {--old text--}{id="s1" by="user" at="2024-01-15T10:30:00.000Z"} here.\n';
+    const accepted = criticMarkdownToEditorState(input);
+    const rejected = criticMarkdownToEditorState(input);
+    const acceptEditor = new Editor({
+      extensions: createEditorExtensions(""),
+      content: accepted.doc,
+    });
+    const rejectEditor = new Editor({
+      extensions: createEditorExtensions(""),
+      content: rejected.doc,
+    });
+
+    try {
+      acceptEditor.commands.acceptCriticChange("s1");
+      rejectEditor.commands.rejectCriticChange("s1");
+
+      expect(
+        editorStateToCriticMarkdown(acceptEditor.getJSON(), accepted.comments),
+      ).toBe("Remove here.\n");
+      expect(
+        editorStateToCriticMarkdown(rejectEditor.getJSON(), rejected.comments),
+      ).toBe("Remove old text here.\n");
+    } finally {
+      acceptEditor.destroy();
+      rejectEditor.destroy();
+    }
+  });
+
+  it("accepts and rejects substitution suggestions", () => {
+    const input =
+      'Use {~~old~>new~~}{id="s1" by="user" at="2024-01-15T10:30:00.000Z"} here.\n';
+    const accepted = criticMarkdownToEditorState(input);
+    const rejected = criticMarkdownToEditorState(input);
+    const acceptEditor = new Editor({
+      extensions: createEditorExtensions(""),
+      content: accepted.doc,
+    });
+    const rejectEditor = new Editor({
+      extensions: createEditorExtensions(""),
+      content: rejected.doc,
+    });
+
+    try {
+      acceptEditor.commands.acceptCriticChange("s1");
+      rejectEditor.commands.rejectCriticChange("s1");
+
+      expect(
+        editorStateToCriticMarkdown(acceptEditor.getJSON(), accepted.comments),
+      ).toBe("Use new here.\n");
+      expect(
+        editorStateToCriticMarkdown(rejectEditor.getJSON(), rejected.comments),
+      ).toBe("Use old here.\n");
+    } finally {
+      acceptEditor.destroy();
+      rejectEditor.destroy();
+    }
+  });
+
+  it("creates critic change attrs with document-local metadata", () => {
+    expect(
+      createCriticChange("addition", undefined, {
+        existingChanges: [{ changeId: "s1" }],
+      }),
+    ).toMatchObject({
+      kind: "addition",
+      changeId: "s2",
+      authorType: "user",
+      authorId: "user",
+    });
   });
 
   it("collects descendants in nested reply order", () => {

--- a/packages/app/test/document-comments.test.ts
+++ b/packages/app/test/document-comments.test.ts
@@ -6,6 +6,7 @@ import {
   getRootThreadIdForCommentId,
   groupCommentAnchorMeasurements,
   normalizeCommentMeasurement,
+  resolveAnchoredRailLayouts,
   resolveCommentRailLayouts,
   resolveCommentThreadRailLayouts,
 } from "../src/document-comments";
@@ -360,6 +361,62 @@ describe("document comment layout helpers", () => {
         key: "c3",
         railTop: 314,
         railBottom: 394,
+      },
+    ]);
+  });
+
+  it("pins any selected rail item to its anchor", () => {
+    const layouts = resolveAnchoredRailLayouts(
+      [
+        {
+          key: "comment-1",
+          anchorTop: 100,
+          anchorBottom: 114,
+          type: "comment",
+        },
+        {
+          key: "suggestion-1",
+          anchorTop: 140,
+          anchorBottom: 154,
+          type: "suggestion",
+        },
+        {
+          key: "comment-2",
+          anchorTop: 190,
+          anchorBottom: 204,
+          type: "comment",
+        },
+      ],
+      {
+        "comment-1": 90,
+        "suggestion-1": 120,
+        "comment-2": 70,
+      },
+      "suggestion-1",
+      16,
+    );
+
+    expect(
+      layouts.map(({ key, railTop, railBottom }) => ({
+        key,
+        railTop,
+        railBottom,
+      })),
+    ).toEqual([
+      {
+        key: "comment-1",
+        railTop: 34,
+        railBottom: 124,
+      },
+      {
+        key: "suggestion-1",
+        railTop: 140,
+        railBottom: 260,
+      },
+      {
+        key: "comment-2",
+        railTop: 276,
+        railBottom: 346,
       },
     ]);
   });

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -162,6 +162,7 @@ function getToolbarButton(container: HTMLElement, label: string) {
 type PageCardTestOptions = Partial<{
   page: Page;
   editorViewMode: "rich-text" | "code";
+  interactionMode: "viewing" | "suggesting" | "editing";
   selected: boolean;
   focusRequestKey: string | null;
 }>;
@@ -197,6 +198,7 @@ async function renderPageCard(
     selected: options.selected ?? true,
     focusRequestKey: options.focusRequestKey ?? null,
     editorViewMode: options.editorViewMode ?? "rich-text",
+    interactionMode: options.interactionMode ?? "editing",
     onSave,
     onSaveStateChange,
     backend,
@@ -382,6 +384,92 @@ describe("PageCard editor integration", () => {
     expect(rendered.onSaveStateChange.mock.calls.at(-1)?.[0]).toBe("idle");
   });
 
+  it("viewing mode disables rich-text editing", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-viewing-1",
+        title: "Doc Viewing 1",
+        content: "Read only",
+      },
+      interactionMode: "viewing",
+      selected: true,
+    });
+
+    expect(
+      getEditable(rendered.container).getAttribute("contenteditable"),
+    ).toBe("false");
+  });
+
+  it("suggesting mode turns typed text into insertion markup", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-suggesting-1",
+        title: "Doc Suggesting 1",
+        content: "Start",
+      },
+      interactionMode: "suggesting",
+      selected: true,
+    });
+    const editor = rendered.getEditor();
+
+    vi.useFakeTimers();
+
+    await act(async () => {
+      editor.commands.focus("end");
+      const position = editor.state.selection.from;
+      editor.view.someProp("handleTextInput", (handler) =>
+        handler(editor.view, position, position, " now"),
+      );
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(rendered.onSave).toHaveBeenCalledWith(
+      "doc-suggesting-1",
+      expect.stringMatching(
+        /^Start \{\+\+now\+\+\}\{id="s1" by="user" at="[^"]+"\}\n$/,
+      ),
+    );
+  });
+
+  it("suggesting mode turns typed replacement into substitution markup", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-suggesting-2",
+        title: "Doc Suggesting 2",
+        content: "Use old text",
+      },
+      interactionMode: "suggesting",
+      selected: true,
+    });
+    const editor = rendered.getEditor();
+
+    vi.useFakeTimers();
+    await selectText(editor, "old");
+
+    await act(async () => {
+      const { from, to } = editor.state.selection;
+      editor.view.someProp("handleTextInput", (handler) =>
+        handler(editor.view, from, to, "new"),
+      );
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(rendered.onSave).toHaveBeenCalledWith(
+      "doc-suggesting-2",
+      expect.stringMatching(
+        /^Use \{~~old~>new~~\}\{id="s1" by="user" at="[^"]+"\} text\n$/,
+      ),
+    );
+  });
+
   it("document code mode shows raw markdown and hides rich text chrome", async () => {
     const rendered = await renderPageCard({
       page: {
@@ -558,6 +646,48 @@ describe("PageCard editor integration", () => {
         ?.textContent,
     ).toContain("Comment body");
     expect(rendered.container.textContent).toContain("Me");
+  });
+
+  it("renders suggestion replies only inside the suggestion card", async () => {
+    const commentText = "Looks good as an inserted phrase.";
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-suggestion-reply-1",
+        title: "Doc Suggestion Reply 1",
+        content: `This sentence includes an insertion: {++clearer wording++}{id="s1" by="user" at="2026-04-25T23:55:00.000Z"}{>>${commentText}<<}{id="c1" by="user" at="2026-04-25T23:56:00.000Z" re="s1"}`,
+      },
+      selected: true,
+    });
+
+    await flushAnimationFrame();
+
+    const railText =
+      rendered.container.querySelector(".document-comment-rail")?.textContent ??
+      "";
+
+    expect(railText.split(commentText).length - 1).toBe(1);
+  });
+
+  it("preserves suggestion color when comments are attached to suggestion text", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-suggestion-reply-color-1",
+        title: "Doc Suggestion Reply Color 1",
+        content:
+          'This sentence includes {++clearer wording++}{id="s1" by="user" at="2026-04-25T23:55:00.000Z"}{>>Looks good.<<}{id="c1" by="user" at="2026-04-25T23:56:00.000Z" re="s1"}',
+      },
+      selected: true,
+    });
+
+    await flushAnimationFrame();
+
+    const suggestion = rendered.container.querySelector(
+      ".critic-change-addition",
+    );
+    expect(suggestion?.textContent).toContain("clearer wording");
+    expect(
+      rendered.container.querySelector(".comment-decoration-on-critic-change"),
+    ).not.toBeNull();
   });
 
   it("centers document layout when there are no comments", async () => {


### PR DESCRIPTION
Adds CriticMarkup suggestion parsing, serialization, and editor marks for insertions, deletions, and substitutions with metadata. Adds viewing/suggesting/editing document modes, context-menu suggestion actions, and accept/reject commands in the editor. Replaces the comment-only rail with a review rail that combines comments and suggestions, supports replies to suggestions, and keeps layout anchored. Adds tests for suggestion round-tripping, accept/reject behavior, rail layout, and PageCard integration.