### PR TITLE
Preserve markdown table headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,17 @@ pnpm dev:install-cli
 
 Then recompute `roughdraft_cmd` and use it.
 
+## Pull Request Workflow
+
+Before creating or updating a PR:
+
+1. Run `pnpm check`.
+2. Fix any lint, format, test, or build failures.
+3. Confirm `git status --short` only shows intended changes.
+4. Commit and push.
+5. Create the PR with `gh pr create --base main`.
+6. If the PR resolves GitHub issues, include closing keywords such as `Fixes #123` in the PR body.
+
 ## Roughdraft Workflow
 
 Use Roughdraft when the user wants to open, review, or comment on a Markdown file.

--- a/packages/app/src/markdown.ts
+++ b/packages/app/src/markdown.ts
@@ -32,6 +32,47 @@ function normalizeMarkdownPath(path: string): string {
   return `./${path.replace(/^\/+/, "")}`;
 }
 
+function tableHasUnsupportedMarkdownContent(table: HTMLTableElement): boolean {
+  return Boolean(
+    table.querySelector(
+      "blockquote, h1, h2, h3, h4, h5, h6, hr, ol, pre, table, ul",
+    ),
+  );
+}
+
+function getFirstTableRow(table: HTMLTableElement): HTMLTableRowElement | null {
+  return table.rows.length > 0 ? table.rows[0] : null;
+}
+
+function isHeaderTableRow(row: HTMLTableRowElement | null): boolean {
+  if (!row || row.cells.length === 0) return false;
+
+  return Array.from(row.cells).every((cell) => cell.tagName === "TH");
+}
+
+function isMarkdownTableDivider(line: string | undefined): boolean {
+  return Boolean(line && /^\|?(?:\s*:?-{3,}:?\s*\|)+\s*$/.test(line));
+}
+
+function markdownTableDividerForCell(cell: HTMLTableCellElement): string {
+  const alignment = (
+    cell.getAttribute("align") ||
+    cell.style.textAlign ||
+    ""
+  ).toLowerCase();
+
+  if (alignment === "left") return ":---";
+  if (alignment === "right") return "---:";
+  if (alignment === "center") return ":---:";
+
+  return "---";
+}
+
+function markdownTableDividerForRow(row: HTMLTableRowElement): string {
+  const dividers = Array.from(row.cells).map(markdownTableDividerForCell);
+  return `| ${dividers.join(" | ")} |`;
+}
+
 function resolveRenderedUrl(
   path: string,
   resolveFileUrl?: MarkdownOptions["resolveFileUrl"],
@@ -162,6 +203,35 @@ export function createTurndownService(): TurndownService {
 
   service.use(tables as Parameters<TurndownService["use"]>[0]);
   service.use(taskListItems as Parameters<TurndownService["use"]>[0]);
+
+  service.addRule("tiptapHeaderTable", {
+    filter(node) {
+      if (node.tagName !== "TABLE") return false;
+
+      const table = node as HTMLTableElement;
+      return (
+        !tableHasUnsupportedMarkdownContent(table) &&
+        isHeaderTableRow(getFirstTableRow(table))
+      );
+    },
+    replacement(content, node) {
+      const table = node as HTMLTableElement;
+      const headerRow = getFirstTableRow(table);
+      if (!headerRow) return content;
+
+      const lines = content.replace(/\n+/g, "\n").trim().split("\n");
+      if (lines.length === 0) return content;
+
+      if (!isMarkdownTableDivider(lines[1])) {
+        lines.splice(1, 0, markdownTableDividerForRow(headerRow));
+      }
+
+      const captionContent = table.caption?.textContent || "";
+      const caption = captionContent ? `${captionContent}\n\n` : "";
+
+      return `\n\n${caption}${lines.join("\n")}\n\n`;
+    },
+  });
 
   // We own the markdown parser and want stable round-trips without doubled escapes.
   service.escape = (value: string) => value;

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -537,35 +537,35 @@ describe("PageCard editor integration", () => {
         "| Body table | This table follows a heading. |",
       ],
     },
-  ])(
-    "rich-text edits preserve table headers after frontmatter $label",
-    async ({ label, bodyLines }) => {
-      const frontmatter = ["---", "title: Table body", "---", ""].join("\n");
-      const body = [...bodyLines, ""].join("\n");
-      const rendered = await renderPageCard({
-        page: {
-          id: `doc-frontmatter-table-autosave-${label.replaceAll(" ", "-")}`,
-          title: "Doc Frontmatter Table Autosave",
-          content: `${frontmatter}${body}`,
-        },
-        selected: true,
-      });
+  ])("rich-text edits preserve table headers after frontmatter $label", async ({
+    label,
+    bodyLines,
+  }) => {
+    const frontmatter = ["---", "title: Table body", "---", ""].join("\n");
+    const body = [...bodyLines, ""].join("\n");
+    const rendered = await renderPageCard({
+      page: {
+        id: `doc-frontmatter-table-autosave-${label.replaceAll(" ", "-")}`,
+        title: "Doc Frontmatter Table Autosave",
+        content: `${frontmatter}${body}`,
+      },
+      selected: true,
+    });
 
-      vi.useFakeTimers();
+    vi.useFakeTimers();
 
-      await insertTextAtEnd(rendered.getEditor(), " updated");
+    await insertTextAtEnd(rendered.getEditor(), " updated");
 
-      await act(async () => {
-        vi.advanceTimersByTime(500);
-        await Promise.resolve();
-      });
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
 
-      expect(rendered.onSave).toHaveBeenCalledTimes(1);
-      expect(rendered.onSave.mock.calls[0]?.[1]).toBe(
-        `${frontmatter}${[...bodyLines, "", "updated", ""].join("\n")}`,
-      );
-    },
-  );
+    expect(rendered.onSave).toHaveBeenCalledTimes(1);
+    expect(rendered.onSave.mock.calls[0]?.[1]).toBe(
+      `${frontmatter}${[...bodyLines, "", "updated", ""].join("\n")}`,
+    );
+  });
 
   it("viewing mode disables rich-text editing", async () => {
     const rendered = await renderPageCard({

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -476,6 +476,97 @@ describe("PageCard editor integration", () => {
     );
   });
 
+  it("rich-text edits preserve normal markdown table headers on autosave", async () => {
+    const content = [
+      "# Body",
+      "",
+      "| Column | Value |",
+      "| --- | --- |",
+      "| Body table | This table should remain editable as Markdown content. |",
+      "",
+    ].join("\n");
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-table-autosave-1",
+        title: "Doc Table Autosave 1",
+        content,
+      },
+      selected: true,
+    });
+
+    vi.useFakeTimers();
+
+    await insertTextAtEnd(rendered.getEditor(), " updated");
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(rendered.onSave).toHaveBeenCalledTimes(1);
+    expect(rendered.onSave.mock.calls[0]?.[1]).toBe(
+      [
+        "# Body",
+        "",
+        "| Column | Value |",
+        "| --- | --- |",
+        "| Body table | This table should remain editable as Markdown content. |",
+        "",
+        "updated",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it.each([
+    {
+      label: "as first body block",
+      bodyLines: [
+        "| Column | Value |",
+        "| --- | --- |",
+        "| Body table | This table is the first body block. |",
+      ],
+    },
+    {
+      label: "after a heading",
+      bodyLines: [
+        "# Body",
+        "",
+        "| Column | Value |",
+        "| --- | --- |",
+        "| Body table | This table follows a heading. |",
+      ],
+    },
+  ])(
+    "rich-text edits preserve table headers after frontmatter $label",
+    async ({ label, bodyLines }) => {
+      const frontmatter = ["---", "title: Table body", "---", ""].join("\n");
+      const body = [...bodyLines, ""].join("\n");
+      const rendered = await renderPageCard({
+        page: {
+          id: `doc-frontmatter-table-autosave-${label.replaceAll(" ", "-")}`,
+          title: "Doc Frontmatter Table Autosave",
+          content: `${frontmatter}${body}`,
+        },
+        selected: true,
+      });
+
+      vi.useFakeTimers();
+
+      await insertTextAtEnd(rendered.getEditor(), " updated");
+
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+        await Promise.resolve();
+      });
+
+      expect(rendered.onSave).toHaveBeenCalledTimes(1);
+      expect(rendered.onSave.mock.calls[0]?.[1]).toBe(
+        `${frontmatter}${[...bodyLines, "", "updated", ""].join("\n")}`,
+      );
+    },
+  );
+
   it("viewing mode disables rich-text editing", async () => {
     const rendered = await renderPageCard({
       page: {


### PR DESCRIPTION
## Summary
- Preserve Tiptap-rendered Markdown table headers during rich-text autosave.
- Add regression coverage for normal tables and tables immediately after YAML frontmatter.

## Tests
- pnpm --filter @roughdraft/app test -- page-card.test.tsx -t "table headers"
- pnpm --filter @roughdraft/app test
- pnpm --filter @roughdraft/app build

Fixes #31
Fixes #32