### PR TITLE
Preserve YAML frontmatter in rich text

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,68 @@
+# Roughdraft Feedback Issues
+
+Source: friend feedback screenshot, pasted commit-blocker text, and local testing in this branch.
+
+## Addressed In This Branch
+
+1. **YAML frontmatter corruption on rich-text round-trip.**
+
+   Rich-text conversion no longer parses YAML frontmatter as Markdown body content, so frontmatter delimiters are preserved as `---` instead of being serialized back as `* * *`.
+
+2. **Frontmatter protected as raw text in rich-text mode.**
+
+   Markdown files with YAML frontmatter now split the frontmatter before rich-text parsing and prepend the original raw frontmatter on save. This preserves delimiters, indentation, arrays, multiline strings, and table-like YAML text unless the user edits the source in code mode.
+
+3. **Initial frontmatter regression coverage.**
+
+   Added tests for exact YAML frontmatter round-trip through the editor conversion layer and for rich-text autosave preserving raw frontmatter while the body changes.
+
+## Remaining Issues To Fix
+
+1. **Autosave can overwrite external git restores.**
+
+   The app has version/conflict plumbing, and current document saves use `expectedVersion`, but the reported behavior still needs an end-to-end reproduction around a stale open tab, pending autosave timer, file watcher updates, and an external `git checkout HEAD -- ...` restore.
+
+   Relevant areas:
+
+   - `packages/app/src/App.tsx`
+   - `packages/app/src/PageCard.tsx`
+   - `packages/app/src/api-backend.ts`
+   - `packages/server/src/index.ts`
+
+2. **Normal Markdown table round-trip can be corrupted.**
+
+   Local testing with `.context/frontmatter-roundtrip-test.md` showed that a normal Markdown table in the body was rewritten with an empty first row after rich-text editing:
+
+   ```md
+   |     |     |
+   | --- | --- |
+   | Column | Value |
+   | Body table | This table should remain editable as Markdown content. |
+   ```
+
+   The frontmatter stayed intact, so this is separate from YAML preservation. It likely lives in the rich-text table parsing/serialization path.
+
+3. **Tables immediately after frontmatter need explicit regression coverage.**
+
+   Table-like text inside YAML frontmatter is now preserved as raw frontmatter, but Markdown tables immediately after frontmatter still need a focused reproduction and expected behavior. This should cover both a table as the first body block and a table following a heading or paragraph.
+
+4. **Need in-app file navigation for project docs.**
+
+   Users jump among `PLAN.md`, `PROGRESS.md`, `RESEARCH.md`, `SPEC.md`, and `STATUS.md`, but currently have to use the CLI to open each file. Backend endpoints for file listing already exist; the frontend needs a project/file sidebar or quick switcher.
+
+5. **Need safer multi-document workflow.**
+
+   Switching docs should handle dirty state, pending autosave timers, file watcher subscriptions, and URL state cleanly. Opening one file after another should not allow stale saves to land on the wrong content or confuse "changed on disk" state.
+
+6. **Need commit-safety regression tests across disk changes.**
+
+   Add tests that open a frontmatter file, round-trip through rich text, simulate an external restore/change, and verify Roughdraft does not rewrite `---` to `* * *` or overwrite a newer disk version.
+
+7. **Need clearer conflict UX for external changes.**
+
+   When a file changes on disk while Roughdraft has unsaved local edits, the app should make the conflict state obvious and give safe choices: reload from disk, keep editing without autosave, or intentionally overwrite.
+
+## Commit-Blocker Text
+
+> Commit blocker: something (Roughdraft, most likely) is re-writing unified-tasks/v1/SPEC.md over my git checkout HEAD --. Working copy starts with * * * again seconds after I restore the valid --- frontmatter from HEAD. The pre-commit hook runs the validator across the whole repo, so the bad file blocks the PR even though it's outside my staged changes. Fix needs you: close the file in Roughdraft (or accept its frontmatter-fix suggestion in-tool, then save). Once the on-disk byte 0 is --- and stays ---, I can re-run the commit.
+

--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -593,6 +593,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
   const [comments, setComments] = useState<Map<string, CriticComment>>(
     () => parsedContent.comments,
   );
+  const frontmatterRef = useRef<string | null>(parsedContent.frontmatter);
 
   useEffect(() => {
     commentsRef.current = comments;
@@ -618,6 +619,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
         editorStateToCriticMarkdown(
           currentDoc,
           nextComments ?? commentsRef.current,
+          { frontmatter: frontmatterRef.current },
         ),
       );
     },
@@ -964,6 +966,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
   useEffect(() => {
     if (!editor) return;
 
+    frontmatterRef.current = parsedContent.frontmatter;
     commentsRef.current = parsedContent.comments;
     setComments(parsedContent.comments);
     setSelectedCommentId(null);

--- a/packages/app/src/critic-markup/index.ts
+++ b/packages/app/src/critic-markup/index.ts
@@ -16,6 +16,8 @@ import {
 import {
   createMarkedRenderer,
   createTurndownService,
+  prependYamlFrontmatter,
+  splitYamlFrontmatter,
   type MarkdownOptions,
 } from "../markdown";
 
@@ -989,31 +991,49 @@ export function criticMarkdownHasReviewRail(
   options?: MarkdownOptions,
 ): boolean {
   const { parser, comments, changes } = createCriticMarked(options);
-  parser.parse(markdown);
+  parser.parse(splitYamlFrontmatter(markdown).body);
   return comments.size > 0 || changes.size > 0;
 }
 
 export function criticMarkdownToEditorState(
   markdown: string,
   options?: MarkdownOptions,
-): { doc: JSONContent; comments: Map<string, CriticComment> } {
+): {
+  doc: JSONContent;
+  comments: Map<string, CriticComment>;
+  frontmatter: string | null;
+} {
+  const { frontmatter, body } = splitYamlFrontmatter(markdown);
   const { parser, comments } = createCriticMarked(options);
-  const html = parser.parse(markdown) as string;
-  const doc = generateJSON(html, extensions);
+  const html = parser.parse(body) as string;
+  const doc = generateJSON(html, extensions) as JSONContent & {
+    yamlFrontmatter?: string;
+  };
+  if (frontmatter) {
+    doc.yamlFrontmatter = frontmatter;
+  }
 
-  return { doc, comments };
+  return { doc, comments, frontmatter };
 }
 
 export function editorStateToCriticMarkdown(
   doc: JSONContent,
   comments: Map<string, CriticComment>,
+  options?: { frontmatter?: string | null },
 ): string {
   const html = generateHTML(doc, extensions);
   const service = createTurndownService();
   addCriticCommentRule(service, comments);
   addCriticChangeRule(service, comments);
   addCriticCodeBlockRule(service);
-  return `${service.turndown(html).trimEnd()}\n`;
+  const frontmatter =
+    options?.frontmatter ??
+    (doc as JSONContent & { yamlFrontmatter?: string }).yamlFrontmatter ??
+    null;
+  return prependYamlFrontmatter(
+    `${service.turndown(html).trimEnd()}\n`,
+    frontmatter,
+  );
 }
 
 export function createCriticComment(

--- a/packages/app/src/markdown.ts
+++ b/packages/app/src/markdown.ts
@@ -6,6 +6,11 @@ export interface MarkdownOptions {
   resolveFileUrl?: (path: string) => string | null;
 }
 
+export interface YamlFrontmatterSplit {
+  frontmatter: string | null;
+  body: string;
+}
+
 function isExternalUrl(path: string): boolean {
   return /^(?:[a-z]+:)?\/\//i.test(path) || path.startsWith("data:");
 }
@@ -33,6 +38,59 @@ function resolveRenderedUrl(
 ) {
   if (isExternalUrl(path) || isInPageAnchor(path)) return path;
   return resolveFileUrl?.(path) ?? path;
+}
+
+function isYamlFrontmatterDelimiter(line: string): boolean {
+  return /^(?:---|\.\.\.)[ \t]*$/.test(line.replace(/\r$/, ""));
+}
+
+export function splitYamlFrontmatter(markdown: string): YamlFrontmatterSplit {
+  const openingDelimiter = markdown.match(/^---[ \t]*(?:\r\n|\n)/);
+  if (!openingDelimiter) return { frontmatter: null, body: markdown };
+
+  let lineStart = openingDelimiter[0].length;
+
+  while (lineStart < markdown.length) {
+    const nextLineBreak = markdown.indexOf("\n", lineStart);
+    const lineEnd = nextLineBreak === -1 ? markdown.length : nextLineBreak + 1;
+    const line = markdown.slice(
+      lineStart,
+      nextLineBreak === -1 ? lineEnd : lineEnd - 1,
+    );
+
+    if (isYamlFrontmatterDelimiter(line)) {
+      let bodyStart = lineEnd;
+
+      while (bodyStart < markdown.length) {
+        const blankLineBreak = markdown.indexOf("\n", bodyStart);
+        const blankLineEnd =
+          blankLineBreak === -1 ? markdown.length : blankLineBreak + 1;
+        const blankLine = markdown.slice(
+          bodyStart,
+          blankLineBreak === -1 ? blankLineEnd : blankLineEnd - 1,
+        );
+
+        if (blankLine.replace(/\r$/, "").trim() !== "") break;
+        bodyStart = blankLineEnd;
+      }
+
+      return {
+        frontmatter: markdown.slice(0, bodyStart),
+        body: markdown.slice(bodyStart),
+      };
+    }
+
+    lineStart = lineEnd;
+  }
+
+  return { frontmatter: null, body: markdown };
+}
+
+export function prependYamlFrontmatter(
+  markdown: string,
+  frontmatter?: string | null,
+): string {
+  return frontmatter ? `${frontmatter}${markdown}` : markdown;
 }
 
 export function createMarkedRenderer(options?: MarkdownOptions) {

--- a/packages/app/test/critic-markup.test.ts
+++ b/packages/app/test/critic-markup.test.ts
@@ -12,6 +12,29 @@ import {
 import { createEditorExtensions } from "../src/editor-extensions";
 
 describe("CriticMarkup comments", () => {
+  it("preserves YAML frontmatter delimiters and raw table-like YAML text", () => {
+    const input = [
+      "---",
+      "title: Frontmatter round trip",
+      "summary: |",
+      "  | column | value |",
+      "  | --- | --- |",
+      "  | path | docs/table.md |",
+      "tags:",
+      "  - roughdraft",
+      "---",
+      "",
+      "# Body",
+      "",
+      "Opening this file in rich text should not rewrite frontmatter.",
+      "",
+    ].join("\n");
+
+    const { doc, comments } = criticMarkdownToEditorState(input);
+
+    expect(editorStateToCriticMarkdown(doc, comments)).toBe(input);
+  });
+
   it("detects review rail content without counting fenced examples", () => {
     expect(
       criticMarkdownHasReviewRail(

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -439,6 +439,43 @@ describe("PageCard editor integration", () => {
     expect(rendered.onSaveStateChange.mock.calls.at(-1)?.[0]).toBe("idle");
   });
 
+  it("rich-text edits preserve raw YAML frontmatter on autosave", async () => {
+    const frontmatter = [
+      "---",
+      "title: Frontmatter autosave",
+      "summary: |",
+      "  | column | value |",
+      "  | --- | --- |",
+      "  | path | docs/table.md |",
+      "tags:",
+      "  - roughdraft",
+      "---",
+      "",
+    ].join("\n");
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-frontmatter-autosave-1",
+        title: "Doc Frontmatter Autosave 1",
+        content: `${frontmatter}# Body\n\nKeep this body editable.\n`,
+      },
+      selected: true,
+    });
+
+    vi.useFakeTimers();
+
+    await insertTextAtEnd(rendered.getEditor(), " updated");
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(rendered.onSave).toHaveBeenCalledTimes(1);
+    expect(rendered.onSave.mock.calls[0]?.[1]).toBe(
+      `${frontmatter}# Body\n\nKeep this body editable. updated\n`,
+    );
+  });
+
   it("viewing mode disables rich-text editing", async () => {
     const rendered = await renderPageCard({
       page: {


### PR DESCRIPTION
## Summary
Preserves YAML frontmatter as raw text during rich-text parsing and autosave so delimiters stay as `---` instead of becoming horizontal rules. Adds regression coverage for exact frontmatter round-trips and rich-text autosave with frontmatter. Adds `ISSUES.md` to track remaining feedback items, including table round-trip behavior and multi-document safety.

## Verification
- `pnpm --dir packages/app test`
- `pnpm --dir packages/app build`
- `pnpm test`
- `pnpm lint`