### PR TITLE
Preserve markdown rich text round trips

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,10 @@ Useful commands:
 "$roughdraft_cmd" help
 ```
 
+## PR Workflow
+
+When creating a PR, rebase the current branch on the latest `origin/main` before pushing and opening the PR.
+
 ## CriticMarkup
 
 Use CriticMarkup when reading or writing inline review feedback in markdown:

--- a/packages/app/src/critic-markup/index.ts
+++ b/packages/app/src/critic-markup/index.ts
@@ -17,6 +17,7 @@ import {
   createMarkedRenderer,
   createTurndownService,
   prependYamlFrontmatter,
+  protectRichTextRoundTripMarkdown,
   splitYamlFrontmatter,
   type MarkdownOptions,
 } from "../markdown";
@@ -1005,7 +1006,7 @@ export function criticMarkdownToEditorState(
 } {
   const { frontmatter, body } = splitYamlFrontmatter(markdown);
   const { parser, comments } = createCriticMarked(options);
-  const html = parser.parse(body) as string;
+  const html = parser.parse(protectRichTextRoundTripMarkdown(body)) as string;
   const doc = generateJSON(html, extensions) as JSONContent & {
     yamlFrontmatter?: string;
   };

--- a/packages/app/src/editor-extensions.ts
+++ b/packages/app/src/editor-extensions.ts
@@ -1,4 +1,4 @@
-import { Extension, Mark, mergeAttributes } from "@tiptap/core";
+import { Extension, Mark, Node, mergeAttributes } from "@tiptap/core";
 import Code from "@tiptap/extension-code";
 import CodeBlock from "@tiptap/extension-code-block";
 import Image from "@tiptap/extension-image";
@@ -17,6 +17,7 @@ import type {
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import StarterKit from "@tiptap/starter-kit";
+import { rawMarkdownBlockAttribute } from "./markdown";
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
@@ -608,12 +609,26 @@ const MarkdownLink = Link.extend({
   addAttributes() {
     return {
       ...this.parent?.(),
+      title: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("title"),
+        renderHTML: (attributes) =>
+          attributes.title ? { title: attributes.title } : {},
+      },
       dataMarkdownSrc: {
         default: null,
         parseHTML: (element) => element.getAttribute("data-markdown-src"),
         renderHTML: (attributes) =>
           attributes.dataMarkdownSrc
             ? { "data-markdown-src": attributes.dataMarkdownSrc }
+            : {},
+      },
+      dataMarkdownAutolink: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-markdown-autolink"),
+        renderHTML: (attributes) =>
+          attributes.dataMarkdownAutolink
+            ? { "data-markdown-autolink": attributes.dataMarkdownAutolink }
             : {},
       },
     };
@@ -632,6 +647,12 @@ const MarkdownImage = Image.extend({
   addAttributes() {
     return {
       ...this.parent?.(),
+      title: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("title"),
+        renderHTML: (attributes) =>
+          attributes.title ? { title: attributes.title } : {},
+      },
       dataMarkdownSrc: {
         default: null,
         parseHTML: (element) => element.getAttribute("data-markdown-src"),
@@ -641,6 +662,34 @@ const MarkdownImage = Image.extend({
             : {},
       },
     };
+  },
+});
+
+const RawMarkdownBlock = Node.create({
+  name: "rawMarkdownBlock",
+  group: "block",
+  atom: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      rawMarkdown: {
+        default: "",
+        parseHTML: (element) =>
+          element.getAttribute(rawMarkdownBlockAttribute) ?? "",
+        renderHTML: (attributes) => ({
+          [rawMarkdownBlockAttribute]: attributes.rawMarkdown ?? "",
+        }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: `div[${rawMarkdownBlockAttribute}]`, priority: 1000 }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["div", mergeAttributes(HTMLAttributes)];
   },
 });
 
@@ -675,6 +724,7 @@ export function createEditorExtensions(placeholder: string) {
     }),
     CommentRef,
     CriticChange,
+    RawMarkdownBlock,
     MarkdownCodeBlock,
     CommentHighlight,
     CriticChangeHighlight,

--- a/packages/app/src/markdown.ts
+++ b/packages/app/src/markdown.ts
@@ -2,6 +2,8 @@ import { tables, taskListItems } from "@joplin/turndown-plugin-gfm";
 import { marked } from "marked";
 import TurndownService from "turndown";
 
+export const rawMarkdownBlockAttribute = "data-markdown-raw-block";
+
 export interface MarkdownOptions {
   resolveFileUrl?: (path: string) => string | null;
 }
@@ -12,7 +14,7 @@ export interface YamlFrontmatterSplit {
 }
 
 function isExternalUrl(path: string): boolean {
-  return /^(?:[a-z]+:)?\/\//i.test(path) || path.startsWith("data:");
+  return /^[a-z][a-z0-9+.-]*:/i.test(path) || path.startsWith("//");
 }
 
 function isInPageAnchor(path: string): boolean {
@@ -25,6 +27,87 @@ function escapeHtml(value: string): string {
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;");
+}
+
+export function encodeRawMarkdownBlock(markdown: string): string {
+  return encodeURIComponent(markdown);
+}
+
+export function decodeRawMarkdownBlock(encoded: string): string {
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return encoded;
+  }
+}
+
+function createRawMarkdownBlock(markdown: string): string {
+  return `<div ${rawMarkdownBlockAttribute}="${escapeHtml(
+    encodeRawMarkdownBlock(markdown),
+  )}"></div>\n`;
+}
+
+function protectRawHtmlBlocks(markdown: string): string {
+  return markdown
+    .replace(
+      /^[ \t]*<details\b[\s\S]*?<\/details>[ \t]*(?:\r?\n|$)/gim,
+      (raw) => createRawMarkdownBlock(raw),
+    )
+    .replace(/^[ \t]*<!--[\s\S]*?-->[ \t]*(?:\r?\n|$)/gm, (raw) =>
+      createRawMarkdownBlock(raw),
+    );
+}
+
+function protectIndentedCodeAfterLists(markdown: string): string {
+  return markdown.replace(
+    /^(?:[-*+]|\d+[.)]) [^\r\n]*(?:\r?\n)[ \t]*(?:\r?\n)(?:(?: {4}|\t)[^\r\n]*(?:\r?\n|$))+/gm,
+    (raw) => createRawMarkdownBlock(raw),
+  );
+}
+
+function codeSpanContainsPipe(value: string): boolean {
+  return /`[^`\n]*\|[^`\n]*`/.test(value);
+}
+
+function protectPipeSensitiveTables(markdown: string): string {
+  const lines = markdown.match(/[^\r\n]*(?:\r?\n|$)/g) ?? [];
+  const output: string[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    const nextLine = lines[index + 1] ?? "";
+
+    if (
+      !line.includes("|") ||
+      !/^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$/.test(nextLine)
+    ) {
+      output.push(line);
+      continue;
+    }
+
+    const tableLines = [line, nextLine];
+    index += 2;
+
+    while (index < lines.length) {
+      const row = lines[index] ?? "";
+      if (!row.trim() || !row.includes("|")) break;
+      tableLines.push(row);
+      index += 1;
+    }
+
+    const raw = tableLines.join("");
+    const needsProtection = raw.includes("\\|") || codeSpanContainsPipe(raw);
+    output.push(needsProtection ? createRawMarkdownBlock(raw) : raw);
+    index -= 1;
+  }
+
+  return output.join("");
+}
+
+export function protectRichTextRoundTripMarkdown(markdown: string): string {
+  return protectPipeSensitiveTables(
+    protectIndentedCodeAfterLists(protectRawHtmlBlocks(markdown)),
+  );
 }
 
 function normalizeMarkdownPath(path: string): string {
@@ -149,18 +232,22 @@ export function createMarkedRenderer(options?: MarkdownOptions) {
     return `<pre><code${classAttr}>${content}</code></pre>\n`;
   };
 
-  renderer.link = function ({ href, title, tokens }) {
+  renderer.link = function ({ href, title, tokens, raw }) {
     const rawHref = href || "";
     const renderedHref = resolveRenderedUrl(rawHref, resolveFileUrl);
     const text = this.parser.parseInline(tokens);
     const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
     const markdownSrcAttr = ` data-markdown-src="${escapeHtml(rawHref)}"`;
+    const autolinkAttr =
+      !title && raw?.startsWith("<") && raw.endsWith(">")
+        ? ' data-markdown-autolink="true"'
+        : "";
     const externalAttr =
       isExternalUrl(rawHref) && !rawHref.startsWith("mailto:")
         ? ' target="_blank" rel="noreferrer noopener"'
         : "";
 
-    return `<a href="${escapeHtml(renderedHref)}"${titleAttr}${markdownSrcAttr}${externalAttr}>${text}</a>`;
+    return `<a href="${escapeHtml(renderedHref)}"${titleAttr}${markdownSrcAttr}${autolinkAttr}${externalAttr}>${text}</a>`;
   };
 
   renderer.image = ({ href, title, text }) => {
@@ -199,6 +286,17 @@ export function createTurndownService(): TurndownService {
   const service = new TurndownService({
     headingStyle: "atx",
     codeBlockStyle: "fenced",
+    blankReplacement(_content, node) {
+      if (node.hasAttribute(rawMarkdownBlockAttribute)) {
+        return `\n\n${decodeRawMarkdownBlock(
+          node.getAttribute(rawMarkdownBlockAttribute) ?? "",
+        ).trimEnd()}\n\n`;
+      }
+
+      return (node as HTMLElement & { isBlock?: boolean }).isBlock
+        ? "\n\n"
+        : "";
+    },
   });
 
   service.use(tables as Parameters<TurndownService["use"]>[0]);
@@ -248,7 +346,21 @@ export function createTurndownService(): TurndownService {
         isExternalUrl(href) || isInPageAnchor(href)
           ? href
           : normalizeMarkdownPath(href);
-      return `[${content}](${normalizedHref})`;
+      const title = element.getAttribute("title");
+      const titleMarkdown = title
+        ? ` "${title.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`
+        : "";
+
+      if (
+        element.getAttribute("data-markdown-autolink") === "true" &&
+        !titleMarkdown
+      ) {
+        return href.startsWith("mailto:")
+          ? `<${href.slice("mailto:".length)}>`
+          : `<${normalizedHref}>`;
+      }
+
+      return `[${content}](${normalizedHref}${titleMarkdown})`;
     },
   });
 
@@ -264,7 +376,32 @@ export function createTurndownService(): TurndownService {
         ? src
         : normalizeMarkdownPath(src);
       const alt = element.getAttribute("alt") || "";
-      return `![${alt}](${normalizedSrc})`;
+      const title = element.getAttribute("title");
+      const titleMarkdown = title
+        ? ` "${title.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`
+        : "";
+      return `![${alt}](${normalizedSrc}${titleMarkdown})`;
+    },
+  });
+
+  service.addRule("markdownStrikethrough", {
+    filter: (node) =>
+      node.nodeName === "DEL" ||
+      node.nodeName === "S" ||
+      node.nodeName === "STRIKE",
+    replacement(content) {
+      return `~~${content}~~`;
+    },
+  });
+
+  service.addRule("rawMarkdownBlock", {
+    filter: (node) =>
+      node.nodeType === 1 &&
+      (node as HTMLElement).hasAttribute(rawMarkdownBlockAttribute),
+    replacement(_content, node) {
+      const encoded =
+        (node as HTMLElement).getAttribute(rawMarkdownBlockAttribute) ?? "";
+      return `\n\n${decodeRawMarkdownBlock(encoded).trimEnd()}\n\n`;
     },
   });
 

--- a/packages/app/test/critic-markup.test.ts
+++ b/packages/app/test/critic-markup.test.ts
@@ -634,3 +634,86 @@ const command = "{==roughdraft open==}{>>test<<}{id="c1" by="user" at="2026-04-2
     expect(getCommentDescendantIds("c1", comments)).toEqual(["c2", "c3", "c4"]);
   });
 });
+
+function richTextRoundTrip(markdown: string): string {
+  const { doc, comments, frontmatter } = criticMarkdownToEditorState(markdown);
+  return editorStateToCriticMarkdown(doc, comments, { frontmatter });
+}
+
+describe("Markdown rich-text round-trip regressions", () => {
+  it("preserves GFM strikethrough markup", () => {
+    const input = "Keep ~~removed~~ and **bold** text.\n";
+
+    expect(richTextRoundTrip(input)).toBe(input);
+  });
+
+  it("preserves inline link titles", () => {
+    const input = '[Roughdraft](./README.md "Local title")\n';
+
+    expect(richTextRoundTrip(input)).toBe(input);
+  });
+
+  it("preserves image titles", () => {
+    const input = '![Alt text](./image.png "Image title")\n';
+
+    expect(richTextRoundTrip(input)).toBe(input);
+  });
+
+  it("preserves mailto autolinks as mailto URLs", () => {
+    const input = "Visit <https://example.com/a?b=c> or <me@example.com>.\n";
+
+    expect(richTextRoundTrip(input)).toBe(input);
+  });
+
+  it("preserves source-only HTML comments", () => {
+    const input = [
+      "Before",
+      "",
+      "<!-- keep this source note -->",
+      "",
+      "After",
+      "",
+    ].join("\n");
+
+    expect(richTextRoundTrip(input)).toBe(input);
+  });
+
+  it("preserves raw details HTML blocks", () => {
+    const input = [
+      "<details>",
+      "<summary>More</summary>",
+      "",
+      "Hidden **markdown** body.",
+      "",
+      "</details>",
+      "",
+    ].join("\n");
+
+    expect(richTextRoundTrip(input)).toBe(input);
+  });
+
+  it("preserves multi-line indented code blocks after lists", () => {
+    const input = [
+      "- Item before",
+      "",
+      "    code block",
+      "    second line",
+      "",
+      "After",
+      "",
+    ].join("\n");
+
+    expect(richTextRoundTrip(input)).toBe(input);
+  });
+
+  it("preserves table cells containing escaped pipes and inline code pipes", () => {
+    const input = [
+      "| Column | Value |",
+      "| --- | --- |",
+      "| Escaped | `a | b` and plain a \\| b |",
+      "",
+    ].join("\n");
+
+    expect(richTextRoundTrip(input)).toBe(input);
+  });
+});


### PR DESCRIPTION
Preserves more Markdown source constructs when documents move through the rich-text editor, including strikethrough, link and image titles, mailto autolinks, selected raw blocks, indented code after lists, and pipe-sensitive table rows. Adds regression coverage for those round-trip cases. Updates AGENTS.md so future PRs rebase on the latest origin/main before pushing and opening. Verified with pnpm lint, pnpm test, and pnpm build.