### PR TITLE
Bump package version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roughdraft",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A local markdown review app",
   "license": "MIT",
   "author": "Nathan Baschez",


### PR DESCRIPTION
Bumps the root roughdraft package version from 0.1.0 to 0.1.1. This makes the publish workflow detect a newer npm version and publish the package after merge.