### PR TITLE
Add agent testing workflow and slog skill

### DIFF
--- a/.claude/skills/slog
+++ b/.claude/skills/slog
@@ -1,0 +1,1 @@
+../../.codex/skills/slog

--- a/.codex/skills/slog/SKILL.md
+++ b/.codex/skills/slog/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: slog
+description: Structured logging workflow for debugging code paths with per-run log files in `.context/slog`. Use when the user says "use slog", asks for structured logging, wants you to instrument a flow, run it, and inspect logs. Triggers on requests like "use slog", "add structured logs", "log this flow", or "debug with slog".
+---
+
+# Structured Logging with slog
+
+Use this skill to debug or verify a concrete code path by writing newline-delimited JSON logs to a run-specific file in `.context/slog`, exercising the path, and then reading the output.
+
+In this repo, treat `slog` as a default self-verification tool:
+
+- Use it when fixing bugs.
+- Use it when building new features.
+- Use it during planning when you need to verify your understanding of the current runtime path before making changes.
+- Prefer it whenever the task depends on what the code actually does at runtime, not just what it appears to do from static reading.
+
+## Default workflow
+
+1. Create a fresh run file. Do not reuse the previous file.
+
+```bash
+bun .codex/skills/slog/scripts/slog.ts new signup-before-fix
+```
+
+2. The helper also writes `.context/slog/current.env`. In this repo, the local dev scripts source that file automatically via `scripts/load-worktree-env.sh`, so a normal restart of `web`, `trigger`, `hocuspocus`, `admin`, or `desktop` is enough to pick up the new slog target.
+3. Use the printed `THOUGHTFUL_SLOG_FILE`, `THOUGHTFUL_SLOG_RUN_ID`, and `THOUGHTFUL_SLOG_LABEL` values only for one-shot commands that do not go through the shared dev scripts.
+4. Add focused structured logs near decisions, boundaries, and surprising state changes.
+5. Trigger the code path yourself when possible.
+6. Read the log file and summarize what changed.
+7. For the next run, mint a new file name again instead of appending to the previous run.
+
+This is the default verification loop:
+
+1. Form a hypothesis about the current behavior or the behavior you expect after a change.
+2. Mint a fresh slog run.
+3. Add focused logs around the branch or boundary that should prove or disprove that hypothesis.
+4. Exercise the real path.
+5. Read the slog file and confirm what happened.
+
+## Per-run file naming
+
+The helper script creates files like:
+
+```text
+.context/slog/20260402T193501Z-a1b2c3d-dirty-signup-before-fix.jsonl
+```
+
+The name captures:
+
+- Timestamp
+- Current git SHA
+- Dirty/clean state
+- Human label for the run
+
+This makes it easy to compare log output across code changes.
+
+## Standard log shape
+
+Use JSONL. Write one JSON object per line with stable keys.
+
+```json
+{
+  "ts": "2026-04-02T19:35:01.123Z",
+  "runId": "20260402T193501Z-a1b2c3d-dirty-signup-before-fix",
+  "source": "apps/web/src/server/example.ts",
+  "event": "signup.user-created",
+  "step": "after-insert",
+  "data": {
+    "userId": "123",
+    "workspaceId": "456"
+  }
+}
+```
+
+Rules:
+
+- Keep keys stable across runs so diffs are meaningful.
+- Prefer small scalar fields and shallow objects.
+- Do not log secrets, tokens, cookies, raw auth headers, or full request bodies unless the user explicitly asks and the data is safe.
+- Include IDs, counts, branch decisions, and error summaries.
+
+## TypeScript helper pattern
+
+Use a small local helper when the code path does not already have one:
+
+```ts
+import fs from "node:fs";
+import path from "node:path";
+
+function appendSlog(
+  source: string,
+  event: string,
+  data: Record<string, unknown> = {},
+  step?: string,
+): void {
+  const file = process.env.THOUGHTFUL_SLOG_FILE;
+  if (!file) return;
+
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.appendFileSync(
+    file,
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      runId: process.env.THOUGHTFUL_SLOG_RUN_ID ?? "manual",
+      source,
+      event,
+      step,
+      data,
+    }) + "\n",
+  );
+}
+```
+
+Guidance:
+
+- Prefer adding logs at system boundaries: request entry, parsed input, DB read/write result, branch selection, downstream call, returned output, caught error.
+- If the code already uses a logger, keep it. Add file logging alongside it only for the investigation.
+- Default to removing temporary instrumentation after the debugging session unless the user wants to keep it.
+
+## Triggering the code path
+
+After instrumenting, try to run the code path yourself.
+
+Preferred order:
+
+1. Existing unit or integration test
+2. Small targeted script
+3. Existing CLI command
+4. Local HTTP request
+5. Browser flow using `agent-browser`
+
+If you cannot trigger it directly, give the user exact steps:
+
+1. The command to create a fresh slog run
+2. Whether the relevant service needs a restart to pick up `.context/slog/current.env`
+3. The exact action to perform manually
+4. The command to read the log file afterward
+
+## Reading logs
+
+Use the helper to recover the latest run:
+
+```bash
+bun .codex/skills/slog/scripts/slog.ts latest
+bun .codex/skills/slog/scripts/slog.ts latest file
+bun .codex/skills/slog/scripts/slog.ts list
+```
+
+Useful follow-up commands:
+
+```bash
+tail -n 200 "$(bun .codex/skills/slog/scripts/slog.ts latest file)"
+jq -c . "$(bun .codex/skills/slog/scripts/slog.ts latest file)"
+rg '"event"' "$(bun .codex/skills/slog/scripts/slog.ts latest file)"
+```
+
+## Comparing runs
+
+When behavior changes between edits:
+
+1. Create a new run file with a label that captures the hypothesis, such as `before-null-guard` or `after-parse-fix`.
+2. Keep the old file.
+3. Compare the normalized outputs.
+
+Example:
+
+```bash
+jq -S . .context/slog/20260402T193501Z-a1b2c3d-dirty-before-null-guard.jsonl > /tmp/run-a.jsonl
+jq -S . .context/slog/20260402T194122Z-e4f5g6h-dirty-after-null-guard.jsonl > /tmp/run-b.jsonl
+diff -u /tmp/run-a.jsonl /tmp/run-b.jsonl
+```
+
+## Completion standard
+
+Do not stop after adding logs. The full `slog` workflow is:
+
+1. Create a new run file
+2. Instrument the code path
+3. Run the path if possible
+4. Read the file
+5. Explain what the logs say
+
+If step 3 is impossible in the current environment, explicitly say what the user needs to do manually.

--- a/.codex/skills/slog/scripts/slog.ts
+++ b/.codex/skills/slog/scripts/slog.ts
@@ -1,0 +1,195 @@
+#!/usr/bin/env bun
+
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+type LatestRun = {
+  createdAt: string;
+  file: string;
+  gitSha: string | null;
+  gitState: "clean" | "dirty" | "unknown";
+  label: string;
+  relativeFile: string;
+  runId: string;
+};
+
+const PROJECT_ROOT = process.cwd();
+const SLOG_DIR = path.join(PROJECT_ROOT, ".context", "slog");
+const LATEST_FILE = path.join(SLOG_DIR, "latest.json");
+const CURRENT_ENV_FILE = path.join(SLOG_DIR, "current.env");
+
+function usage(): never {
+  console.error(`Usage:
+  bun .codex/skills/slog/scripts/slog.ts new [label]
+  bun .codex/skills/slog/scripts/slog.ts latest [field]
+  bun .codex/skills/slog/scripts/slog.ts list
+
+Fields for "latest": runId | label | file | relativeFile | createdAt | gitSha | gitState`);
+  process.exit(1);
+}
+
+function ensureDir(): void {
+  fs.mkdirSync(SLOG_DIR, { recursive: true });
+}
+
+function sanitizeLabel(input: string | undefined): string {
+  const base = (input ?? "run").trim().toLowerCase();
+  const cleaned = base
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 60);
+
+  return cleaned || "run";
+}
+
+function timestampForFilename(date = new Date()): string {
+  return date
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}Z$/, "Z");
+}
+
+function gitSha(): string | null {
+  const result = spawnSync("git", ["rev-parse", "--short", "HEAD"], {
+    cwd: PROJECT_ROOT,
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    return null;
+  }
+
+  const value = result.stdout.trim();
+  return value || null;
+}
+
+function gitState(): "clean" | "dirty" | "unknown" {
+  const result = spawnSync(
+    "git",
+    ["status", "--short", "--untracked-files=normal"],
+    {
+      cwd: PROJECT_ROOT,
+      encoding: "utf8",
+    },
+  );
+
+  if (result.status === 0) {
+    return result.stdout.trim() ? "dirty" : "clean";
+  }
+
+  return "unknown";
+}
+
+function createRun(labelArg: string | undefined): void {
+  ensureDir();
+
+  const label = sanitizeLabel(labelArg);
+  const createdAt = new Date().toISOString();
+  const sha = gitSha();
+  const state = gitState();
+  const runIdParts = [
+    timestampForFilename(),
+    sha,
+    state === "dirty" ? "dirty" : null,
+    label,
+  ].filter(Boolean) as string[];
+  const runId = runIdParts.join("-");
+  const file = path.join(SLOG_DIR, `${runId}.jsonl`);
+  const relativeFile = path.relative(PROJECT_ROOT, file);
+
+  fs.writeFileSync(file, "");
+
+  const latest: LatestRun = {
+    createdAt,
+    file,
+    gitSha: sha,
+    gitState: state,
+    label,
+    relativeFile,
+    runId,
+  };
+
+  fs.writeFileSync(LATEST_FILE, `${JSON.stringify(latest, null, 2)}\n`);
+  fs.writeFileSync(
+    CURRENT_ENV_FILE,
+    [
+      `export THOUGHTFUL_SLOG_FILE="${file}"`,
+      `export THOUGHTFUL_SLOG_RUN_ID="${runId}"`,
+      `export THOUGHTFUL_SLOG_LABEL="${label}"`,
+      "",
+    ].join("\n"),
+  );
+
+  console.log(`Created slog run
+runId=${runId}
+label=${label}
+file=${relativeFile}
+envFile=${path.relative(PROJECT_ROOT, CURRENT_ENV_FILE)}
+
+export THOUGHTFUL_SLOG_FILE="${file}"
+export THOUGHTFUL_SLOG_RUN_ID="${runId}"
+export THOUGHTFUL_SLOG_LABEL="${label}"`);
+}
+
+function readLatest(): LatestRun {
+  if (!fs.existsSync(LATEST_FILE)) {
+    console.error(
+      "No slog run found. Create one first with: bun .codex/skills/slog/scripts/slog.ts new <label>",
+    );
+    process.exit(1);
+  }
+
+  return JSON.parse(fs.readFileSync(LATEST_FILE, "utf8")) as LatestRun;
+}
+
+function printLatest(field: string | undefined): void {
+  const latest = readLatest();
+
+  if (!field) {
+    console.log(JSON.stringify(latest, null, 2));
+    return;
+  }
+
+  const value = latest[field as keyof LatestRun];
+  if (value === undefined) {
+    usage();
+  }
+
+  console.log(String(value));
+}
+
+function listRuns(): void {
+  ensureDir();
+
+  const latest = fs.existsSync(LATEST_FILE) ? readLatest() : null;
+  const files = fs
+    .readdirSync(SLOG_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+    .map((entry) => entry.name)
+    .sort()
+    .reverse();
+
+  for (const fileName of files) {
+    const absolutePath = path.join(SLOG_DIR, fileName);
+    const marker = latest?.file === absolutePath ? "*" : " ";
+    console.log(`${marker} ${path.relative(PROJECT_ROOT, absolutePath)}`);
+  }
+}
+
+const [, , command, arg] = process.argv;
+
+switch (command) {
+  case "new":
+    createRun(arg);
+    break;
+  case "latest":
+    printLatest(arg);
+    break;
+  case "list":
+    listRuns();
+    break;
+  default:
+    usage();
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,50 @@
 # Roughdraft Agent Instructions
 
+## Bug Fix Workflow
+
+When the user asks you to fix something, first have a subagent reproduce the bug with a failing test case before implementing the fix. The subagent should focus on the smallest behavioral test that demonstrates the problem, and should report the failing command, changed test files, and why the failure captures the requested bug.
+
+Tests should follow Kent Beck's desiderata:
+
+- Isolated: tests should return the same results regardless of the order in which they are run.
+- Composable: if tests are isolated, then 1, 10, 100, or 1,000,000 tests can run and get the same results.
+- Fast: tests should run quickly.
+- Inspiring: passing tests should inspire confidence.
+- Writable: tests should be cheap to write relative to the cost of the code being tested.
+- Readable: tests should be comprehensible for the reader, invoking the motivation for writing this particular test.
+- Behavioral: tests should be sensitive to changes in the behavior of the code under test. If the behavior changes, the test result should change.
+- Structure-insensitive: tests should not change their result if the structure of the code changes.
+- Automated: tests should run without human intervention.
+- Specific: if a test fails, the cause of the failure should be obvious.
+- Deterministic: if nothing changes, the test result should not change.
+- Predictive: if the tests all pass, then the code under test should be suitable for production.
+
+## Slog Default
+
+This repo vendors the `slog` skill at `.codex/skills/slog`.
+
+Treat `slog` as a default self-verification tool in this repo.
+
+- Use `slog` when fixing bugs.
+- Use `slog` when building new features.
+- Use `slog` during planning when you need to verify your understanding of the current code path before changing it.
+- Default pattern: mint a fresh run, add focused logs around the decision points, exercise the path, read the log file, and summarize what the logs prove.
+- Prefer `slog` over guesswork when the task depends on how the code actually behaves at runtime.
+
+Basic workflow:
+
+```bash
+bun .codex/skills/slog/scripts/slog.ts new <label>
+```
+
+- Restart any long-running local services after creating the run so they pick up `.context/slog/current.env`.
+- For one-shot commands, source or export `.context/slog/current.env` before running the command.
+- Inspect the latest file with:
+
+```bash
+bun .codex/skills/slog/scripts/slog.ts latest file
+```
+
 ## Worktree-Specific CLI
 
 This repo installs a worktree-specific Roughdraft CLI wrapper during setup.


### PR DESCRIPTION
## Summary
- require bug fixes to start with a subagent-created failing repro test
- document Kent Beck-inspired test desiderata for those repro tests
- vendor the slog skill and make it the default runtime self-verification workflow

## Verification
- ran Created slog run
runId=20260428T030801Z-036c305-agents-workflow-test
label=agents-workflow-test
file=.context/slog/20260428T030801Z-036c305-agents-workflow-test.jsonl
envFile=.context/slog/current.env

export THOUGHTFUL_SLOG_FILE="/Users/nbaschez/conductor/workspaces/roughdraft/yeosu-v1/.context/slog/20260428T030801Z-036c305-agents-workflow-test.jsonl"
export THOUGHTFUL_SLOG_RUN_ID="20260428T030801Z-036c305-agents-workflow-test"
export THOUGHTFUL_SLOG_LABEL="agents-workflow-test"
- ran /Users/nbaschez/conductor/workspaces/roughdraft/yeosu-v1/.context/slog/20260428T030801Z-036c305-agents-workflow-test.jsonl