### PR TITLE
Improve suggestion review threads

### DIFF
--- a/packages/app/src/CommentEditorList.tsx
+++ b/packages/app/src/CommentEditorList.tsx
@@ -38,6 +38,33 @@ interface CommentEditorListProps {
   onReplyComment?: (commentId: string) => void;
   pendingFocusCommentId?: string | null;
   onAutoFocusComment?: (commentId: string) => void;
+  renderCommentContent?: (context: CommentContentRenderContext) => ReactNode;
+  getCommentActions?: (
+    context: CommentActionsRenderContext,
+  ) => CommentActionDefinition[];
+}
+
+export interface CommentActionDefinition {
+  key: string;
+  label: string;
+  tone?: "neutral" | "danger";
+  icon: ReactNode;
+  compact?: boolean;
+  onClick: (event: MouseEvent) => void;
+}
+
+export interface CommentContentRenderContext {
+  comment: CriticComment;
+  depth: number;
+  isEditing: boolean;
+  defaultContent: ReactNode;
+}
+
+export interface CommentActionsRenderContext {
+  comment: CriticComment;
+  depth: number;
+  isEditing: boolean;
+  defaultActions: CommentActionDefinition[];
 }
 
 function isEditableShortcutTarget(target: EventTarget | null) {
@@ -75,6 +102,8 @@ export function CommentEditorList({
   onReplyComment,
   pendingFocusCommentId = null,
   onAutoFocusComment,
+  renderCommentContent,
+  getCommentActions,
 }: CommentEditorListProps) {
   const textareaRefs = useRef(new Map<string, HTMLTextAreaElement>());
   const [drafts, setDrafts] = useState<Record<string, string>>({});
@@ -262,6 +291,8 @@ export function CommentEditorList({
           onStartEditingComment={startEditingComment}
           onSubmitEditingComment={submitEditingComment}
           onCancelEditingComment={cancelEditingComment}
+          renderCommentContent={renderCommentContent}
+          getCommentActions={getCommentActions}
           onChangeDraft={(commentId, nextContent) => {
             setDrafts((current) => ({
               ...current,
@@ -296,6 +327,10 @@ interface CommentThreadNodeProps {
   onStartEditingComment: (commentId: string) => void;
   onSubmitEditingComment: (commentId: string) => void;
   onCancelEditingComment: (commentId: string) => void;
+  renderCommentContent?: (context: CommentContentRenderContext) => ReactNode;
+  getCommentActions?: (
+    context: CommentActionsRenderContext,
+  ) => CommentActionDefinition[];
   onChangeDraft: (commentId: string, nextContent: string) => void;
 }
 
@@ -373,6 +408,8 @@ function CommentThreadNode({
   onStartEditingComment,
   onSubmitEditingComment,
   onCancelEditingComment,
+  renderCommentContent,
+  getCommentActions,
   onChangeDraft,
 }: CommentThreadNodeProps) {
   const { comment, replies } = thread;
@@ -407,6 +444,76 @@ function CommentThreadNode({
       : "bg-transparent";
   const treeLineTone =
     variant === "banner" ? "bg-[#DED8CE]/90" : "bg-[#DED8CE]/85";
+  const defaultContent =
+    comment.content.trim().length > 0 ? comment.content : "Empty comment";
+  const renderedContent =
+    renderCommentContent?.({
+      comment,
+      depth,
+      isEditing,
+      defaultContent,
+    }) ?? defaultContent;
+  const defaultActions: CommentActionDefinition[] = isEditing
+    ? [
+        {
+          key: "save",
+          label: "Save",
+          icon: <Check className="size-3.5" />,
+          onClick: (event) => {
+            event.stopPropagation();
+            onSubmitEditingComment(comment.id);
+          },
+        },
+        {
+          key: "cancel",
+          label: "Cancel",
+          icon: <X className="size-3.5" />,
+          onClick: (event) => {
+            event.stopPropagation();
+            onCancelEditingComment(comment.id);
+          },
+        },
+      ]
+    : [
+        {
+          key: "reply",
+          label: "Reply",
+          icon: <Reply className="size-3.5" />,
+          compact: true,
+          onClick: (event) => {
+            event.stopPropagation();
+            onReplyComment?.(comment.id);
+          },
+        },
+        {
+          key: "edit",
+          label: "Edit",
+          icon: <Pencil className="size-3.5" />,
+          compact: true,
+          onClick: (event) => {
+            event.stopPropagation();
+            onStartEditingComment(comment.id);
+          },
+        },
+        {
+          key: "delete",
+          label: "Delete",
+          tone: "danger",
+          icon: <Trash2 className="size-3.5" />,
+          compact: true,
+          onClick: (event) => {
+            event.stopPropagation();
+            onDeleteComment(comment.id);
+          },
+        },
+      ];
+  const actions =
+    getCommentActions?.({
+      comment,
+      depth,
+      isEditing,
+      defaultActions,
+    }) ?? defaultActions;
   const ancestorGuideOffsets = parentLines.reduce<number[]>(
     (offsets, showLine, guideIndex) => {
       if (showLine) {
@@ -546,11 +653,7 @@ function CommentThreadNode({
                   variant === "banner" ? "text-slate-800" : "text-slate-700",
                 )}
               >
-                {isEditing
-                  ? null
-                  : comment.content.trim().length > 0
-                    ? comment.content
-                    : "Empty comment"}
+                {isEditing ? null : renderedContent}
               </div>
               {isEditing ? (
                 <Textarea
@@ -605,57 +708,16 @@ function CommentThreadNode({
                 />
               ) : null}
               <div className="mt-2 flex flex-wrap items-center gap-1">
-                {isEditing ? (
-                  <>
-                    <CommentActionButton
-                      label="Save"
-                      icon={<Check className="size-3.5" />}
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onSubmitEditingComment(comment.id);
-                      }}
-                    />
-                    <CommentActionButton
-                      label="Cancel"
-                      icon={<X className="size-3.5" />}
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onCancelEditingComment(comment.id);
-                      }}
-                    />
-                  </>
-                ) : (
-                  <>
-                    <CommentActionButton
-                      label="Reply"
-                      icon={<Reply className="size-3.5" />}
-                      compact
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onReplyComment?.(comment.id);
-                      }}
-                    />
-                    <CommentActionButton
-                      label="Edit"
-                      icon={<Pencil className="size-3.5" />}
-                      compact
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onStartEditingComment(comment.id);
-                      }}
-                    />
-                    <CommentActionButton
-                      label="Delete"
-                      tone="danger"
-                      icon={<Trash2 className="size-3.5" />}
-                      compact
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onDeleteComment(comment.id);
-                      }}
-                    />
-                  </>
-                )}
+                {actions.map((action) => (
+                  <CommentActionButton
+                    key={action.key}
+                    label={action.label}
+                    tone={action.tone}
+                    icon={action.icon}
+                    compact={action.compact}
+                    onClick={action.onClick}
+                  />
+                ))}
               </div>
             </div>
           </div>
@@ -687,6 +749,8 @@ function CommentThreadNode({
               onStartEditingComment={onStartEditingComment}
               onSubmitEditingComment={onSubmitEditingComment}
               onCancelEditingComment={onCancelEditingComment}
+              renderCommentContent={renderCommentContent}
+              getCommentActions={getCommentActions}
               onChangeDraft={onChangeDraft}
             />
           ))}

--- a/packages/app/src/DocumentReviewRail.tsx
+++ b/packages/app/src/DocumentReviewRail.tsx
@@ -1,6 +1,11 @@
 import { Check, Reply, X } from "lucide-react";
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { CommentEditorList } from "./CommentEditorList";
+import {
+  CommentEditorList,
+  type CommentActionDefinition,
+  type CommentActionsRenderContext,
+  type CommentContentRenderContext,
+} from "./CommentEditorList";
 import type {
   CriticChangeAttrs,
   CriticChangeKind,
@@ -54,12 +59,6 @@ interface DocumentReviewRailProps {
   onAutoFocusComment?: (commentId: string) => void;
 }
 
-function getSuggestionTypeLabel(kind: CriticChangeKind) {
-  if (kind === "addition") return "Insertion";
-  if (kind === "deletion") return "Deletion";
-  return "Replacement";
-}
-
 function getSuggestionPreview(suggestion: CriticChangeRailItem) {
   const oldText = suggestion.oldText.trim();
   const newText = suggestion.newText.trim();
@@ -70,8 +69,58 @@ function getSuggestionPreview(suggestion: CriticChangeRailItem) {
   return oldText || newText || "Changed text";
 }
 
-function getSuggestionAuthor(change: CriticChangeAttrs) {
-  return change.authorType === "ai" ? "AI" : change.authorId || "Me";
+function getSuggestionRootComment(
+  suggestion: CriticChangeRailItem,
+): CriticComment {
+  return {
+    id: suggestion.changeId,
+    content: getSuggestionPreview(suggestion),
+    createdAt: suggestion.change.createdAt,
+    authorType: suggestion.change.authorType,
+    authorId: suggestion.change.authorId,
+  };
+}
+
+function renderQuotedSuggestionText(text: string, fallback: string) {
+  return (
+    <span className="italic text-slate-600">"{text.trim() || fallback}"</span>
+  );
+}
+
+function SuggestionCommentContent({
+  suggestion,
+}: {
+  suggestion: CriticChangeRailItem;
+}) {
+  const oldText = suggestion.oldText.trim();
+  const newText = suggestion.newText.trim();
+
+  if (suggestion.kind === "addition") {
+    return (
+      <>
+        <span className="font-semibold text-slate-800">Insert:</span>{" "}
+        {renderQuotedSuggestionText(newText, "Inserted text")}
+      </>
+    );
+  }
+
+  if (suggestion.kind === "deletion") {
+    return (
+      <>
+        <span className="font-semibold text-slate-800">Delete:</span>{" "}
+        {renderQuotedSuggestionText(oldText, "Deleted text")}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <span className="font-semibold text-slate-800">Replace:</span>{" "}
+      {renderQuotedSuggestionText(oldText, "Original text")}{" "}
+      <span className="text-slate-500">with</span>{" "}
+      {renderQuotedSuggestionText(newText, "Changed text")}
+    </>
+  );
 }
 
 export function DocumentReviewRail({
@@ -333,10 +382,76 @@ export function DocumentReviewRail({
           const suggestion = layout.suggestion;
           const isSelected = selectedChangeId === suggestion.changeId;
           const isHovered = hoveredChangeId === suggestion.changeId;
-          const isExpanded = isSelected || suggestion.commentIds.length > 0;
           const suggestionComments = suggestion.commentIds
             .map((commentId) => comments.get(commentId))
             .filter((comment): comment is CriticComment => Boolean(comment));
+          const suggestionCommentIds = new Set(
+            suggestionComments.map((comment) => comment.id),
+          );
+          const normalizedSuggestionComments = suggestionComments.map(
+            (comment) =>
+              comment.parentCommentId === suggestion.changeId ||
+              (comment.parentCommentId &&
+                suggestionCommentIds.has(comment.parentCommentId))
+                ? comment
+                : {
+                    ...comment,
+                    parentCommentId: suggestion.changeId,
+                  },
+          );
+          const suggestionRootComment = getSuggestionRootComment(suggestion);
+          const suggestionThreadComments = [
+            suggestionRootComment,
+            ...normalizedSuggestionComments,
+          ];
+          const renderCommentContent = ({
+            comment,
+            defaultContent,
+          }: CommentContentRenderContext) =>
+            comment.id === suggestion.changeId ? (
+              <SuggestionCommentContent suggestion={suggestion} />
+            ) : (
+              defaultContent
+            );
+          const getCommentActions = ({
+            comment,
+            defaultActions,
+          }: CommentActionsRenderContext): CommentActionDefinition[] =>
+            comment.id === suggestion.changeId
+              ? [
+                  {
+                    key: "accept",
+                    label: "Accept suggestion",
+                    icon: <Check className="size-3.5" />,
+                    compact: true,
+                    onClick: (event) => {
+                      event.stopPropagation();
+                      onAcceptSuggestion(suggestion.changeId);
+                    },
+                  },
+                  {
+                    key: "reject",
+                    label: "Reject suggestion",
+                    tone: "danger",
+                    icon: <X className="size-3.5" />,
+                    compact: true,
+                    onClick: (event) => {
+                      event.stopPropagation();
+                      onRejectSuggestion(suggestion.changeId);
+                    },
+                  },
+                  {
+                    key: "reply",
+                    label: "Reply",
+                    icon: <Reply className="size-3.5" />,
+                    compact: true,
+                    onClick: (event) => {
+                      event.stopPropagation();
+                      onReplySuggestion(suggestion.changeId);
+                    },
+                  },
+                ]
+              : defaultActions;
 
           return (
             <div
@@ -344,7 +459,7 @@ export function DocumentReviewRail({
               ref={(node) => setItemRef(layout.key, node)}
               data-suggestion-thread-container="true"
               className={cn(
-                "absolute left-0 right-0 rounded-xl border border-transparent bg-transparent px-4 py-3 shadow-none transition-all duration-200 ease-out will-change-transform",
+                "absolute left-0 right-0 rounded-xl border border-transparent bg-transparent shadow-none transition-all duration-200 ease-out will-change-transform",
                 isSelected
                   ? "-translate-x-2 border-[#DFDFDC] bg-white shadow-[0_20px_48px_rgba(57,47,38,0.14)]"
                   : "",
@@ -359,73 +474,54 @@ export function DocumentReviewRail({
                 onFocusSuggestion(suggestion.changeId);
               }}
             >
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <div className="text-[11px] font-semibold tracking-[0.08em] text-stone-500 uppercase">
-                    {getSuggestionTypeLabel(suggestion.kind)}
-                  </div>
-                  <div className="mt-1 text-sm leading-5 text-slate-800">
-                    {getSuggestionPreview(suggestion)}
-                  </div>
-                  <div className="mt-1 truncate text-[11px] text-stone-400">
-                    {getSuggestionAuthor(suggestion.change)}
-                  </div>
-                </div>
-                <div className="flex shrink-0 items-center gap-1">
-                  <button
-                    type="button"
-                    className="flex size-7 items-center justify-center rounded-full text-emerald-700 transition hover:bg-emerald-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
-                    aria-label="Accept suggestion"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onAcceptSuggestion(suggestion.changeId);
-                    }}
-                  >
-                    <Check className="size-4" />
-                  </button>
-                  <button
-                    type="button"
-                    className="flex size-7 items-center justify-center rounded-full text-rose-700 transition hover:bg-rose-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-300"
-                    aria-label="Reject suggestion"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onRejectSuggestion(suggestion.changeId);
-                    }}
-                  >
-                    <X className="size-4" />
-                  </button>
-                </div>
-              </div>
-              {isExpanded && suggestionComments.length > 0 ? (
-                <CommentEditorList
-                  comments={suggestionComments}
-                  variant="rail"
-                  className="mt-3 border-t border-slate-200/80 px-0 pt-3"
-                  selectedCommentId={selectedCommentId}
-                  hoveredCommentId={hoveredCommentId}
-                  onDeleteComment={onDeleteComment}
-                  onUpdateComment={onUpdateComment}
-                  onReplyComment={onReplyComment}
-                  onSelectComment={onSelectComment}
-                  onFocusComment={onFocusComment}
-                  onHoverComment={onHoverComment}
-                  pendingFocusCommentId={pendingFocusCommentId}
-                  onAutoFocusComment={onAutoFocusComment}
-                />
-              ) : null}
-              {isExpanded ? (
-                <button
-                  type="button"
-                  className="mt-3 inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium text-stone-500 transition hover:bg-[#DED8CE]/45 hover:text-stone-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-stone-300"
-                  onClick={(event) => {
-                    event.stopPropagation();
+              <CommentEditorList
+                comments={suggestionThreadComments}
+                variant="rail"
+                selectedCommentId={
+                  selectedCommentId ?? (isSelected ? suggestion.changeId : null)
+                }
+                hoveredCommentId={
+                  hoveredCommentId ?? (isHovered ? suggestion.changeId : null)
+                }
+                onDeleteComment={onDeleteComment}
+                onUpdateComment={onUpdateComment}
+                onReplyComment={(commentId) => {
+                  if (commentId === suggestion.changeId) {
                     onReplySuggestion(suggestion.changeId);
-                  }}
-                >
-                  <Reply className="size-3.5" />
-                  Reply
-                </button>
-              ) : null}
+                    return;
+                  }
+
+                  onReplyComment(commentId);
+                }}
+                onSelectComment={(commentId) => {
+                  if (commentId === suggestion.changeId) {
+                    onSelectSuggestion(suggestion.changeId);
+                    return;
+                  }
+
+                  onSelectComment(commentId);
+                }}
+                onFocusComment={(commentId) => {
+                  if (commentId === suggestion.changeId) {
+                    onFocusSuggestion(suggestion.changeId);
+                    return;
+                  }
+
+                  onFocusComment(commentId);
+                }}
+                onHoverComment={(commentId) => {
+                  if (commentId === suggestion.changeId) {
+                    onHoverSuggestion(suggestion.changeId);
+                    return;
+                  }
+
+                  onHoverComment(commentId);
+                }}
+                pendingFocusCommentId={pendingFocusCommentId}
+                onAutoFocusComment={onAutoFocusComment}
+                renderCommentContent={renderCommentContent}
+                getCommentActions={getCommentActions}
+              />
             </div>
           );
         })}

--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -1,6 +1,7 @@
 import type { JSONContent } from "@tiptap/core";
 import type { Editor } from "@tiptap/react";
 import { EditorContent, useEditor, useEditorState } from "@tiptap/react";
+import type { Mark as ProseMirrorMark } from "@tiptap/pm/model";
 import { TextSelection } from "@tiptap/pm/state";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Check, X } from "lucide-react";
@@ -143,6 +144,52 @@ function getSelectionCommentIds(editor: Editor | null): string[] {
   return [...commentIds];
 }
 
+function getSelectionCriticChangeIds(editor: Editor | null): string[] {
+  if (!editor) return [];
+
+  const directChangeId = editor.getAttributes("criticChange").changeId;
+
+  if (typeof directChangeId === "string" && directChangeId.length > 0) {
+    return [directChangeId];
+  }
+
+  const { from, to, empty, $from } = editor.state.selection;
+  const changeIds = new Set<string>();
+
+  if (empty) {
+    for (const mark of $from.marks()) {
+      if (mark.type.name !== "criticChange") continue;
+      if (typeof mark.attrs.changeId === "string") {
+        changeIds.add(mark.attrs.changeId);
+      }
+    }
+  } else {
+    editor.state.doc.nodesBetween(from, to, (node) => {
+      if (!node.isText) return;
+
+      for (const mark of node.marks) {
+        if (mark.type.name !== "criticChange") continue;
+        if (typeof mark.attrs.changeId === "string") {
+          changeIds.add(mark.attrs.changeId);
+        }
+      }
+    });
+  }
+
+  return [...changeIds];
+}
+
+function getPreferredCriticChangeId(
+  changeIds: string[],
+  currentChangeId: string | null,
+): string | null {
+  if (currentChangeId && changeIds.includes(currentChangeId)) {
+    return currentChangeId;
+  }
+
+  return changeIds[0] ?? null;
+}
+
 function findCommentRange(editor: Editor | null, commentId: string) {
   if (!editor) return null;
 
@@ -276,6 +323,26 @@ function getDocumentCriticChanges(
   });
 
   return [...changes.values()];
+}
+
+function getReusableSuggestionInputMark(
+  editor: Editor,
+  position: number,
+): ProseMirrorMark | null {
+  const markType = editor.state.schema.marks.criticChange;
+  if (!markType) return null;
+
+  const isReusableSuggestionMark = (mark: ProseMirrorMark) =>
+    mark.type === markType &&
+    (mark.attrs.kind === "addition" || mark.attrs.kind === "substitution-new");
+  const $position = editor.state.doc.resolve(position);
+  const previousMark = $position.nodeBefore?.marks.find(
+    isReusableSuggestionMark,
+  );
+
+  if (previousMark) return previousMark;
+
+  return $position.nodeAfter?.marks.find(isReusableSuggestionMark) ?? null;
 }
 
 function getDocumentCriticChangeRailItems(
@@ -653,30 +720,31 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
                 existingChanges: getDocumentCriticChanges(currentEditor),
               },
             );
+            const newMark = view.state.schema.marks.criticChange.create({
+              ...oldChange,
+              kind: "substitution-new",
+            });
             tr.addMark(
               from,
               to,
               view.state.schema.marks.criticChange.create(oldChange),
             );
-            tr.insert(
-              to,
-              view.state.schema.text(text, [
-                view.state.schema.marks.criticChange.create({
-                  ...oldChange,
-                  kind: "substitution-new",
-                }),
-              ]),
-            );
+            tr.insert(to, view.state.schema.text(text, [newMark]));
+            tr.setSelection(TextSelection.create(tr.doc, to + text.length));
           } else {
-            const change = createCriticChange("addition", undefined, {
-              existingChanges: getDocumentCriticChanges(currentEditor),
-            });
-            tr.insert(
+            const existingMark = getReusableSuggestionInputMark(
+              currentEditor,
               from,
-              view.state.schema.text(text, [
-                view.state.schema.marks.criticChange.create(change),
-              ]),
             );
+            const mark =
+              existingMark ??
+              view.state.schema.marks.criticChange.create(
+                createCriticChange("addition", undefined, {
+                  existingChanges: getDocumentCriticChanges(currentEditor),
+                }),
+              );
+            tr.insert(from, view.state.schema.text(text, [mark]));
+            tr.setSelection(TextSelection.create(tr.doc, from + text.length));
           }
 
           view.dispatch(tr.scrollIntoView());
@@ -747,6 +815,13 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
         getSelectionCommentIds(currentEditor),
       equalityFn: areCommentIdListsEqual,
     }) ?? [];
+  const activeChangeIds =
+    useEditorState({
+      editor,
+      selector: ({ editor: currentEditor }) =>
+        getSelectionCriticChangeIds(currentEditor),
+      equalityFn: areCommentIdListsEqual,
+    }) ?? [];
 
   const { commentGroups, contentHeight, measureLayout } =
     useCommentAnchorLayout(editor, comments.size > 0);
@@ -764,6 +839,12 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
       getPreferredCommentId(activeCommentIds, current),
     );
   }, [activeCommentIds]);
+
+  useEffect(() => {
+    setSelectedChangeId((current) =>
+      getPreferredCriticChangeId(activeChangeIds, current),
+    );
+  }, [activeChangeIds]);
 
   useEffect(() => {
     if (!editor) return;

--- a/packages/app/src/editor-extensions.ts
+++ b/packages/app/src/editor-extensions.ts
@@ -525,11 +525,23 @@ function createCriticChangeHighlightDecorations(
 
     if (!isSelected && !isHovered) return;
 
+    const changeKind = node.marks.find(
+      (mark) =>
+        mark.type === changeMarkType &&
+        typeof mark.attrs.changeId === "string" &&
+        changeIds.includes(mark.attrs.changeId) &&
+        isCriticChangeKind(mark.attrs.kind),
+    )?.attrs.kind as CriticChangeKind | undefined;
     decorations.push(
       Decoration.inline(pos, pos + node.nodeSize, {
-        class: isSelected
-          ? "critic-change-decoration-active"
-          : "critic-change-decoration-hovered",
+        class: [
+          isSelected
+            ? "critic-change-decoration-active"
+            : "critic-change-decoration-hovered",
+          changeKind ? `critic-change-decoration-${changeKind}` : null,
+        ]
+          .filter(Boolean)
+          .join(" "),
       }),
     );
   });

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -126,8 +126,8 @@
 
   .tiptap .critic-change-addition,
   .tiptap .critic-change-substitution-new {
-    @apply rounded-sm px-0.5 text-emerald-950;
-    background-color: rgb(209 250 229 / 0.9);
+    @apply rounded-sm px-0.5 text-emerald-850;
+    background-color: rgb(236 253 245 / 0.95);
     text-decoration: underline;
     text-decoration-color: rgb(16 185 129 / 0.75);
     text-underline-offset: 0.16em;
@@ -136,15 +136,65 @@
   .tiptap .critic-change-deletion,
   .tiptap .critic-change-substitution-old {
     @apply rounded-sm px-0.5 text-rose-950;
-    background-color: rgb(255 228 230 / 0.95);
+    background-color: rgb(255 241 242 / 0.95);
     text-decoration: line-through;
     text-decoration-color: rgb(225 29 72 / 0.75);
   }
 
-  .tiptap .critic-change-decoration-hovered,
-  .tiptap .critic-change-decoration-active {
-    @apply ring-2 ring-emerald-300/80;
+  .tiptap .critic-change-decoration-hovered {
     border-radius: 0.2rem;
+  }
+
+  .tiptap .critic-change-decoration-active {
+    border-radius: 0.2rem;
+  }
+
+  .tiptap .critic-change-addition.critic-change-decoration-hovered,
+  .tiptap .critic-change-substitution-new.critic-change-decoration-hovered,
+  .tiptap .critic-change-decoration-addition.critic-change-decoration-hovered,
+  .tiptap
+    .critic-change-decoration-substitution-new.critic-change-decoration-hovered,
+  .tiptap .critic-change-decoration-hovered .critic-change-addition,
+  .tiptap .critic-change-decoration-hovered .critic-change-substitution-new,
+  .tiptap .critic-change-addition .critic-change-decoration-hovered,
+  .tiptap .critic-change-substitution-new .critic-change-decoration-hovered {
+    background-color: rgb(209 250 229 / 0.95);
+  }
+
+  .tiptap .critic-change-addition.critic-change-decoration-active,
+  .tiptap .critic-change-substitution-new.critic-change-decoration-active,
+  .tiptap .critic-change-decoration-addition.critic-change-decoration-active,
+  .tiptap
+    .critic-change-decoration-substitution-new.critic-change-decoration-active,
+  .tiptap .critic-change-decoration-active .critic-change-addition,
+  .tiptap .critic-change-decoration-active .critic-change-substitution-new,
+  .tiptap .critic-change-addition .critic-change-decoration-active,
+  .tiptap .critic-change-substitution-new .critic-change-decoration-active {
+    background-color: rgb(167 243 208 / 0.95);
+  }
+
+  .tiptap .critic-change-deletion.critic-change-decoration-hovered,
+  .tiptap .critic-change-substitution-old.critic-change-decoration-hovered,
+  .tiptap .critic-change-decoration-deletion.critic-change-decoration-hovered,
+  .tiptap
+    .critic-change-decoration-substitution-old.critic-change-decoration-hovered,
+  .tiptap .critic-change-decoration-hovered .critic-change-deletion,
+  .tiptap .critic-change-decoration-hovered .critic-change-substitution-old,
+  .tiptap .critic-change-deletion .critic-change-decoration-hovered,
+  .tiptap .critic-change-substitution-old .critic-change-decoration-hovered {
+    background-color: rgb(255 228 230 / 0.95);
+  }
+
+  .tiptap .critic-change-deletion.critic-change-decoration-active,
+  .tiptap .critic-change-substitution-old.critic-change-decoration-active,
+  .tiptap .critic-change-decoration-deletion.critic-change-decoration-active,
+  .tiptap
+    .critic-change-decoration-substitution-old.critic-change-decoration-active,
+  .tiptap .critic-change-decoration-active .critic-change-deletion,
+  .tiptap .critic-change-decoration-active .critic-change-substitution-old,
+  .tiptap .critic-change-deletion .critic-change-decoration-active,
+  .tiptap .critic-change-substitution-old .critic-change-decoration-active {
+    background-color: rgb(254 205 211 / 0.95);
   }
 
   .tiptap code {
@@ -376,6 +426,7 @@
 @theme inline {
   --font-heading: var(--font-sans);
   --font-sans: "Inter Variable", sans-serif;
+  --color-emerald-850: rgb(6 83 61);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -184,6 +184,24 @@ async function insertTextAtEnd(editor: Editor, text: string) {
   await flushReact();
 }
 
+async function typeTextAsBrowserInput(editor: Editor, text: string) {
+  for (const character of text) {
+    await act(async () => {
+      const { from, to } = editor.state.selection;
+      let handled = false;
+
+      editor.view.someProp("handleTextInput", (handler) => {
+        handled = handler(editor.view, from, to, character);
+        return handled;
+      });
+
+      expect(handled).toBe(true);
+    });
+  }
+
+  await flushReact();
+}
+
 function getEditable(container: HTMLElement) {
   const editable = container.querySelector(".ProseMirror");
   expect(editable).not.toBeNull();
@@ -472,6 +490,41 @@ describe("PageCard editor integration", () => {
     );
   });
 
+  it("suggesting mode groups sequential insertion keystrokes into one suggestion", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-suggesting-grouped-insertion-1",
+        title: "Doc Suggesting Grouped Insertion 1",
+        content: "Start-",
+      },
+      interactionMode: "suggesting",
+      selected: true,
+    });
+    const editor = rendered.getEditor();
+
+    vi.useFakeTimers();
+
+    await act(async () => {
+      const range = findTextRange(editor, "Start-");
+      expect(range).not.toBeNull();
+      editor.commands.focus();
+      editor.commands.setTextSelection(range?.to ?? editor.state.selection.to);
+    });
+    await typeTextAsBrowserInput(editor, "now");
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(rendered.onSave).toHaveBeenCalledWith(
+      "doc-suggesting-grouped-insertion-1",
+      expect.stringMatching(
+        /^Start-\{\+\+now\+\+\}\{id="s1" by="user" at="[^"]+"\}\n$/,
+      ),
+    );
+  });
+
   it("suggesting mode turns typed replacement into substitution markup", async () => {
     const rendered = await renderPageCard({
       page: {
@@ -501,6 +554,35 @@ describe("PageCard editor integration", () => {
 
     expect(rendered.onSave).toHaveBeenCalledWith(
       "doc-suggesting-2",
+      expect.stringMatching(
+        /^Use \{~~old~>new~~\}\{id="s1" by="user" at="[^"]+"\} text\n$/,
+      ),
+    );
+  });
+
+  it("suggesting mode groups sequential replacement keystrokes into one suggestion", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-suggesting-grouped-replacement-1",
+        title: "Doc Suggesting Grouped Replacement 1",
+        content: "Use old text",
+      },
+      interactionMode: "suggesting",
+      selected: true,
+    });
+    const editor = rendered.getEditor();
+
+    vi.useFakeTimers();
+    await selectText(editor, "old");
+    await typeTextAsBrowserInput(editor, "new");
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(rendered.onSave).toHaveBeenCalledWith(
+      "doc-suggesting-grouped-replacement-1",
       expect.stringMatching(
         /^Use \{~~old~>new~~\}\{id="s1" by="user" at="[^"]+"\} text\n$/,
       ),
@@ -924,6 +1006,53 @@ describe("PageCard editor integration", () => {
     expect(railText.split(commentText).length - 1).toBe(1);
   });
 
+  it("renders suggestions as comment-style author bubbles", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-suggestion-bubble-1",
+        title: "Doc Suggestion Bubble 1",
+        content:
+          'This sentence removes {--conversation--}{id="s1" by="AI" at="2026-04-25T23:55:00.000Z"}',
+      },
+      selected: true,
+    });
+
+    await flushAnimationFrame();
+
+    const suggestionThread = rendered.container.querySelector<HTMLElement>(
+      '[data-suggestion-thread-container="true"]',
+    );
+    const suggestionText = suggestionThread?.textContent ?? "";
+
+    expect(suggestionText).toContain("AI");
+    expect(suggestionText).toContain('Delete: "conversation"');
+    expect(suggestionText).not.toContain("Deletion");
+  });
+
+  it("renders suggestion replies through the regular comment tree", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-suggestion-tree-1",
+        title: "Doc Suggestion Tree 1",
+        content:
+          'This sentence includes {++clearer wording++}{id="s1" by="user" at="2026-04-25T23:55:00.000Z"}{>>Looks good.<<}{id="c1" by="user" at="2026-04-25T23:56:00.000Z" re="s1"}',
+      },
+      selected: true,
+    });
+
+    await flushAnimationFrame();
+
+    const suggestionThread = rendered.container.querySelector<HTMLElement>(
+      '[data-suggestion-thread-container="true"]',
+    );
+
+    expect(suggestionThread?.textContent).toContain(
+      'Insert: "clearer wording"',
+    );
+    expect(suggestionThread?.textContent).toContain("Looks good.");
+    expect(suggestionThread?.querySelector('[class*="w-px"]')).not.toBeNull();
+  });
+
   it("preserves suggestion color when comments are attached to suggestion text", async () => {
     const rendered = await renderPageCard({
       page: {
@@ -943,6 +1072,38 @@ describe("PageCard editor integration", () => {
     expect(suggestion?.textContent).toContain("clearer wording");
     expect(
       rendered.container.querySelector(".comment-decoration-on-critic-change"),
+    ).not.toBeNull();
+  });
+
+  it("activates a suggestion thread when the cursor is inside suggested text", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-suggestion-cursor-active-1",
+        title: "Doc Suggestion Cursor Active 1",
+        content:
+          'This sentence includes {++clearer wording++}{id="s1" by="user" at="2026-04-25T23:55:00.000Z"}{>>Looks good.<<}{id="c1" by="user" at="2026-04-25T23:56:00.000Z" re="s1"}',
+      },
+      selected: true,
+    });
+    const editor = rendered.getEditor();
+
+    await flushAnimationFrame();
+    const range = findTextRange(editor, "clearer wording");
+    expect(range).not.toBeNull();
+
+    await act(async () => {
+      editor.commands.focus();
+      editor.commands.setTextSelection((range?.from ?? 1) + 1);
+    });
+    await flushReact();
+    await flushReact();
+
+    const suggestionThread = rendered.container.querySelector<HTMLElement>(
+      '[data-suggestion-thread-container="true"]',
+    );
+    expect(suggestionThread?.classList.contains("-translate-x-2")).toBe(true);
+    expect(
+      rendered.container.querySelector(".critic-change-decoration-active"),
     ).not.toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- group sequential suggestion typing into a single insertion or replacement suggestion
- select and highlight suggestion threads when the cursor is inside suggested text
- render suggestion bubbles through the regular comment thread UI, including author display, shared actions, and reply tree lines
- tune suggestion highlight colors and add regression coverage for grouped suggestions and suggestion rail behavior

## Tests
- pnpm exec biome check packages/app/src/CommentEditorList.tsx packages/app/src/DocumentReviewRail.tsx packages/app/src/PageCard.tsx packages/app/src/editor-extensions.ts packages/app/src/style.css packages/app/test/page-card.test.tsx --assist-enabled=false
- pnpm --filter @roughdraft/app test -- page-card.test.tsx
- pnpm --filter @roughdraft/app build