### PR TITLE
Fix comments inside code blocks

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -18,6 +18,7 @@
     "@joplin/turndown-plugin-gfm": "^1.0.64",
     "@tiptap/core": "^3.22.4",
     "@tiptap/extension-code": "^3.22.4",
+    "@tiptap/extension-code-block": "^3.22.4",
     "@tiptap/extension-image": "^3.22.4",
     "@tiptap/extension-link": "^3.22.4",
     "@tiptap/extension-placeholder": "^3.22.4",

--- a/packages/app/src/critic-markup/index.ts
+++ b/packages/app/src/critic-markup/index.ts
@@ -590,6 +590,77 @@ function renderCriticChangeSpan(
   )}">${changeSpan}</span>`;
 }
 
+function renderCriticCodeText(
+  text: string,
+  comments: Map<string, CriticComment>,
+) {
+  let result = "";
+  let offset = 0;
+
+  while (offset < text.length) {
+    const anchorMatch = text.slice(offset).match(criticCommentAnchorPattern);
+
+    if (!anchorMatch || anchorMatch.index !== 0) {
+      result += escapeHtml(text[offset] ?? "");
+      offset += 1;
+      continue;
+    }
+
+    const [, anchor] = anchorMatch;
+    let nextOffset = offset + anchorMatch[0].length;
+    const parsedComments: CriticComment[] = [];
+
+    while (nextOffset < text.length) {
+      const commentMatch = text
+        .slice(nextOffset)
+        .match(criticCommentBlockPattern);
+      if (!commentMatch) break;
+
+      const [, commentText, , legacyMetadataText, attributeMetadataText] =
+        commentMatch;
+      const comment = createCommentWithContext(
+        {
+          ...parseMetadata(legacyMetadataText, attributeMetadataText),
+          content: commentText,
+        },
+        [...comments.values(), ...parsedComments],
+      );
+      parsedComments.push(comment);
+      nextOffset += commentMatch[0].length;
+    }
+
+    if (parsedComments.length === 0) {
+      result += escapeHtml(anchorMatch[0]);
+      offset += anchorMatch[0].length;
+      continue;
+    }
+
+    for (const comment of parsedComments) {
+      comments.set(comment.id, comment);
+    }
+
+    result += `<span data-comment-ids="${escapeHtml(
+      JSON.stringify(parsedComments.map((comment) => comment.id)),
+    )}">${escapeHtml(anchor)}</span>`;
+    offset = nextOffset;
+  }
+
+  return result;
+}
+
+function renderCriticCodeBlock(
+  token: Tokens.Code,
+  comments: Map<string, CriticComment>,
+) {
+  const language = (token.lang || "").match(/\S+/)?.[0];
+  const classAttr = language ? ` class="language-${escapeHtml(language)}"` : "";
+  const content = token.escaped
+    ? token.text
+    : renderCriticCodeText(token.text, comments);
+
+  return `<pre><code${classAttr}>${content}</code></pre>\n`;
+}
+
 function addCriticCommentRule(
   service: TurndownService,
   comments: Map<string, CriticComment>,
@@ -630,6 +701,37 @@ function addCriticCommentRule(
       if (!commentBlocks) return content;
 
       return `{==${content}==}${commentBlocks}`;
+    },
+  });
+}
+
+function addCriticCodeBlockRule(service: TurndownService) {
+  service.addRule("criticCodeBlock", {
+    filter: (node) => {
+      if (node.nodeName !== "PRE") return false;
+      const codeElement = (node as HTMLElement).firstElementChild;
+      return (
+        codeElement?.nodeName === "CODE" &&
+        Boolean(
+          codeElement.querySelector(
+            "span[data-comment-ids], span[data-critic-change-kind]",
+          ),
+        )
+      );
+    },
+    replacement(_content, node) {
+      const codeElement = (node as HTMLElement)
+        .firstElementChild as HTMLElement | null;
+
+      if (!codeElement) return "";
+
+      const language =
+        [...codeElement.classList]
+          .find((className) => className.startsWith("language-"))
+          ?.slice("language-".length) ?? "";
+      const content = service.turndown(codeElement.innerHTML).trimEnd();
+
+      return `\n\n\`\`\`${language}\n${content}\n\`\`\`\n\n`;
     },
   });
 }
@@ -777,6 +879,7 @@ function createCriticMarked(markdownOptions?: MarkdownOptions) {
   const comments = new Map<string, CriticComment>();
   const changes = new Map<string, CriticChangeAttrs>();
   const renderer = createMarkedRenderer(markdownOptions);
+  renderer.code = (token) => renderCriticCodeBlock(token, comments);
   const parser = new Marked({
     gfm: true,
     async: false,
@@ -900,6 +1003,7 @@ export function editorStateToCriticMarkdown(
   const service = createTurndownService();
   addCriticCommentRule(service, comments);
   addCriticChangeRule(service, comments);
+  addCriticCodeBlockRule(service);
   return `${service.turndown(html).trimEnd()}\n`;
 }
 

--- a/packages/app/src/editor-extensions.ts
+++ b/packages/app/src/editor-extensions.ts
@@ -1,5 +1,6 @@
 import { Extension, Mark, mergeAttributes } from "@tiptap/core";
 import Code from "@tiptap/extension-code";
+import CodeBlock from "@tiptap/extension-code-block";
 import Image from "@tiptap/extension-image";
 import Link from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
@@ -611,6 +612,10 @@ const MarkdownCode = Code.extend({
   excludes: "bold italic strike link",
 });
 
+const MarkdownCodeBlock = CodeBlock.extend({
+  marks: "commentRef criticChange",
+});
+
 const MarkdownImage = Image.extend({
   addAttributes() {
     return {
@@ -634,6 +639,7 @@ export function createEditorExtensions(placeholder: string) {
         levels: [1, 2, 3],
       },
       code: false,
+      codeBlock: false,
       link: false,
     }),
     Placeholder.configure({
@@ -657,6 +663,7 @@ export function createEditorExtensions(placeholder: string) {
     }),
     CommentRef,
     CriticChange,
+    MarkdownCodeBlock,
     CommentHighlight,
     CriticChangeHighlight,
     MarkdownImage.configure({

--- a/packages/app/test/critic-markup.test.ts
+++ b/packages/app/test/critic-markup.test.ts
@@ -163,6 +163,116 @@ Use CriticMarkup for inline review feedback in markdown.`,
     expect(editorStateToCriticMarkdown(doc, new Map())).toBe(input);
   });
 
+  it("creates a comment anchor when a selection is inside a fenced code block", () => {
+    const input = `\`\`\`ts
+const command = "roughdraft open";
+\`\`\`
+`;
+    const { doc } = criticMarkdownToEditorState(input);
+    const editor = new Editor({
+      extensions: createEditorExtensions(""),
+      content: doc,
+    });
+
+    try {
+      const text = editor.state.doc.textBetween(
+        0,
+        editor.state.doc.content.size,
+        "\n",
+      );
+      const start = text.indexOf("roughdraft open");
+      const end = start + "roughdraft open".length;
+
+      editor.commands.setTextSelection({ from: start + 1, to: end + 1 });
+      const added = editor.commands.setCommentRef({ commentIds: ["c1"] });
+
+      expect(added).toBe(true);
+      expect(editor.getJSON().content?.[0]).toMatchObject({
+        type: "codeBlock",
+        attrs: { language: "ts" },
+        content: [
+          {
+            type: "text",
+            text: 'const command = "',
+          },
+          {
+            type: "text",
+            text: "roughdraft open",
+            marks: [
+              {
+                type: "commentRef",
+                attrs: { commentIds: ["c1"] },
+              },
+            ],
+          },
+          {
+            type: "text",
+            text: '";',
+          },
+        ],
+      });
+      expect(
+        editorStateToCriticMarkdown(
+          editor.getJSON(),
+          new Map([
+            [
+              "c1",
+              {
+                id: "c1",
+                content: "test",
+                createdAt: "2026-04-25T22:14:08.827Z",
+              },
+            ],
+          ]),
+        ),
+      ).toBe(`\`\`\`ts
+const command = "{==roughdraft open==}{>>test<<}{id="c1" by="user" at="2026-04-25T22:14:08.827Z"}";
+\`\`\`
+`);
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  it("round-trips comment anchors inside fenced code blocks", () => {
+    const input = `\`\`\`ts
+const command = "{==roughdraft open==}{>>test<<}{id="c1" by="user" at="2026-04-25T22:14:08.827Z"}";
+\`\`\`
+`;
+
+    const { doc, comments } = criticMarkdownToEditorState(input);
+
+    expect(doc.content?.[0]).toMatchObject({
+      type: "codeBlock",
+      attrs: { language: "ts" },
+      content: [
+        {
+          type: "text",
+          text: 'const command = "',
+        },
+        {
+          type: "text",
+          text: "roughdraft open",
+          marks: [
+            {
+              type: "commentRef",
+              attrs: { commentIds: ["c1"] },
+            },
+          ],
+        },
+        {
+          type: "text",
+          text: '";',
+        },
+      ],
+    });
+    expect(comments.get("c1")).toMatchObject({
+      id: "c1",
+      content: "test",
+    });
+    expect(editorStateToCriticMarkdown(doc, comments)).toBe(input);
+  });
+
   it("round-trips an anchored reply thread", () => {
     const input =
       'Please revisit {==this sentence==}{>>Needs a source<<}{id="c1" by="user" at="2024-01-15T10:30:00.000Z"}{>>I can add one from the intro.<<}{id="c2" by="AI" at="2024-01-15T10:31:00.000Z" re="c1"}.\n';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@tiptap/extension-code':
         specifier: ^3.22.4
         version: 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))
+      '@tiptap/extension-code-block':
+        specifier: ^3.22.4
+        version: 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)
       '@tiptap/extension-image':
         specifier: ^3.22.4
         version: 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))


### PR DESCRIPTION
## Summary
- Allow Roughdraft comment and critic-change marks inside Tiptap code blocks.
- Preserve CriticMarkup comment anchors when parsing and serializing fenced code blocks.
- Add regression coverage for adding and round-tripping comments inside fenced code.

## Verification
- pnpm lint
- pnpm test
- pnpm build