### PR TITLE
Fix repeated Delete in suggest mode

### DIFF
--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -345,6 +345,29 @@ function getReusableSuggestionInputMark(
   return $position.nodeAfter?.marks.find(isReusableSuggestionMark) ?? null;
 }
 
+function getReusableSuggestionDeletionMark(
+  editor: Editor,
+  from: number,
+  to: number,
+): ProseMirrorMark | null {
+  const markType = editor.state.schema.marks.criticChange;
+  if (!markType) return null;
+
+  const isReusableDeletionMark = (mark: ProseMirrorMark) =>
+    mark.type === markType && mark.attrs.kind === "deletion";
+  const beforeRange = editor.state.doc
+    .resolve(from)
+    .nodeBefore?.marks.find(isReusableDeletionMark);
+
+  if (beforeRange) return beforeRange;
+
+  return (
+    editor.state.doc
+      .resolve(to)
+      .nodeAfter?.marks.find(isReusableDeletionMark) ?? null
+  );
+}
+
 function getDocumentCriticChangeRailItems(
   editor: Editor | null,
   comments: ReadonlyMap<string, CriticComment>,
@@ -889,18 +912,19 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
           if (from === to) return false;
 
           event.preventDefault();
-          const change = createCriticChange("deletion", undefined, {
-            existingChanges: getDocumentCriticChanges(currentEditor),
-          });
-          view.dispatch(
-            view.state.tr
-              .addMark(
-                from,
-                to,
-                view.state.schema.marks.criticChange.create(change),
-              )
-              .scrollIntoView(),
-          );
+          const mark =
+            getReusableSuggestionDeletionMark(currentEditor, from, to) ??
+            view.state.schema.marks.criticChange.create(
+              createCriticChange("deletion", undefined, {
+                existingChanges: getDocumentCriticChanges(currentEditor),
+              }),
+            );
+          const nextSelectionPosition = event.key === "Backspace" ? from : to;
+          const tr = view.state.tr.addMark(from, to, mark);
+          tr.setSelection(TextSelection.create(tr.doc, nextSelectionPosition));
+          tr.scrollIntoView();
+
+          view.dispatch(tr);
           return true;
         },
       },

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -202,6 +202,28 @@ async function typeTextAsBrowserInput(editor: Editor, text: string) {
   await flushReact();
 }
 
+async function pressEditorKey(editor: Editor, key: string) {
+  await act(async () => {
+    let handled = false;
+
+    editor.view.someProp("handleKeyDown", (handler) => {
+      handled = handler(
+        editor.view,
+        new KeyboardEvent("keydown", {
+          key,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      return handled;
+    });
+
+    expect(handled).toBe(true);
+  });
+
+  await flushReact();
+}
+
 function getEditable(container: HTMLElement) {
   const editable = container.querySelector(".ProseMirror");
   expect(editable).not.toBeNull();
@@ -713,6 +735,44 @@ describe("PageCard editor integration", () => {
       "doc-suggesting-grouped-replacement-1",
       expect.stringMatching(
         /^Use \{~~old~>new~~\}\{id="s1" by="user" at="[^"]+"\} text\n$/,
+      ),
+    );
+  });
+
+  it("suggesting mode advances repeated Delete keypresses from a cursor", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-suggesting-repeated-delete-1",
+        title: "Doc Suggesting Repeated Delete 1",
+        content: "Start",
+      },
+      interactionMode: "suggesting",
+      selected: true,
+    });
+    const editor = rendered.getEditor();
+
+    vi.useFakeTimers();
+
+    await act(async () => {
+      const range = findTextRange(editor, "Start");
+      expect(range).not.toBeNull();
+      editor.commands.focus();
+      editor.commands.setTextSelection((range?.from ?? 1) + 1);
+    });
+
+    await pressEditorKey(editor, "Delete");
+    await pressEditorKey(editor, "Delete");
+    await pressEditorKey(editor, "Delete");
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(rendered.onSave).toHaveBeenCalledWith(
+      "doc-suggesting-repeated-delete-1",
+      expect.stringMatching(
+        /^S\{--tar--\}\{id="s1" by="user" at="[^"]+"\}t\n$/,
       ),
     );
   });


### PR DESCRIPTION
Fixes repeated Delete keypresses in suggest mode so the cursor advances and adjacent deletion marks reuse the same suggestion. Adds a regression test that presses Delete three times from a cursor and expects one CriticMarkup deletion suggestion.\n\nTests: pnpm test