### PR TITLE
Reply from focused comment threads with r

### DIFF
--- a/packages/app/src/CommentEditorList.tsx
+++ b/packages/app/src/CommentEditorList.tsx
@@ -1,6 +1,7 @@
 import { Bot, Check, Pencil, Reply, Trash2, User, X } from "lucide-react";
 import {
   type MouseEvent,
+  type KeyboardEvent,
   type MutableRefObject,
   type ReactNode,
   useEffect,
@@ -39,6 +40,26 @@ interface CommentEditorListProps {
   onAutoFocusComment?: (commentId: string) => void;
 }
 
+function isEditableShortcutTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+
+  return Boolean(
+    target.closest(
+      'input, textarea, select, [contenteditable="true"], [role="textbox"]',
+    ),
+  );
+}
+
+function isReplyShortcut(event: KeyboardEvent) {
+  return (
+    event.key.toLowerCase() === "r" &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey
+  );
+}
+
 export function CommentEditorList({
   comments,
   variant = "banner",
@@ -66,6 +87,24 @@ export function CommentEditorList({
   const hasActiveSelection =
     !!selectedCommentId &&
     comments.some((comment) => comment.id === selectedCommentId);
+  const handleKeyDownCapture = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!interactive || !onReplyComment) return;
+    if (!isReplyShortcut(event)) return;
+    if (isEditableShortcutTarget(event.target)) return;
+
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+
+    const rootThread = target.closest<HTMLElement>(
+      "[data-comment-thread-root-id]",
+    );
+    const rootCommentId = rootThread?.dataset.commentThreadRootId;
+    if (!rootCommentId) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    onReplyComment(rootCommentId);
+  };
 
   useEffect(() => {
     const validCommentIds = new Set(comments.map((comment) => comment.id));
@@ -197,6 +236,7 @@ export function CommentEditorList({
           : "space-y-1.5 px-4 py-3",
         className,
       )}
+      onKeyDownCapture={handleKeyDownCapture}
     >
       {threads.map((thread, index) => (
         <CommentThreadNode
@@ -375,8 +415,10 @@ function CommentThreadNode({
 
   return (
     <div
+      data-comment-thread-root-id={depth === 0 ? comment.id : undefined}
+      tabIndex={interactive && depth === 0 ? 0 : undefined}
       className={cn(
-        "relative transition-all duration-200 ease-out",
+        "relative transition-all duration-200 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-stone-300",
         variant === "rail" &&
           depth === 0 &&
           (index > 0 ? "border-t border-slate-200/80 pt-3" : "pt-0"),

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -648,6 +648,57 @@ describe("PageCard editor integration", () => {
     expect(rendered.container.textContent).toContain("Me");
   });
 
+  it("opens a reply to the root comment when r is pressed in a focused thread", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-comment-reply-shortcut-1",
+        title: "Doc Comment Reply Shortcut 1",
+        content:
+          '{==alpha==}{>>Root comment<<}{id="root" by="user" at="2026-04-25T23:56:00.000Z"}{>>Nested reply<<}{id="child" by="user" at="2026-04-25T23:57:00.000Z" re="root"}\n\nParagraph',
+      },
+      selected: true,
+    });
+
+    await selectText(rendered.getEditor(), "alpha");
+
+    const editButtons = rendered.container.querySelectorAll(
+      'button[aria-label="Edit"]',
+    );
+    expect(editButtons.length).toBeGreaterThanOrEqual(2);
+    const nestedEditButton = editButtons[1] as HTMLButtonElement;
+
+    vi.useFakeTimers();
+    await act(async () => {
+      nestedEditButton.focus();
+      nestedEditButton.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "r",
+          bubbles: true,
+        }),
+      );
+      await Promise.resolve();
+    });
+    await flushReact();
+    await flushReact();
+
+    const replyEditor = rendered.container.querySelector<HTMLTextAreaElement>(
+      'textarea[placeholder="Write a reply"]',
+    );
+    expect(replyEditor).not.toBeNull();
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(rendered.onSave).toHaveBeenCalledWith(
+      "doc-comment-reply-shortcut-1",
+      expect.stringMatching(
+        /\{>><<\}\{id="c1" by="user" at="[^"]+" re="root"\}/,
+      ),
+    );
+  });
+
   it("renders suggestion replies only inside the suggestion card", async () => {
     const commentText = "Looks good as an inserted phrase.";
     const rendered = await renderPageCard({


### PR DESCRIPTION
## Summary
- make top-level comment threads focusable and handle plain `r` as a reply shortcut
- route replies from nested thread focus back to the top-level comment
- add regression coverage for the focused-thread shortcut

## Tests
- pnpm --filter @roughdraft/app test -- page-card.test.tsx
- pnpm biome check packages/app/src/CommentEditorList.tsx packages/app/test/page-card.test.tsx --assist-enabled=false
- pnpm --filter @roughdraft/app build