### PR TITLE
Improve document toolbar controls

### DIFF
--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -1,7 +1,27 @@
-import { CodeXml, Eye, RefreshCcw, Upload } from "lucide-react";
+import {
+  CodeXml,
+  Eye,
+  MessageSquarePlus,
+  PencilLine,
+  RefreshCcw,
+  Upload,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 import type { DocumentEditorViewMode } from "./app-navigation";
 import { Button } from "./components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectItemText,
+  SelectTrigger,
+  SelectValue,
+} from "./components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "./components/ui/tooltip";
 import { criticMarkdownHasReviewRail } from "./critic-markup";
 import { cn } from "./lib/utils";
 import { PageCard, type DocumentInteractionMode } from "./PageCard";
@@ -9,6 +29,16 @@ import type { Page, StorageBackend } from "./storage";
 
 type SaveState = "idle" | "saving" | "error";
 type DiskChangeState = "clean" | "changed" | "conflict";
+
+const documentInteractionModeOptions = [
+  { value: "editing", label: "editing", Icon: PencilLine },
+  { value: "suggesting", label: "suggesting", Icon: MessageSquarePlus },
+  { value: "viewing", label: "viewing", Icon: Eye },
+] satisfies {
+  value: DocumentInteractionMode;
+  label: string;
+  Icon: typeof Eye;
+}[];
 
 interface DocumentWorkspaceProps {
   documentPage: Page | null;
@@ -58,105 +88,134 @@ export function DocumentWorkspace({
     );
   }, [documentPage]);
 
+  const editorViewModeToggleLabel =
+    documentEditorViewMode === "rich-text"
+      ? "Switch to code view"
+      : "Switch to rich text view";
+  const activeDocumentInteractionMode = documentInteractionModeOptions.find(
+    (option) => option.value === documentInteractionMode,
+  );
+  const ActiveDocumentInteractionModeIcon =
+    activeDocumentInteractionMode?.Icon ?? PencilLine;
+
   return (
     <div className="min-h-0 flex-1 overflow-y-auto px-8 pt-10 pb-8 sm:px-12">
       <div className="mx-auto min-h-full max-w-[1080px]">
         {documentPage ? (
           <div
             className={cn(
-              "document-page-header mb-2 flex w-full max-w-[46.5rem] flex-wrap items-center gap-1.5 px-1 text-[0.62rem] font-medium tracking-[0.01em] text-stone-400",
-              !documentHasComments && "document-page-header-no-comments",
+              "document-page-shell mb-2 text-[0.62rem] font-medium tracking-[0.01em] text-stone-400",
+              !documentHasComments && "document-page-shell-no-comments",
             )}
           >
-            <button
-              type="button"
-              className="grid h-[1.25rem] shrink-0 grid-cols-2 rounded-[999px] bg-[#DED8CE] px-[2px] py-[2px] shadow-[inset_0_1px_0_rgba(255,251,245,0.72)]"
-              onClick={() =>
-                onDocumentEditorViewModeChange(
-                  documentEditorViewMode === "rich-text" ? "code" : "rich-text",
-                )
-              }
-              aria-label={
-                documentEditorViewMode === "rich-text"
-                  ? "Switch to code view"
-                  : "Switch to rich text view"
-              }
-              title={
-                documentEditorViewMode === "rich-text"
-                  ? "Switch to code view"
-                  : "Switch to rich text view"
-              }
-            >
-              <span
-                className={`flex h-[1rem] w-[1.375rem] items-center justify-center rounded-full transition ${
-                  documentEditorViewMode === "rich-text"
-                    ? "bg-[#FFFDFC] text-stone-700 shadow-[0_1px_2px_rgba(41,37,36,0.12)]"
-                    : "text-stone-500"
-                }`}
-              >
-                <Eye className="size-[0.75rem]" />
-              </span>
-              <span
-                className={`flex h-[1rem] w-[1.375rem] items-center justify-center rounded-full transition ${
-                  documentEditorViewMode === "code"
-                    ? "bg-[#FFFDFC] text-stone-700 shadow-[0_1px_2px_rgba(41,37,36,0.12)]"
-                    : "text-stone-500"
-                }`}
-              >
-                <CodeXml className="size-[0.75rem]" />
-              </span>
-            </button>
-            <div
-              className="min-w-0 truncate font-mono text-[0.7rem] tracking-[0.01em] text-stone-400"
-              title={documentFilenameLabel}
-            >
-              {documentFilenameLabel}
-            </div>
-            <label className="ml-auto flex shrink-0 items-center gap-1.5 rounded-[8px] border border-[#DFDFDC] bg-[#FFFDFC] px-2 py-1 text-[0.68rem] text-stone-600">
-              <span>Mode</span>
-              <select
-                value={documentInteractionMode}
-                className="bg-transparent text-[0.68rem] font-medium text-stone-800 outline-none"
-                aria-label="Document mode"
-                onChange={(event) =>
-                  setDocumentInteractionMode(
-                    event.target.value as DocumentInteractionMode,
-                  )
-                }
-              >
-                <option value="viewing">Viewing</option>
-                <option value="suggesting">Suggesting</option>
-                <option value="editing">Editing</option>
-              </select>
-            </label>
-            {documentDiskChangeState !== "clean" ? (
-              <div className="flex max-w-full shrink-0 items-center gap-1.5 rounded-[8px] border border-amber-200 bg-amber-50 px-2 py-1 text-[0.68rem] text-amber-900">
-                <span className="whitespace-nowrap">
-                  {documentDiskChangeState === "conflict"
-                    ? "Save conflict"
-                    : "Changed on disk"}
-                </span>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="h-6 rounded-[7px] px-1.5 text-[0.68rem] text-amber-950 hover:bg-amber-100"
-                  onClick={() => void onReloadDocumentFromDisk()}
+            <div className="document-page-main min-w-0">
+              <div className="flex w-full flex-wrap items-center gap-1.5 px-1">
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        type="button"
+                        className="grid h-[1.25rem] shrink-0 grid-cols-2 rounded-[999px] bg-[#DED8CE] px-[2px] py-[2px] shadow-[inset_0_1px_0_rgba(255,251,245,0.72)]"
+                      >
+                        <span
+                          className={`flex h-[1rem] w-[1.375rem] items-center justify-center rounded-full transition ${
+                            documentEditorViewMode === "rich-text"
+                              ? "bg-[#FFFDFC] text-stone-700 shadow-[0_1px_2px_rgba(41,37,36,0.12)]"
+                              : "text-stone-500"
+                          }`}
+                        >
+                          <Eye className="size-[0.75rem]" />
+                        </span>
+                        <span
+                          className={`flex h-[1rem] w-[1.375rem] items-center justify-center rounded-full transition ${
+                            documentEditorViewMode === "code"
+                              ? "bg-[#FFFDFC] text-stone-700 shadow-[0_1px_2px_rgba(41,37,36,0.12)]"
+                              : "text-stone-500"
+                          }`}
+                        >
+                          <CodeXml className="size-[0.75rem]" />
+                        </span>
+                      </button>
+                    }
+                    aria-label={editorViewModeToggleLabel}
+                    onClick={() =>
+                      onDocumentEditorViewModeChange(
+                        documentEditorViewMode === "rich-text"
+                          ? "code"
+                          : "rich-text",
+                      )
+                    }
+                  />
+                  <TooltipContent>{editorViewModeToggleLabel}</TooltipContent>
+                </Tooltip>
+                <div
+                  className="min-w-0 truncate font-mono text-[0.7rem] tracking-[0.01em] text-stone-400"
+                  title={documentFilenameLabel}
                 >
-                  <RefreshCcw className="size-3" />
-                  Reload
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="h-6 rounded-[7px] px-1.5 text-[0.68rem] text-amber-950 hover:bg-amber-100"
-                  onClick={() => void onOverwriteDocumentOnDisk()}
-                >
-                  <Upload className="size-3" />
-                  Overwrite
-                </Button>
+                  {documentFilenameLabel}
+                </div>
+                <div className="ml-auto inline-flex h-[1.25rem] shrink-0 items-center">
+                  <Select<DocumentInteractionMode>
+                    value={documentInteractionMode}
+                    onValueChange={(value) => {
+                      if (value) setDocumentInteractionMode(value);
+                    }}
+                  >
+                    <SelectTrigger
+                      aria-label="Document mode"
+                      className="h-[1.5rem] px-1 font-mono text-[0.7rem] leading-[1.25rem] font-normal tracking-[0.01em] text-stone-400 hover:text-stone-500"
+                    >
+                      <ActiveDocumentInteractionModeIcon className="size-[0.68rem]" />
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {documentInteractionModeOptions.map(
+                        ({ value, label, Icon }) => (
+                          <SelectItem key={value} value={value} label={label}>
+                            <Icon className="size-3 text-stone-500" />
+                            <SelectItemText>{label}</SelectItemText>
+                          </SelectItem>
+                        ),
+                      )}
+                    </SelectContent>
+                  </Select>
+                </div>
+                {documentDiskChangeState !== "clean" ? (
+                  <div className="flex max-w-full shrink-0 items-center gap-1.5 rounded-[8px] border border-amber-200 bg-amber-50 px-2 py-1 text-[0.68rem] text-amber-900">
+                    <span className="whitespace-nowrap">
+                      {documentDiskChangeState === "conflict"
+                        ? "Save conflict"
+                        : "Changed on disk"}
+                    </span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 rounded-[7px] px-1.5 text-[0.68rem] text-amber-950 hover:bg-amber-100"
+                      onClick={() => void onReloadDocumentFromDisk()}
+                    >
+                      <RefreshCcw className="size-3" />
+                      Reload
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 rounded-[7px] px-1.5 text-[0.68rem] text-amber-950 hover:bg-amber-100"
+                      onClick={() => void onOverwriteDocumentOnDisk()}
+                    >
+                      <Upload className="size-3" />
+                      Overwrite
+                    </Button>
+                  </div>
+                ) : null}
               </div>
+            </div>
+            {documentHasComments ? (
+              <div
+                className="document-comment-rail pointer-events-none invisible"
+                aria-hidden="true"
+              />
             ) : null}
           </div>
         ) : null}

--- a/packages/app/src/components/ui/select.tsx
+++ b/packages/app/src/components/ui/select.tsx
@@ -1,0 +1,129 @@
+import { Select as SelectPrimitive } from "@base-ui/react/select";
+import { Check, ChevronDown } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Select<Value, Multiple extends boolean | undefined = false>({
+  ...props
+}: SelectPrimitive.Root.Props<Value, Multiple>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      className={cn(
+        "inline-flex items-center justify-between gap-1 rounded-full outline-none transition focus-visible:ring-2 focus-visible:ring-stone-300/70 disabled:pointer-events-none disabled:opacity-50 data-[popup-open]:ring-2 data-[popup-open]:ring-stone-300/70",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        data-slot="select-icon"
+        className="flex shrink-0 items-center text-current transition-transform data-[popup-open]:rotate-180"
+      >
+        <ChevronDown className="size-[0.62rem]" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("truncate", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectContent({
+  className,
+  side = "bottom",
+  sideOffset = 5,
+  align = "end",
+  children,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        align={align}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          className={cn(
+            "z-50 min-w-32 origin-(--transform-origin) rounded-lg border border-[#DCD6CC] bg-[#FFFDFC] p-1 text-xs text-stone-700 shadow-[0_12px_32px_rgba(57,47,38,0.16)] data-[ending-style]:animate-out data-[ending-style]:fade-out-0 data-[ending-style]:zoom-out-95 data-[starting-style]:animate-in data-[starting-style]:fade-in-0 data-[starting-style]:zoom-in-95",
+            className,
+          )}
+          {...props}
+        >
+          <SelectPrimitive.List data-slot="select-list">
+            {children}
+          </SelectPrimitive.List>
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "flex cursor-default items-center gap-2 rounded-md px-2 py-1.5 text-[0.72rem] leading-none outline-none transition select-none data-[highlighted]:bg-[#EEE9E1] data-[highlighted]:text-stone-900 data-[selected]:text-stone-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.ItemIndicator
+        data-slot="select-item-indicator"
+        className="ml-auto flex size-3 items-center justify-center text-stone-700"
+      >
+        <Check className="size-3" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectItemText({
+  className,
+  ...props
+}: SelectPrimitive.ItemText.Props) {
+  return (
+    <SelectPrimitive.ItemText
+      data-slot="select-item-text"
+      className={cn("truncate", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+  SelectItemText,
+};


### PR DESCRIPTION
## Summary
- Add a shared Base UI select wrapper for compact toolbar dropdowns.
- Replace the document mode native select with an iconized select menu.
- Add a tooltip to the rich-text/code view toggle and keep the toolbar aligned with the comment rail.

## Verification
- pnpm --filter @roughdraft/app build