### PR TITLE
Fix comment draft autosave loops

### DIFF
--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -491,6 +491,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
   const criticChangeFrameRef = useRef<number | null>(null);
   const interactionModeRef = useRef<DocumentInteractionMode>(interactionMode);
   const commentsRef = useRef<Map<string, CriticComment>>(new Map());
+  const suppressNextMarkdownUpdateRef = useRef(false);
   const lastFocusRequestKeyRef = useRef<string | null>(null);
   const selectedCommentIdRef = useRef<string | null>(null);
   const selectedChangeIdRef = useRef<string | null>(null);
@@ -718,6 +719,11 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
         },
       },
       onUpdate: ({ editor: currentEditor }) => {
+        if (suppressNextMarkdownUpdateRef.current) {
+          suppressNextMarkdownUpdateRef.current = false;
+          return;
+        }
+
         emitMarkdownChange(currentEditor.getJSON());
         refreshCriticChanges();
       },
@@ -961,19 +967,22 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
     commentsRef.current = nextComments;
     setComments(nextComments);
 
+    suppressNextMarkdownUpdateRef.current = true;
     currentEditor
       .chain()
       .focus()
       .setCommentRef({ commentIds: [...existingIds, comment.id] })
       .run();
+    if (suppressNextMarkdownUpdateRef.current) {
+      suppressNextMarkdownUpdateRef.current = false;
+    }
 
     setSelectedCommentId(comment.id);
     setPendingFocusCommentId(comment.id);
-    emitMarkdownChange(currentEditor.getJSON(), nextComments);
     requestAnimationFrame(() => {
       measureLayout();
     });
-  }, [emitMarkdownChange, measureLayout]);
+  }, [measureLayout]);
 
   const handleSuggestDeletion = useCallback(() => {
     const currentEditor = editorRef.current;
@@ -1120,11 +1129,15 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
           existingComments: commentsRef.current.values(),
         },
       );
+      suppressNextMarkdownUpdateRef.current = true;
       const nextAnchorCommentIds = addCommentIdsToAnchor(
         currentEditor,
         commentId,
         [comment.id],
       );
+      if (suppressNextMarkdownUpdateRef.current) {
+        suppressNextMarkdownUpdateRef.current = false;
+      }
       if (!nextAnchorCommentIds) return;
 
       const nextComments = new Map(commentsRef.current);
@@ -1134,12 +1147,11 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
       setSelectedCommentId(comment.id);
       setHoveredCommentId(null);
       setPendingFocusCommentId(comment.id);
-      emitMarkdownChange(currentEditor.getJSON(), nextComments);
       requestAnimationFrame(() => {
         measureLayout();
       });
     },
-    [emitMarkdownChange, measureLayout],
+    [measureLayout],
   );
 
   const removeSuggestionComments = useCallback(
@@ -1217,7 +1229,16 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
           existingComments: commentsRef.current.values(),
         },
       );
-      if (!addCommentIdsToCriticChange(currentEditor, changeId, [comment.id])) {
+      suppressNextMarkdownUpdateRef.current = true;
+      const didAddCommentId = addCommentIdsToCriticChange(
+        currentEditor,
+        changeId,
+        [comment.id],
+      );
+      if (suppressNextMarkdownUpdateRef.current) {
+        suppressNextMarkdownUpdateRef.current = false;
+      }
+      if (!didAddCommentId) {
         return;
       }
 
@@ -1229,13 +1250,12 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
       setSelectedCommentId(comment.id);
       setHoveredCommentId(null);
       setPendingFocusCommentId(comment.id);
-      emitMarkdownChange(currentEditor.getJSON(), nextComments);
       refreshCriticChanges();
       requestAnimationFrame(() => {
         measureLayout();
       });
     },
-    [emitMarkdownChange, measureLayout, refreshCriticChanges],
+    [measureLayout, refreshCriticChanges],
   );
 
   const deleteComment = useCallback(
@@ -1653,6 +1673,12 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
       return;
     }
 
+    if (markdown === page.content) {
+      lastAcceptedMarkdownRef.current = page.content;
+      reportDirtyState(false);
+      return;
+    }
+
     acceptMarkdown(page.content);
   }, [acceptMarkdown, forceResetKey, markdown, page.content, reportDirtyState]);
 
@@ -1706,7 +1732,9 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
   }
 
   const effectiveRichTextSourceMarkdown =
-    !localDirtyRef.current && !recentMarkdownRef.current.has(page.content)
+    !localDirtyRef.current &&
+    !recentMarkdownRef.current.has(page.content) &&
+    markdown !== page.content
       ? page.content
       : richTextSourceMarkdown;
 

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -139,6 +139,43 @@ async function selectText(editor: Editor, text: string) {
   await flushReact();
 }
 
+async function addCommentWithShortcut() {
+  await flushAnimationFrame();
+  const commentButton = [...document.querySelectorAll("button")].find(
+    (button) =>
+      button.getAttribute("aria-label") === "Comment" ||
+      button.textContent?.includes("Comment"),
+  );
+  if (commentButton) {
+    await act(async () => {
+      commentButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+    await flushReact();
+    await flushReact();
+    return;
+  }
+
+  const isApplePlatform = /mac|iphone|ipad|ipod/i.test(navigator.platform);
+
+  await act(async () => {
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "m",
+        code: "KeyM",
+        altKey: true,
+        ctrlKey: !isApplePlatform,
+        metaKey: isApplePlatform,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    await Promise.resolve();
+  });
+  await flushReact();
+  await flushReact();
+}
+
 async function insertTextAtEnd(editor: Editor, text: string) {
   await act(async () => {
     editor.chain().focus("end").insertContent(text).run();
@@ -629,6 +666,52 @@ describe("PageCard editor integration", () => {
     ).toContain("Comment body");
   });
 
+  it("same-content disk echoes do not recreate the rich text editor", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-same-content-echo-1",
+        title: "Doc Same Content Echo 1",
+        content: "Start",
+      },
+      selected: true,
+    });
+
+    vi.useFakeTimers();
+
+    await insertTextAtEnd(rendered.getEditor(), " updated");
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    const savedMarkdown = rendered.onSave.mock.calls[0]?.[1];
+    expect(typeof savedMarkdown).toBe("string");
+
+    const editorAfterSave = rendered.getEditor();
+    const editableAfterSave = getEditable(rendered.container);
+
+    await rendered.rerender({
+      page: {
+        id: "doc-same-content-echo-1",
+        title: "Doc Same Content Echo 1",
+        content: savedMarkdown as string,
+      },
+    });
+    await rendered.rerender({
+      page: {
+        id: "doc-same-content-echo-1",
+        title: "Doc Same Content Echo 1",
+        content: savedMarkdown as string,
+        version: "same-content-new-version",
+      },
+    });
+
+    expect(rendered.getEditor()).toBe(editorAfterSave);
+    expect(getEditable(rendered.container)).toBe(editableAfterSave);
+    expect(rendered.getEditor().getText()).toContain("Start updated");
+  });
+
   it("comment selection still updates fallback UI", async () => {
     const rendered = await renderPageCard({
       page: {
@@ -646,6 +729,65 @@ describe("PageCard editor integration", () => {
         ?.textContent,
     ).toContain("Comment body");
     expect(rendered.container.textContent).toContain("Me");
+  });
+
+  it("does not autosave a newly-created empty comment before it is submitted", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-comment-empty-draft-1",
+        title: "Doc Comment Empty Draft 1",
+        content: "Comment target text",
+      },
+      selected: true,
+    });
+
+    await selectText(rendered.getEditor(), "target");
+    await addCommentWithShortcut();
+
+    vi.useFakeTimers();
+
+    const commentEditor = rendered.container.querySelector<HTMLTextAreaElement>(
+      'textarea[placeholder="Add your comment"]',
+    );
+    expect(commentEditor).not.toBeNull();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+
+    expect(rendered.onSave).not.toHaveBeenCalled();
+
+    await act(async () => {
+      if (!commentEditor) return;
+      const valueSetter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value",
+      )?.set;
+      valueSetter?.call(commentEditor, "Draft comment");
+      commentEditor.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    });
+
+    const saveButton = [...rendered.container.querySelectorAll("button")].find(
+      (button) => button.textContent?.includes("Save"),
+    );
+    expect(saveButton).not.toBeUndefined();
+
+    await act(async () => {
+      saveButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(rendered.onSave).toHaveBeenCalledWith(
+      "doc-comment-empty-draft-1",
+      expect.stringMatching(
+        /\{==target==\}\{>>Draft comment<<\}\{id="c1" by="user" at="[^"]+"\}/,
+      ),
+    );
   });
 
   it("opens a reply to the root comment when r is pressed in a focused thread", async () => {
@@ -691,12 +833,7 @@ describe("PageCard editor integration", () => {
       await Promise.resolve();
     });
 
-    expect(rendered.onSave).toHaveBeenCalledWith(
-      "doc-comment-reply-shortcut-1",
-      expect.stringMatching(
-        /\{>><<\}\{id="c1" by="user" at="[^"]+" re="root"\}/,
-      ),
-    );
+    expect(rendered.onSave).not.toHaveBeenCalled();
   });
 
   it("renders suggestion replies only inside the suggestion card", async () => {


### PR DESCRIPTION
## Summary
- prevent newly-created empty comments/replies from being autosaved before text is submitted
- avoid remounting the rich text editor on same-content save/disk echoes
- add PageCard regression coverage for both behaviors

## Tests
- pnpm --filter @roughdraft/app test -- page-card.test.tsx
- pnpm lint
- pnpm --filter @roughdraft/app build