### PR TITLE
Improve document title, review rail, and thread deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ roughdraft status
 roughdraft stop
 ```
 
-`roughdraft open` will reuse the running server and auto-start it if needed.
-You can also use `roughdraft ./path/to/file.md` as a shortcut when the input clearly looks like a path.
+`roughdraft open` will reuse the running server and auto-start it if needed. You can also use `roughdraft ./path/to/file.md` as a shortcut when the input clearly looks like a path.
 
 Roughdraft does not edit `~/CLAUDE.md`, `~/AGENTS.md`, or other user-level agent files. The setup prompt asks your agent to update its own guidance.
 
@@ -254,7 +253,7 @@ This is {++inserted++} text.
 This is {~~old~>new~~} substituted text.
 This is {>>a comment<<} in the margin.
 This is {==highlighted==} text.
-This is {==anchored text==}{>>a threaded comment<<}{id="c1" by="user" at="2026-04-23T18:00:00.000Z"}.
+This is anchored text.
 ```
 
 This matters because the main workflow is often:

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -225,9 +225,7 @@ export function App() {
         )
       : null;
 
-    document.title = workspaceTitlePath
-      ? `Roughdraft of ${workspaceTitlePath}`
-      : "Roughdraft";
+    document.title = workspaceTitlePath ?? "Roughdraft";
   }, [activeDocumentPath, backend, requestedPathState.rawPath]);
 
   const handleSaveDocument = useCallback(

--- a/packages/app/src/CommentEditorList.tsx
+++ b/packages/app/src/CommentEditorList.tsx
@@ -1,7 +1,7 @@
 import { Bot, Check, Pencil, Reply, Trash2, User, X } from "lucide-react";
 import {
-  type MouseEvent,
   type KeyboardEvent,
+  type MouseEvent,
   type MutableRefObject,
   type ReactNode,
   useEffect,
@@ -310,12 +310,14 @@ function CommentActionButton({
   tone = "neutral",
   icon,
   compact = false,
+  className,
   onClick,
 }: {
   label: string;
   tone?: "neutral" | "danger";
   icon: ReactNode;
   compact?: boolean;
+  className?: string;
   onClick: (event: MouseEvent) => void;
 }) {
   return (
@@ -333,6 +335,7 @@ function CommentActionButton({
               tone === "danger"
                 ? "text-stone-400 hover:bg-rose-100 hover:text-rose-700"
                 : "text-stone-400 hover:bg-[#DED8CE]/45 hover:text-stone-600",
+              className,
             )}
           >
             {icon}
@@ -374,6 +377,7 @@ function CommentThreadNode({
 }: CommentThreadNodeProps) {
   const { comment, replies } = thread;
   const hasReplies = replies.length > 0;
+  const isRootThread = depth === 0;
   const isSelected = comment.id === selectedCommentId;
   const isHovered = comment.id === hoveredCommentId;
   const isEditing = interactive && editingCommentIds.includes(comment.id);
@@ -415,12 +419,12 @@ function CommentThreadNode({
 
   return (
     <div
-      data-comment-thread-root-id={depth === 0 ? comment.id : undefined}
-      tabIndex={interactive && depth === 0 ? 0 : undefined}
+      data-comment-thread-root-id={isRootThread ? comment.id : undefined}
+      tabIndex={interactive && isRootThread ? 0 : undefined}
       className={cn(
         "relative transition-all duration-200 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-stone-300",
         variant === "rail" &&
-          depth === 0 &&
+          isRootThread &&
           (index > 0 ? "border-t border-slate-200/80 pt-3" : "pt-0"),
       )}
       onClick={() => {
@@ -488,6 +492,19 @@ function CommentThreadNode({
         ) : null}
         <div className="min-w-0 flex-1">
           <div className="relative grid grid-cols-[2rem_minmax(0,1fr)] gap-x-2">
+            {interactive && isRootThread ? (
+              <CommentActionButton
+                label="Delete thread"
+                tone="danger"
+                icon={<Trash2 className="size-3.5" />}
+                compact
+                className="absolute top-0 right-0 z-20 bg-white/80"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onDeleteComment(comment.id);
+                }}
+              />
+            ) : null}
             {hasReplies ? (
               <div
                 aria-hidden="true"
@@ -513,7 +530,13 @@ function CommentThreadNode({
                 <AuthorIcon className="size-3.5 shrink-0" />
               </div>
             </div>
-            <div className={cn("min-w-0 rounded-xl px-0.5", bodyTone)}>
+            <div
+              className={cn(
+                "min-w-0 rounded-xl px-0.5",
+                isRootThread && interactive && "pr-7",
+                bodyTone,
+              )}
+            >
               <div className="truncate text-[13px] font-semibold text-slate-900">
                 {authorLabel}
               </div>

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -2,6 +2,7 @@ import { CodeXml, Eye, RefreshCcw, Upload } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { DocumentEditorViewMode } from "./app-navigation";
 import { Button } from "./components/ui/button";
+import { criticMarkdownHasReviewRail } from "./critic-markup";
 import { cn } from "./lib/utils";
 import { PageCard, type DocumentInteractionMode } from "./PageCard";
 import type { Page, StorageBackend } from "./storage";
@@ -46,18 +47,14 @@ export function DocumentWorkspace({
     useState<DocumentInteractionMode>("editing");
   const [documentHasComments, setDocumentHasComments] = useState(
     () =>
-      !!documentPage?.content.includes("{>>") ||
-      !!documentPage?.content.includes("{++") ||
-      !!documentPage?.content.includes("{--") ||
-      !!documentPage?.content.includes("{~~"),
+      !!documentPage?.content &&
+      criticMarkdownHasReviewRail(documentPage.content),
   );
 
   useEffect(() => {
     setDocumentHasComments(
-      !!documentPage?.content.includes("{>>") ||
-        !!documentPage?.content.includes("{++") ||
-        !!documentPage?.content.includes("{--") ||
-        !!documentPage?.content.includes("{~~"),
+      !!documentPage?.content &&
+        criticMarkdownHasReviewRail(documentPage.content),
     );
   }, [documentPage]);
 

--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -12,6 +12,7 @@ import {
 import {
   createCriticChange,
   createCriticComment,
+  criticMarkdownHasReviewRail,
   criticMarkdownToEditorState,
   editorStateToCriticMarkdown,
   getCommentDescendantIds,
@@ -1709,11 +1710,10 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
     };
   }, []);
 
-  const hasCommentRailSpace =
-    markdown.includes("{>>") ||
-    markdown.includes("{++") ||
-    markdown.includes("{--") ||
-    markdown.includes("{~~");
+  const hasCommentRailSpace = useMemo(
+    () => criticMarkdownHasReviewRail(markdown),
+    [markdown],
+  );
 
   useEffect(() => {
     if (editorViewMode !== "code") return;

--- a/packages/app/src/critic-markup/index.ts
+++ b/packages/app/src/critic-markup/index.ts
@@ -981,7 +981,16 @@ function createCriticMarked(markdownOptions?: MarkdownOptions) {
     ],
   });
 
-  return { parser, comments };
+  return { parser, comments, changes };
+}
+
+export function criticMarkdownHasReviewRail(
+  markdown: string,
+  options?: MarkdownOptions,
+): boolean {
+  const { parser, comments, changes } = createCriticMarked(options);
+  parser.parse(markdown);
+  return comments.size > 0 || changes.size > 0;
 }
 
 export function criticMarkdownToEditorState(

--- a/packages/app/test/critic-markup.test.ts
+++ b/packages/app/test/critic-markup.test.ts
@@ -4,6 +4,7 @@ import {
   createCriticChange,
   createNextChangeId,
   createNextCommentId,
+  criticMarkdownHasReviewRail,
   criticMarkdownToEditorState,
   editorStateToCriticMarkdown,
   getCommentDescendantIds,
@@ -11,6 +12,30 @@ import {
 import { createEditorExtensions } from "../src/editor-extensions";
 
 describe("CriticMarkup comments", () => {
+  it("detects review rail content without counting fenced examples", () => {
+    expect(
+      criticMarkdownHasReviewRail(
+        [
+          "```md",
+          "This is {--deleted--} text.",
+          "This is {++inserted++} text.",
+          "This is {~~old~>new~~} substituted text.",
+          "This is {>>a comment<<} in the margin.",
+          "```",
+        ].join("\n"),
+      ),
+    ).toBe(false);
+
+    expect(
+      criticMarkdownHasReviewRail(
+        'This is {==anchored text==}{>>a threaded comment<<}{id="c1" by="user" at="2026-04-23T18:00:00.000Z"}.\n',
+      ),
+    ).toBe(true);
+    expect(criticMarkdownHasReviewRail("This is {++inserted++} text.\n")).toBe(
+      true,
+    );
+  });
+
   it("round-trips a highlighted comment anchor", () => {
     const input =
       'This is {==highlighted==}{>>comment text<<}{id="cmt1" by="AI" at="2024-01-15T10:30:00.000Z"} text.\n';

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -551,6 +551,34 @@ describe("PageCard editor integration", () => {
     ).not.toBeNull();
   });
 
+  it("document code mode does not keep rail space for fenced CriticMarkup examples", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-code-examples",
+        title: "Doc Code Examples",
+        content: [
+          "```md",
+          "This is {--deleted--} text.",
+          "This is {++inserted++} text.",
+          "This is {~~old~>new~~} substituted text.",
+          "This is {>>a comment<<} in the margin.",
+          "```",
+        ].join("\n"),
+      },
+      editorViewMode: "code",
+      selected: true,
+    });
+
+    expect(
+      rendered.container
+        .querySelector(".document-page-shell")
+        ?.classList.contains("document-page-shell-no-comments"),
+    ).toBe(true);
+    expect(
+      rendered.container.querySelector(".document-comment-rail"),
+    ).toBeNull();
+  });
+
   it("document code mode shows line numbers without the default dotted focus outline", async () => {
     const rendered = await renderPageCard({
       page: {
@@ -834,6 +862,46 @@ describe("PageCard editor integration", () => {
     });
 
     expect(rendered.onSave).not.toHaveBeenCalled();
+  });
+
+  it("deletes a whole root comment thread from the thread action", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-delete-comment-thread-1",
+        title: "Doc Delete Comment Thread 1",
+        content:
+          '{==alpha==}{>>Root comment<<}{id="root" by="user" at="2026-04-25T23:56:00.000Z"}{>>Nested reply<<}{id="child" by="user" at="2026-04-25T23:57:00.000Z" re="root"}\n\nParagraph',
+      },
+      selected: true,
+    });
+
+    await selectText(rendered.getEditor(), "alpha");
+
+    const deleteThreadButton =
+      rendered.container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Delete thread"]',
+      );
+    expect(deleteThreadButton).not.toBeNull();
+
+    vi.useFakeTimers();
+    await act(async () => {
+      deleteThreadButton?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    const savedMarkdown = rendered.onSave.mock.calls[0]?.[1];
+    expect(savedMarkdown).toContain("alpha");
+    expect(savedMarkdown).not.toContain("Root comment");
+    expect(savedMarkdown).not.toContain("Nested reply");
+    expect(savedMarkdown).not.toContain('id="root"');
+    expect(savedMarkdown).not.toContain('id="child"');
   });
 
   it("renders suggestion replies only inside the suggestion card", async () => {


### PR DESCRIPTION
Updates the app window title to show the active path directly. Adds parser-backed review rail detection so fenced CriticMarkup examples do not reserve comment rail space, and updates the README example accordingly. Adds a root-thread delete action in the comment rail that removes the full thread, including replies. Tested with `pnpm --filter @roughdraft/app test -- packages/app/test/critic-markup.test.ts packages/app/test/page-card.test.tsx`.