### PR TITLE
Add markdown smoke coverage and ADRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,12 @@ jobs:
 
       - name: Run repo checks
         run: pnpm check
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run browser smoke tests
+        run: pnpm test:smoke
+
+      - name: Run coverage thresholds
+        run: pnpm test:coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules
 dist
+coverage
+playwright-report
+test-results
 .DS_Store
 *.tsbuildinfo
 sandbox

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ roughdraft_cmd="roughdraft-dev-$worktree_name"
 Example in this checkout:
 
 ```bash
-roughdraft-dev-lyon-v2 start
+roughdraft-dev-shanghai-v4 start
 ```
 
 Do not use the global `roughdraft` command for repo-local development in this repo unless the user explicitly asks for the published package.
@@ -88,9 +88,39 @@ Before creating or updating a PR:
 1. Run `pnpm check`.
 2. Fix any lint, format, test, or build failures.
 3. Confirm `git status --short` only shows intended changes.
-4. Commit and push.
-5. Create the PR with `gh pr create --base main`.
-6. If the PR resolves GitHub issues, include closing keywords such as `Fixes #123` in the PR body.
+4. Rebase the current branch on the latest `origin/main`.
+5. Commit and push.
+6. Create the PR with `gh pr create --base main`.
+7. If the PR resolves GitHub issues, include closing keywords such as `Fixes #123` in the PR body.
+
+## Plan Writing Workflow
+
+When the user asks for a plan, write the plan as a Markdown file in `.context/` so it is easy to review, revise, and keep out of commits.
+
+Before writing the plan:
+
+1. Read every ADR in `docs/adr/` if that directory exists.
+2. Read the code, tests, and docs needed to ground the plan in the current implementation.
+3. Use `slog` if runtime behavior needs verification before the plan can be accurate.
+
+Plan file guidelines:
+
+- Use a concrete, task-specific filename such as `.context/markdown-smoke-tests-plan.md`.
+- Include goals, non-goals, proposed file changes, test strategy, risks, and suggested implementation order.
+- Keep product-boundary decisions aligned with the ADRs; if the plan needs to change a recorded decision, call that out explicitly.
+- Use CriticMarkup for inline review notes when helpful.
+
+After writing the plan, open it in Roughdraft for review:
+
+```bash
+worktree_root="$(git rev-parse --show-toplevel)"
+worktree_name="$(basename "$worktree_root")"
+roughdraft_cmd="roughdraft-dev-$worktree_name"
+"$roughdraft_cmd" start
+"$roughdraft_cmd" open "$worktree_root/.context/<plan-file>.md"
+```
+
+After the user finishes reviewing in Roughdraft, read the plan file from disk and address any CriticMarkup feedback before implementing.
 
 ## Roughdraft Workflow
 
@@ -122,10 +152,6 @@ Useful commands:
 "$roughdraft_cmd" stop
 "$roughdraft_cmd" help
 ```
-
-## PR Workflow
-
-When creating a PR, rebase the current branch on the latest `origin/main` before pushing and opening the PR.
 
 ## CriticMarkup
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,3 @@
-AGENTS.md
+@AGENTS.md
+
+This file is a Claude Code compatibility shim. Keep shared agent instructions in `AGENTS.md`.

--- a/biome.json
+++ b/biome.json
@@ -5,6 +5,9 @@
       "**",
       "!.context",
       "!.roughdraft-state",
+      "!**/coverage",
+      "!**/playwright-report",
+      "!**/test-results",
       "!**/node_modules",
       "!**/dist"
     ]

--- a/docs/adr/0001-single-local-markdown-file.md
+++ b/docs/adr/0001-single-local-markdown-file.md
@@ -1,0 +1,17 @@
+# 0001: Single Local Markdown File
+
+## Context
+
+Roughdraft's core workflow is opening one ordinary Markdown file from the local filesystem so a human and coding agents can review it together.
+
+## Decision
+
+Roughdraft treats a Markdown file path as the primary unit of work. The server resolves that file within local-file boundaries and the app edits the file directly.
+
+## Consequences
+
+The CLI and app should optimize for quick open, review, edit, save, and close flows. Features that require a project database, global index, or vault model need a separate decision.
+
+## What This Explicitly Does Not Mean
+
+This does not make Roughdraft a vault manager, note database, git client, desktop shell, or multi-document workspace.

--- a/docs/adr/0002-criticmarkup-as-review-format.md
+++ b/docs/adr/0002-criticmarkup-as-review-format.md
@@ -1,0 +1,17 @@
+# 0002: CriticMarkup As Review Format
+
+## Context
+
+Review feedback must remain portable in the Markdown file and readable outside the app.
+
+## Decision
+
+Roughdraft uses CriticMarkup for comments, highlights, insertions, deletions, substitutions, and threaded metadata. The app may render richer controls, but the saved representation is Markdown plus CriticMarkup.
+
+## Consequences
+
+Agents can leave review feedback without depending on Roughdraft-specific sidecar files. Parser and editor changes must preserve CriticMarkup predictably, including escaped metadata and literal examples in code spans or fenced code blocks.
+
+## What This Explicitly Does Not Mean
+
+CriticMarkup is not a hidden product database, chat transcript format, or replacement for normal Markdown content.

--- a/docs/adr/0003-markdown-roundtrip-contract.md
+++ b/docs/adr/0003-markdown-roundtrip-contract.md
@@ -1,0 +1,17 @@
+# 0003: Markdown Round-Trip Contract
+
+## Context
+
+Roughdraft renders Markdown through rich text and code editing surfaces. Accidental rewrites make reviews noisy and can damage documents.
+
+## Decision
+
+Roughdraft should preserve user-authored Markdown unless an edit requires a minimal, understandable serialization change. Frontmatter, local links, image paths, tables, task lists, code fences, inline code, raw supported HTML blocks, and CriticMarkup need explicit tests.
+
+## Consequences
+
+Round-trip tests are part of the product contract. New Markdown support should add fixture coverage before broad parser refactors.
+
+## What This Explicitly Does Not Mean
+
+Roughdraft does not promise to preserve every byte of unsupported Markdown syntax, and it should not normalize documents just to make implementation easier.

--- a/docs/adr/0004-cli-server-state-model.md
+++ b/docs/adr/0004-cli-server-state-model.md
@@ -1,0 +1,17 @@
+# 0004: CLI Server State Model
+
+## Context
+
+The CLI starts or reuses a local server so `roughdraft open <file.md>` works without manual process management.
+
+## Decision
+
+The server state file records the managed background process, port, URL, and start time. The CLI should reuse healthy managed servers, recover from stale state, and avoid claiming ownership of unrelated processes unless explicitly requested.
+
+## Consequences
+
+State handling must remain deterministic and testable. Stale-write protection and local-file boundary checks belong in the core server path.
+
+## What This Explicitly Does Not Mean
+
+The state file is not a project database, collaboration backend, sync system, or persistent document model.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "unused": "knip --no-progress",
     "format": "biome format --write .",
     "test": "pnpm --filter @roughdraft/app test && pnpm --filter @roughdraft/server test",
+    "test:e2e": "playwright test --config packages/app/playwright.config.ts",
+    "test:smoke": "playwright test --config packages/app/playwright.config.ts --grep @smoke",
+    "test:coverage": "pnpm --filter @roughdraft/app exec vitest run --coverage && pnpm --filter @roughdraft/server exec vitest run --coverage",
     "check": "pnpm lint && pnpm test && pnpm build",
     "build": "pnpm --filter @roughdraft/app build && pnpm --filter @roughdraft/server build",
     "preview": "node packages/server/bin/roughdraft.mjs open README.md"
@@ -38,6 +41,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",
+    "@playwright/test": "^1.59.1",
+    "@vitest/coverage-v8": "^4.1.5",
     "knip": "^6.7.0",
     "tsx": "^4.21.0",
     "typescript": "^5.8.3"

--- a/packages/app/e2e/criticmarkup-review.spec.ts
+++ b/packages/app/e2e/criticmarkup-review.spec.ts
@@ -5,6 +5,7 @@ import {
   openMarkdownFile,
   readProjectFile,
   removeMarkdownProject,
+  selectRichText,
   writeProjectFile,
 } from "./helpers";
 
@@ -56,6 +57,39 @@ test.describe("CriticMarkup review flows", () => {
 
     logE2eEvent("criticmarkup.reply-saved", {
       file: "comment.md",
+    });
+  });
+
+  test("creates a new root comment and saves it to disk @smoke", async ({
+    page,
+  }) => {
+    const filePath = writeProjectFile(
+      projectDir,
+      "new-comment.md",
+      [
+        "# New Comment",
+        "",
+        "This paragraph has target text to review.",
+        "",
+      ].join("\n"),
+    );
+
+    await openMarkdownFile(page, filePath);
+    await selectRichText(page, "target text");
+    await page.getByRole("button", { name: /Comment/ }).click();
+    await page
+      .getByRole("textbox", { name: "Add your comment" })
+      .fill("Clarify this phrase.");
+    await page.locator('button[aria-label="Save"]:visible').click();
+
+    await expect
+      .poll(() => readProjectFile(projectDir, "new-comment.md"))
+      .toMatch(
+        /\{==target text==\}\{>>Clarify this phrase\.<<\}\{id="c1" by="user" at="[^"]+"\}/,
+      );
+
+    logE2eEvent("criticmarkup.root-comment-saved", {
+      file: "new-comment.md",
     });
   });
 

--- a/packages/app/e2e/criticmarkup-review.spec.ts
+++ b/packages/app/e2e/criticmarkup-review.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "@playwright/test";
+import {
+  createMarkdownProject,
+  logE2eEvent,
+  openMarkdownFile,
+  readProjectFile,
+  removeMarkdownProject,
+  writeProjectFile,
+} from "./helpers";
+
+test.describe("CriticMarkup review flows", () => {
+  let projectDir: string;
+
+  test.beforeEach(() => {
+    projectDir = createMarkdownProject("criticmarkup");
+  });
+
+  test.afterEach(() => {
+    removeMarkdownProject(projectDir);
+  });
+
+  test("renders a comment thread and saves a reply @smoke", async ({
+    page,
+  }) => {
+    const filePath = writeProjectFile(
+      projectDir,
+      "comment.md",
+      [
+        "# Comment Review",
+        "",
+        'This paragraph has {==target text==}{>>Needs detail<<}{id="c1" by="user" at="2026-04-23T18:00:00.000Z"}.',
+        "",
+      ].join("\n"),
+    );
+
+    await openMarkdownFile(page, filePath);
+    await expect(page.getByText("Needs detail")).toBeVisible();
+
+    await page
+      .getByLabel("Reply")
+      .first()
+      .evaluate((element) => {
+        (element as HTMLButtonElement).click();
+      });
+    await page
+      .getByPlaceholder("Write a reply")
+      .fill("Added context looks good.");
+    await page.getByLabel("Save").evaluate((element) => {
+      (element as HTMLButtonElement).click();
+    });
+
+    await expect
+      .poll(() => readProjectFile(projectDir, "comment.md"))
+      .toContain("Added context looks good.");
+    expect(readProjectFile(projectDir, "comment.md")).toContain('re="c1"');
+
+    logE2eEvent("criticmarkup.reply-saved", {
+      file: "comment.md",
+    });
+  });
+
+  test("accepts and rejects suggested changes on disk @smoke", async ({
+    page,
+  }) => {
+    const filePath = writeProjectFile(
+      projectDir,
+      "suggestions.md",
+      [
+        "# Suggestion Review",
+        "",
+        'Keep {++clear wording++}{id="s1" by="user" at="2026-04-23T18:00:00.000Z"} here.',
+        "",
+        'Remove {--drafty --}{id="s2" by="user" at="2026-04-23T18:01:00.000Z"}there.',
+        "",
+      ].join("\n"),
+    );
+
+    await openMarkdownFile(page, filePath);
+    await expect(page.locator('[data-critic-change-id="s1"]')).toBeVisible();
+
+    await page.getByLabel("Accept suggestion").first().click();
+    await expect
+      .poll(() => readProjectFile(projectDir, "suggestions.md"))
+      .toContain("Keep clear wording here.");
+
+    await page.getByLabel("Reject suggestion").first().click();
+    await expect
+      .poll(() => readProjectFile(projectDir, "suggestions.md"))
+      .toContain("Remove drafty there.");
+    expect(readProjectFile(projectDir, "suggestions.md")).not.toContain("{++");
+    expect(readProjectFile(projectDir, "suggestions.md")).not.toContain("{--");
+
+    logE2eEvent("criticmarkup.suggestions-applied", {
+      file: "suggestions.md",
+    });
+  });
+});

--- a/packages/app/e2e/helpers.ts
+++ b/packages/app/e2e/helpers.ts
@@ -48,6 +48,40 @@ export async function appendInCodeEditor(page: Page, text: string) {
   await page.keyboard.type(text);
 }
 
+export async function selectRichText(page: Page, text: string) {
+  await page.locator(".ProseMirror").focus();
+  await page.evaluate((targetText) => {
+    const editor = document.querySelector(".ProseMirror");
+    if (!editor) {
+      throw new Error("Could not find rich-text editor");
+    }
+
+    const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT);
+    let node = walker.nextNode();
+
+    while (node) {
+      const index = node.textContent?.indexOf(targetText) ?? -1;
+
+      if (index >= 0) {
+        const range = document.createRange();
+        range.setStart(node, index);
+        range.setEnd(node, index + targetText.length);
+
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+
+        document.dispatchEvent(new Event("selectionchange", { bubbles: true }));
+        return;
+      }
+
+      node = walker.nextNode();
+    }
+
+    throw new Error(`Could not find text "${targetText}"`);
+  }, text);
+}
+
 export function logE2eEvent(event: string, data: Record<string, unknown> = {}) {
   const file = process.env.THOUGHTFUL_SLOG_FILE;
   if (!file) return;

--- a/packages/app/e2e/helpers.ts
+++ b/packages/app/e2e/helpers.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+export function createMarkdownProject(label: string) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `roughdraft-${label}-`));
+}
+
+export function removeMarkdownProject(projectDir: string) {
+  fs.rmSync(projectDir, { recursive: true, force: true });
+}
+
+export function writeProjectFile(
+  projectDir: string,
+  relativePath: string,
+  content: string | Buffer,
+) {
+  const absolutePath = path.join(projectDir, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, content);
+  return absolutePath;
+}
+
+export function readProjectFile(projectDir: string, relativePath: string) {
+  return fs.readFileSync(path.join(projectDir, relativePath), "utf8");
+}
+
+export async function openMarkdownFile(
+  page: Page,
+  absolutePath: string,
+  editor?: "rich-text" | "code",
+) {
+  const params = new URLSearchParams({ path: absolutePath });
+  if (editor) params.set("editor", editor);
+
+  await page.goto(`/?${params.toString()}`);
+}
+
+export async function appendInCodeEditor(page: Page, text: string) {
+  const editor = page.locator(".cm-content");
+  await expect(editor).toBeVisible();
+  await editor.click();
+  await page.keyboard.press(
+    process.platform === "darwin" ? "Meta+End" : "Control+End",
+  );
+  await page.keyboard.type(text);
+}
+
+export function logE2eEvent(event: string, data: Record<string, unknown> = {}) {
+  const file = process.env.THOUGHTFUL_SLOG_FILE;
+  if (!file) return;
+
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.appendFileSync(
+    file,
+    `${JSON.stringify({
+      ts: new Date().toISOString(),
+      runId: process.env.THOUGHTFUL_SLOG_RUN_ID ?? "manual",
+      source: "packages/app/e2e",
+      event,
+      data,
+    })}\n`,
+  );
+}

--- a/packages/app/e2e/markdown-roundtrip.spec.ts
+++ b/packages/app/e2e/markdown-roundtrip.spec.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs";
+import { expect, test } from "@playwright/test";
+import {
+  appendInCodeEditor,
+  createMarkdownProject,
+  logE2eEvent,
+  openMarkdownFile,
+  readProjectFile,
+  removeMarkdownProject,
+  writeProjectFile,
+} from "./helpers";
+
+test.describe("markdown round-trips", () => {
+  let projectDir: string;
+
+  test.beforeEach(() => {
+    projectDir = createMarkdownProject("roundtrip");
+  });
+
+  test.afterEach(() => {
+    removeMarkdownProject(projectDir);
+  });
+
+  test("toggles rich text and code mode without rewriting literal CriticMarkup @smoke", async ({
+    page,
+  }) => {
+    const original = [
+      "---",
+      "title: Literal CriticMarkup",
+      "---",
+      "",
+      "# Round Trip",
+      "",
+      "Inline code stays literal: `{==not a comment==}`.",
+      "",
+      "```md",
+      "{>>not review feedback<<}",
+      "{++not a suggestion++}",
+      "```",
+      "",
+    ].join("\n");
+    const filePath = writeProjectFile(projectDir, "roundtrip.md", original);
+
+    await openMarkdownFile(page, filePath);
+    await expect(
+      page.getByRole("heading", { name: "Round Trip" }),
+    ).toBeVisible();
+
+    await page.getByLabel("Switch to code view").click();
+    await expect(page.locator(".cm-content")).toContainText(
+      "{>>not review feedback<<}",
+    );
+
+    await page.getByLabel("Switch to rich text view").click();
+    await expect(
+      page.getByRole("heading", { name: "Round Trip" }),
+    ).toBeVisible();
+    expect(readProjectFile(projectDir, "roundtrip.md")).toBe(original);
+
+    logE2eEvent("markdown-roundtrip.toggle-preserved", {
+      file: "roundtrip.md",
+    });
+  });
+
+  test("saves code-mode edits to disk while preserving fenced CriticMarkup examples @smoke", async ({
+    page,
+  }) => {
+    const initial = [
+      "# Code Save",
+      "",
+      "```md",
+      "{==literal==}{>>example<<}",
+      "```",
+      "",
+    ].join("\n");
+    const filePath = writeProjectFile(projectDir, "code-save.md", initial);
+
+    await openMarkdownFile(page, filePath, "code");
+    await appendInCodeEditor(page, "\nSaved from Playwright.\n");
+
+    await expect
+      .poll(() => readProjectFile(projectDir, "code-save.md"))
+      .toContain("Saved from Playwright.");
+    expect(readProjectFile(projectDir, "code-save.md")).toContain(
+      "{==literal==}{>>example<<}",
+    );
+
+    logE2eEvent("markdown-roundtrip.code-save", {
+      size: fs.statSync(filePath).size,
+    });
+  });
+});

--- a/packages/app/e2e/open-file.spec.ts
+++ b/packages/app/e2e/open-file.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "@playwright/test";
+import {
+  createMarkdownProject,
+  logE2eEvent,
+  openMarkdownFile,
+  removeMarkdownProject,
+  writeProjectFile,
+} from "./helpers";
+
+test.describe("opening local markdown files", () => {
+  let projectDir: string;
+
+  test.beforeEach(() => {
+    projectDir = createMarkdownProject("open-file");
+  });
+
+  test.afterEach(() => {
+    removeMarkdownProject(projectDir);
+  });
+
+  test("renders core Markdown blocks from a real file @smoke", async ({
+    page,
+  }) => {
+    const filePath = writeProjectFile(
+      projectDir,
+      "review.md",
+      [
+        "# Smoke Fixture",
+        "",
+        "A paragraph with [local link](./notes.md), [anchor](#smoke-fixture), and [mail](mailto:review@example.com).",
+        "",
+        "- first",
+        "- second",
+        "",
+        "- [x] shipped",
+        "- [ ] pending",
+        "",
+        "| Name | Status |",
+        "| --- | --- |",
+        "| Roughdraft | ready |",
+        "",
+        '![Sketch](./images/sketch.png "Sketch title")',
+        "",
+        "```ts",
+        "const value = 1;",
+        "```",
+        "",
+      ].join("\n"),
+    );
+    writeProjectFile(
+      projectDir,
+      "images/sketch.png",
+      Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+        "base64",
+      ),
+    );
+
+    await openMarkdownFile(page, filePath);
+
+    await expect(
+      page.getByRole("heading", { name: "Smoke Fixture" }),
+    ).toBeVisible();
+    await expect(page.getByText("first")).toBeVisible();
+    await expect(page.getByRole("cell", { name: "Roughdraft" })).toBeVisible();
+    await expect(
+      page.locator('a[data-markdown-src="./notes.md"]', {
+        hasText: "local link",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.locator(
+        'img[alt="Sketch"][data-markdown-src="./images/sketch.png"]',
+      ),
+    ).toBeVisible();
+    await expect(page.getByText("const value = 1;")).toBeVisible();
+
+    logE2eEvent("open-file.rendered", {
+      projectDir,
+      file: "review.md",
+    });
+  });
+});

--- a/packages/app/e2e/stale-write.spec.ts
+++ b/packages/app/e2e/stale-write.spec.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import { expect, test } from "@playwright/test";
+import {
+  appendInCodeEditor,
+  createMarkdownProject,
+  logE2eEvent,
+  openMarkdownFile,
+  readProjectFile,
+  removeMarkdownProject,
+  writeProjectFile,
+} from "./helpers";
+
+test.describe("stale writes", () => {
+  let projectDir: string;
+
+  test.beforeEach(() => {
+    projectDir = createMarkdownProject("stale-write");
+  });
+
+  test.afterEach(() => {
+    removeMarkdownProject(projectDir);
+  });
+
+  test("surfaces a save conflict when the file changed externally @smoke", async ({
+    page,
+  }) => {
+    await page.route("**/api/markdown-file/events**", (route) => route.abort());
+
+    const filePath = writeProjectFile(
+      projectDir,
+      "conflict.md",
+      "# Conflict\n\nOriginal body.\n",
+    );
+
+    await openMarkdownFile(page, filePath, "code");
+    await expect(page.locator(".cm-content")).toContainText("Original body.");
+
+    fs.writeFileSync(filePath, "# Conflict\n\nExternal body.\n");
+    await appendInCodeEditor(page, "\nLocal body.\n");
+
+    await expect(page.getByText("Save conflict")).toBeVisible();
+    await expect(page.getByText("Reload")).toBeVisible();
+    expect(readProjectFile(projectDir, "conflict.md")).toBe(
+      "# Conflict\n\nExternal body.\n",
+    );
+
+    logE2eEvent("stale-write.conflict-surfaced", {
+      file: "conflict.md",
+    });
+  });
+});

--- a/packages/app/e2e/start-api.ts
+++ b/packages/app/e2e/start-api.ts
@@ -1,0 +1,3 @@
+import { createServer } from "../../server/src/index";
+
+await createServer(Number(process.env.API_PORT ?? 4317));

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@base-ui/react": "^1.4.1",
     "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/lang-yaml": "^6.1.3",
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.41.1",
     "@fontsource-variable/inter": "^5.2.8",

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const appPort = Number(process.env.PLAYWRIGHT_APP_PORT ?? 4318);
+const apiPort = Number(process.env.API_PORT ?? 4317);
+const appUrl = `http://127.0.0.1:${appPort}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  expect: {
+    timeout: 7_500,
+  },
+  fullyParallel: true,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: appUrl,
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: [
+    {
+      command: `API_PORT=${apiPort} pnpm exec tsx e2e/start-api.ts`,
+      port: apiPort,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+    {
+      command: `API_PORT=${apiPort} pnpm dev --host 127.0.0.1 --port ${appPort}`,
+      url: appUrl,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  ],
+});

--- a/packages/app/src/MarkdownCodeEditor.test.ts
+++ b/packages/app/src/MarkdownCodeEditor.test.ts
@@ -1,0 +1,19 @@
+import { EditorState } from "@codemirror/state";
+import { describe, expect, it, vi } from "vitest";
+import { createMarkdownCodeEditorExtensions } from "./MarkdownCodeEditor";
+
+describe("createMarkdownCodeEditorExtensions", () => {
+  it("loads YAML frontmatter and Markdown content without rewriting the document", () => {
+    const input = "---\ntitle: Code mode\n---\n\n# Body\n";
+    const onChange = vi.fn();
+    const state = EditorState.create({
+      doc: input,
+      extensions: createMarkdownCodeEditorExtensions(false, onChange, {
+        current: input,
+      }),
+    });
+
+    expect(state.doc.toString()).toBe(input);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/MarkdownCodeEditor.tsx
+++ b/packages/app/src/MarkdownCodeEditor.tsx
@@ -1,6 +1,7 @@
 import { basicSetup } from "codemirror";
 import { markdown } from "@codemirror/lang-markdown";
-import { EditorState } from "@codemirror/state";
+import { yamlFrontmatter } from "@codemirror/lang-yaml";
+import { EditorState, type Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { useEffect, useRef } from "react";
 
@@ -9,6 +10,75 @@ interface MarkdownCodeEditorProps {
   onChange: (value: string) => void;
   autoFocus?: boolean;
   readOnly?: boolean;
+}
+
+export function createMarkdownCodeEditorExtensions(
+  readOnly: boolean,
+  onDocumentChange: (value: string) => void,
+  lastValueRef: { current: string },
+): Extension[] {
+  return [
+    basicSetup,
+    yamlFrontmatter({ content: markdown() }),
+    EditorView.lineWrapping,
+    EditorState.readOnly.of(readOnly),
+    EditorView.editable.of(!readOnly),
+    EditorView.updateListener.of((update) => {
+      if (!update.docChanged) return;
+
+      const nextValue = update.state.doc.toString();
+      if (nextValue === lastValueRef.current) return;
+
+      lastValueRef.current = nextValue;
+      onDocumentChange(nextValue);
+    }),
+    EditorView.theme({
+      "&": {
+        backgroundColor: "transparent",
+        color: "inherit",
+        fontFamily:
+          'ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, "Liberation Mono", monospace',
+        fontSize: "0.95rem",
+      },
+      ".cm-scroller": {
+        fontFamily: "inherit",
+        lineHeight: "1.75",
+        overflow: "auto",
+      },
+      ".cm-content": {
+        minHeight: "70vh",
+        padding: "0",
+      },
+      ".cm-line": {
+        padding: "0",
+      },
+      ".cm-gutters": {
+        backgroundColor: "transparent",
+        border: "none",
+        color: "rgb(148 163 184)",
+        marginRight: "0.75rem",
+      },
+      ".cm-gutterElement": {
+        padding: "0 0.5rem 0 0",
+      },
+      ".cm-foldGutter": {
+        display: "none",
+      },
+      ".cm-activeLine": {
+        backgroundColor: "transparent",
+      },
+      ".cm-activeLineGutter": {
+        backgroundColor: "transparent",
+        color: "rgb(100 116 139)",
+      },
+      ".cm-selectionBackground, ::selection": {
+        backgroundColor: "rgb(224 242 254)",
+      },
+      "&.cm-focused": {
+        outline: "none",
+      },
+    }),
+  ];
 }
 
 export function MarkdownCodeEditor({
@@ -35,68 +105,11 @@ export function MarkdownCodeEditor({
       parent: hostElement,
       state: EditorState.create({
         doc: initialValueRef.current,
-        extensions: [
-          basicSetup,
-          markdown(),
-          EditorView.lineWrapping,
-          EditorState.readOnly.of(readOnly),
-          EditorView.editable.of(!readOnly),
-          EditorView.updateListener.of((update) => {
-            if (!update.docChanged) return;
-
-            const nextValue = update.state.doc.toString();
-            if (nextValue === lastValueRef.current) return;
-
-            lastValueRef.current = nextValue;
-            onChangeRef.current(nextValue);
-          }),
-          EditorView.theme({
-            "&": {
-              backgroundColor: "transparent",
-              color: "inherit",
-              fontFamily:
-                'ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, "Liberation Mono", monospace',
-              fontSize: "0.95rem",
-            },
-            ".cm-scroller": {
-              fontFamily: "inherit",
-              lineHeight: "1.75",
-              overflow: "auto",
-            },
-            ".cm-content": {
-              minHeight: "70vh",
-              padding: "0",
-            },
-            ".cm-line": {
-              padding: "0",
-            },
-            ".cm-gutters": {
-              backgroundColor: "transparent",
-              border: "none",
-              color: "rgb(148 163 184)",
-              marginRight: "0.75rem",
-            },
-            ".cm-gutterElement": {
-              padding: "0 0.5rem 0 0",
-            },
-            ".cm-foldGutter": {
-              display: "none",
-            },
-            ".cm-activeLine": {
-              backgroundColor: "transparent",
-            },
-            ".cm-activeLineGutter": {
-              backgroundColor: "transparent",
-              color: "rgb(100 116 139)",
-            },
-            ".cm-selectionBackground, ::selection": {
-              backgroundColor: "rgb(224 242 254)",
-            },
-            "&.cm-focused": {
-              outline: "none",
-            },
-          }),
-        ],
+        extensions: createMarkdownCodeEditorExtensions(
+          readOnly,
+          (nextValue) => onChangeRef.current(nextValue),
+          lastValueRef,
+        ),
       }),
     });
 

--- a/packages/app/src/markdown.test.ts
+++ b/packages/app/src/markdown.test.ts
@@ -76,6 +76,20 @@ describe("toHtml", () => {
       '<img src="./images/sketch.png" alt="Sketch" title="Sketch title" data-markdown-src="./images/sketch.png">',
     );
   });
+
+  it("round-trips headerless HTML tables to valid GFM table markdown", () => {
+    expect(toMarkdown(toHtml(readMarkdownFixture("headerless-table.md")))).toBe(
+      [
+        "# Headerless Table",
+        "",
+        "|     |     |",
+        "| --- | --- |",
+        "| First | Ready |",
+        "| Second | Open |",
+        "",
+      ].join("\n"),
+    );
+  });
 });
 
 describe("toMarkdown", () => {

--- a/packages/app/src/markdown.test.ts
+++ b/packages/app/src/markdown.test.ts
@@ -1,5 +1,43 @@
+import fs from "node:fs";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { toHtml, toMarkdown } from "./markdown";
+import {
+  splitYamlFrontmatter,
+  toHtml,
+  toMarkdown,
+  rawMarkdownBlockAttribute,
+} from "./markdown";
+
+function readMarkdownFixture(name: string): string {
+  return fs.readFileSync(
+    path.join(process.cwd(), "test", "fixtures", "markdown", name),
+    "utf8",
+  );
+}
+
+describe("splitYamlFrontmatter", () => {
+  it("preserves CRLF frontmatter byte-for-byte while splitting the body", () => {
+    const input = "---\r\ntitle: CRLF\r\n---\r\n\r\n# Body\r\n";
+
+    expect(splitYamlFrontmatter(input)).toEqual({
+      frontmatter: "---\r\ntitle: CRLF\r\n---\r\n\r\n",
+      body: "# Body\r\n",
+    });
+  });
+
+  it("preserves empty frontmatter and table-like YAML text", () => {
+    const empty = "---\n---\n\n# Body\n";
+    const tableLike = readMarkdownFixture("frontmatter-table-yaml.md");
+
+    expect(splitYamlFrontmatter(empty)).toEqual({
+      frontmatter: "---\n---\n\n",
+      body: "# Body\n",
+    });
+    expect(splitYamlFrontmatter(tableLike).frontmatter).toContain(
+      "  | column | value |",
+    );
+  });
+});
 
 describe("toHtml", () => {
   it("preserves original markdown paths while resolving rendered URLs", () => {
@@ -20,6 +58,24 @@ describe("toHtml", () => {
       '<a href="https://example.com" data-markdown-src="https://example.com" target="_blank" rel="noreferrer noopener">Docs</a>',
     );
   });
+
+  it("renders in-page anchors, mailto links, task lists, and table fixtures", () => {
+    const html = toHtml(
+      `${readMarkdownFixture("links-and-images.md")}\n${readMarkdownFixture("tables-and-task-lists.md")}`,
+    );
+
+    expect(html).toContain(
+      '<a href="#links-and-images" data-markdown-src="#links-and-images">In-page anchor</a>',
+    );
+    expect(html).toContain(
+      '<a href="mailto:review@example.com" data-markdown-src="mailto:review@example.com">Mail</a>',
+    );
+    expect(html).toContain('<ul data-type="taskList">');
+    expect(html).toContain("<table>");
+    expect(html).toContain(
+      '<img src="./images/sketch.png" alt="Sketch" title="Sketch title" data-markdown-src="./images/sketch.png">',
+    );
+  });
 });
 
 describe("toMarkdown", () => {
@@ -38,5 +94,20 @@ describe("toMarkdown", () => {
     );
 
     expect(markdown).toBe("[Jump to comments](#comments)\n");
+  });
+
+  it("ends output with exactly one newline", () => {
+    expect(toMarkdown("<p>Done</p>\n\n")).toBe("Done\n");
+  });
+
+  it("documents the raw HTML policy for generic inline HTML and protected blocks", () => {
+    expect(toMarkdown('<p><span data-x="1">raw</span></p>')).toBe("raw\n");
+
+    const protectedMarkdown = "<!-- keep this source note -->\n";
+    const encoded = encodeURIComponent(protectedMarkdown);
+
+    expect(
+      toMarkdown(`<div ${rawMarkdownBlockAttribute}="${encoded}"></div>`),
+    ).toBe(protectedMarkdown);
   });
 });

--- a/packages/app/test/critic-markup.test.ts
+++ b/packages/app/test/critic-markup.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { Editor } from "@tiptap/core";
 import {
@@ -10,6 +12,15 @@ import {
   getCommentDescendantIds,
 } from "../src/critic-markup";
 import { createEditorExtensions } from "../src/editor-extensions";
+
+function readMarkdownFixture(name: string): string {
+  return `${fs
+    .readFileSync(
+      path.join(process.cwd(), "test", "fixtures", "markdown", name),
+      "utf8",
+    )
+    .trimEnd()}\n`;
+}
 
 describe("CriticMarkup comments", () => {
   it("preserves YAML frontmatter delimiters and raw table-like YAML text", () => {
@@ -375,6 +386,30 @@ const command = "{==roughdraft open==}{>>test<<}{id="c1" by="user" at="2026-04-2
       authorId: 'user\\"name',
     });
     expect(editorStateToCriticMarkdown(doc, comments)).toBe(input);
+  });
+
+  it.each([
+    "criticmarkup-basic.md",
+    "criticmarkup-code-fences.md",
+    "frontmatter-table-yaml.md",
+    "mixed-roundtrip.md",
+  ])("round-trips markdown fixture %s", (fixtureName) => {
+    const input = readMarkdownFixture(fixtureName);
+    const { doc, comments, frontmatter } = criticMarkdownToEditorState(input);
+
+    expect(editorStateToCriticMarkdown(doc, comments, { frontmatter })).toBe(
+      input,
+    );
+  });
+
+  it("keeps unanchored CriticMarkup examples literal in code spans and fenced code", () => {
+    const input = readMarkdownFixture("criticmarkup-code-fences.md");
+    const { doc, comments, frontmatter } = criticMarkdownToEditorState(input);
+
+    expect(comments.size).toBe(0);
+    expect(editorStateToCriticMarkdown(doc, comments, { frontmatter })).toBe(
+      input,
+    );
   });
 
   it("allocates simple document-local ids", () => {

--- a/packages/app/test/fixtures/markdown/criticmarkup-basic.md
+++ b/packages/app/test/fixtures/markdown/criticmarkup-basic.md
@@ -1,0 +1,5 @@
+# Review Notes
+
+Please revisit {==this sentence==}{>>Needs a source<<}{id="c1" by="user" at="2024-01-15T10:30:00.000Z"}{>>Use the intro source.<<}{id="c2" by="AI" at="2024-01-15T10:31:00.000Z" re="c1"}.
+
+Add {++one concrete example++}{id="s1" by="user" at="2024-01-15T10:32:00.000Z"}, remove {--vague phrasing--}{id="s2" by="AI" at="2024-01-15T10:33:00.000Z"}, and use {~~rough~>specific~~}{id="s3" by="user@example.com" at="2024-01-15T10:34:00.000Z"} wording.

--- a/packages/app/test/fixtures/markdown/criticmarkup-code-fences.md
+++ b/packages/app/test/fixtures/markdown/criticmarkup-code-fences.md
@@ -1,0 +1,9 @@
+```md
+This is literal example text:
+{++inserted++}
+{--deleted--}
+{~~old~>new~~}
+{>>comment<<}
+```
+
+Inline code stays literal: `{==not an anchor==}` and `{++not a suggestion++}`.

--- a/packages/app/test/fixtures/markdown/frontmatter-table-yaml.md
+++ b/packages/app/test/fixtures/markdown/frontmatter-table-yaml.md
@@ -1,0 +1,13 @@
+---
+title: Frontmatter round trip
+summary: |
+  | column | value |
+  | --- | --- |
+  | path | docs/table.md |
+tags:
+  - roughdraft
+---
+
+# Body
+
+Opening this file in rich text should not rewrite frontmatter.

--- a/packages/app/test/fixtures/markdown/headerless-table.md
+++ b/packages/app/test/fixtures/markdown/headerless-table.md
@@ -1,0 +1,8 @@
+# Headerless Table
+
+<table>
+<tbody>
+<tr><td>First</td><td>Ready</td></tr>
+<tr><td>Second</td><td>Open</td></tr>
+</tbody>
+</table>

--- a/packages/app/test/fixtures/markdown/links-and-images.md
+++ b/packages/app/test/fixtures/markdown/links-and-images.md
@@ -1,0 +1,11 @@
+# Links And Images
+
+[Local draft](../notes/draft.md)
+
+[In-page anchor](#links-and-images)
+
+[External docs](https://example.com/docs)
+
+[Mail](mailto:review@example.com)
+
+![Sketch](./images/sketch.png "Sketch title")

--- a/packages/app/test/fixtures/markdown/mixed-roundtrip.md
+++ b/packages/app/test/fixtures/markdown/mixed-roundtrip.md
@@ -1,0 +1,17 @@
+---
+title: Mixed document
+---
+
+# Mixed
+
+| Column | Value |
+| --- | --- |
+| Link | [Draft](./draft.md) |
+
+Keep `{>>literal inline comment<<}` and this fenced example:
+
+```md
+{++literal insertion++}
+```
+
+Review {==this line==}{>>Needs one more example<<}{id="c1" by="user" at="2024-01-15T10:30:00.000Z"}.

--- a/packages/app/test/fixtures/markdown/tables-and-task-lists.md
+++ b/packages/app/test/fixtures/markdown/tables-and-task-lists.md
@@ -1,0 +1,10 @@
+# Tables And Tasks
+
+- [x] Done
+- [ ] Open
+  - [ ] Nested
+
+| Item | Status |
+| --- | --- |
+| Draft | Ready |
+| Review | Open |

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -8,6 +8,23 @@ export default defineConfig({
     },
   },
   test: {
+    coverage: {
+      provider: "v8",
+      reportsDirectory: "../../coverage/app",
+      exclude: [
+        "dist/**",
+        "test/**",
+        "src/**/*.test.ts",
+        "src/**/*.test.tsx",
+        "src/types.d.ts",
+      ],
+      thresholds: {
+        lines: 60,
+        functions: 60,
+        branches: 50,
+        statements: 60,
+      },
+    },
     environment: "jsdom",
     include: [
       "src/**/*.test.ts",

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -832,6 +832,16 @@ describe("cli", () => {
     );
   });
 
+  it("keeps CLAUDE.md as a short compatibility shim to AGENTS.md", () => {
+    const claudePath = path.join(serverRoot, "CLAUDE.md");
+    const claude = fs.readFileSync(claudePath, "utf8");
+
+    expect(claude.length).toBeLessThan(200);
+    expect(claude).toContain("@AGENTS.md");
+    expect(claude).toContain("compatibility shim");
+    expect(fs.lstatSync(claudePath).isSymbolicLink()).toBe(false);
+  });
+
   it("treats removed install command as an unknown command", async () => {
     const test = createTestDependencies();
 

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -69,6 +69,87 @@ describe("createApp", () => {
     expect(response.body.version).toEqual(expect.any(String));
   });
 
+  it("lists, updates, and deletes page-backed markdown files", async () => {
+    fs.writeFileSync(path.join(projectDir, "alpha.md"), "# Alpha\n");
+
+    const { app } = createApp({
+      homeDir,
+      staticDirPath: projectDir,
+    });
+
+    const listResponse = await request(app).get("/api/pages").query({
+      projectPath: projectDir,
+    });
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body).toEqual([
+      { id: "alpha", title: "Alpha", content: "# Alpha\n" },
+    ]);
+
+    const readResponse = await request(app).get("/api/pages/alpha").query({
+      projectPath: projectDir,
+    });
+    expect(readResponse.status).toBe(200);
+    expect(readResponse.body).toEqual({
+      id: "alpha",
+      title: "Alpha",
+      content: "# Alpha\n",
+    });
+
+    const updateResponse = await request(app)
+      .put("/api/pages/alpha")
+      .query({ projectPath: projectDir })
+      .send({ content: "# Beta\n" });
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.body).toEqual({
+      id: "alpha",
+      title: "Beta",
+      content: "# Beta\n",
+    });
+    expect(fs.readFileSync(path.join(projectDir, "alpha.md"), "utf-8")).toBe(
+      "# Beta\n",
+    );
+
+    const deleteResponse = await request(app).delete("/api/pages/alpha").query({
+      projectPath: projectDir,
+    });
+    expect(deleteResponse.status).toBe(200);
+    expect(deleteResponse.body).toEqual({ ok: true });
+    expect(fs.existsSync(path.join(projectDir, "alpha.md"))).toBe(false);
+  });
+
+  it("saves a markdown file when the expected version matches", async () => {
+    fs.writeFileSync(path.join(projectDir, "draft.md"), "# Original\n");
+
+    const { app } = createApp({
+      homeDir,
+      staticDirPath: projectDir,
+    });
+
+    const readResponse = await request(app).get("/api/markdown-file").query({
+      projectPath: projectDir,
+      path: "draft.md",
+    });
+
+    const saveResponse = await request(app)
+      .put("/api/markdown-file")
+      .query({ projectPath: projectDir, path: "draft.md" })
+      .send({
+        content: "# Saved\n",
+        expectedVersion: readResponse.body.version,
+      });
+
+    expect(saveResponse.status).toBe(200);
+    expect(saveResponse.body).toMatchObject({
+      id: "draft",
+      title: "Saved",
+      content: "# Saved\n",
+    });
+    expect(saveResponse.body.version).toEqual(expect.any(String));
+    expect(fs.readFileSync(path.join(projectDir, "draft.md"), "utf-8")).toBe(
+      "# Saved\n",
+    );
+  });
+
   it("rejects stale markdown-file writes", async () => {
     const nestedDir = path.join(projectDir, "notes");
     fs.mkdirSync(nestedDir, { recursive: true });
@@ -213,5 +294,130 @@ describe("createApp", () => {
         }),
       ]),
     );
+  });
+
+  it("lists markdown files and directories for the file picker", async () => {
+    fs.mkdirSync(path.join(homeDir, "docs"));
+    fs.writeFileSync(path.join(homeDir, "draft.md"), "# Draft\n");
+    fs.writeFileSync(path.join(homeDir, "ignored.txt"), "Nope\n");
+
+    const { app } = createApp({
+      homeDir,
+      staticDirPath: projectDir,
+    });
+
+    const response = await request(app).get("/api/fs/list");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      path: homeDir,
+      displayPath: "~",
+      parentPath: null,
+    });
+    expect(response.body.directories).toEqual([
+      {
+        name: "docs",
+        path: path.join(homeDir, "docs"),
+        kind: "directory",
+      },
+    ]);
+    expect(response.body.files).toEqual([
+      {
+        name: "draft.md",
+        path: path.join(homeDir, "draft.md"),
+        kind: "file",
+      },
+    ]);
+  });
+
+  it("returns project tree paths with directories before files", async () => {
+    fs.mkdirSync(path.join(projectDir, "notes", "nested"), {
+      recursive: true,
+    });
+    fs.writeFileSync(path.join(projectDir, "zeta.md"), "# Zeta\n");
+    fs.writeFileSync(path.join(projectDir, "notes", "alpha.md"), "# Alpha\n");
+
+    const { app } = createApp({
+      homeDir,
+      staticDirPath: projectDir,
+    });
+
+    const response = await request(app).get("/api/file-tree").query({
+      projectPath: projectDir,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      paths: ["notes/", "notes/nested/", "notes/alpha.md", "zeta.md"],
+    });
+  });
+
+  it("opens and creates project directories", async () => {
+    const createdDir = path.join(projectDir, "created", "workspace");
+
+    const { app } = createApp({
+      homeDir,
+      staticDirPath: projectDir,
+      port: 4321,
+    });
+
+    const openResponse = await request(app)
+      .post("/api/project/open")
+      .send({ path: projectDir });
+    expect(openResponse.status).toBe(200);
+    expect(openResponse.body).toEqual({
+      backend: "local-files",
+      projectDir,
+      port: 4321,
+    });
+
+    const createResponse = await request(app)
+      .post("/api/project/create")
+      .send({ path: createdDir });
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body).toEqual({
+      backend: "local-files",
+      projectDir: createdDir,
+      port: 4321,
+    });
+    expect(fs.statSync(createdDir).isDirectory()).toBe(true);
+  });
+
+  it("serves local files and stores uploaded assets inside the project", async () => {
+    fs.writeFileSync(path.join(projectDir, "image.txt"), "asset text\n");
+
+    const { app } = createApp({
+      homeDir,
+      staticDirPath: projectDir,
+    });
+
+    const fileResponse = await request(app).get("/api/files").query({
+      projectPath: projectDir,
+      path: "image.txt",
+    });
+    expect(fileResponse.status).toBe(200);
+    expect(fileResponse.text).toBe("asset text\n");
+
+    const assetResponse = await request(app)
+      .post("/api/assets")
+      .send({
+        projectPath: projectDir,
+        filename: "My Sketch.png",
+        mimeType: "image/png",
+        dataBase64: Buffer.from("png bytes").toString("base64"),
+      });
+
+    expect(assetResponse.status).toBe(201);
+    expect(assetResponse.body).toMatchObject({
+      markdownPath: "./.roughdraft-assets/My-Sketch.png",
+      mimeType: "image/png",
+    });
+    expect(assetResponse.body.previewUrl).toContain("/api/files?");
+    expect(
+      fs.readFileSync(
+        path.join(projectDir, ".roughdraft-assets", "My-Sketch.png"),
+        "utf-8",
+      ),
+    ).toBe("png bytes");
   });
 });

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -2,6 +2,17 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    coverage: {
+      provider: "v8",
+      reportsDirectory: "../../coverage/server",
+      exclude: ["dist/**", "src/**/*.test.ts", "defaults.d.mts"],
+      thresholds: {
+        lines: 60,
+        functions: 60,
+        branches: 50,
+        statements: 60,
+      },
+    },
     environment: "node",
     include: ["src/**/*.test.ts"],
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,12 @@ importers:
       '@biomejs/biome':
         specifier: ^2.4.12
         version: 2.4.12
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
       knip:
         specifier: ^6.7.0
         version: 6.7.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
@@ -33,6 +39,9 @@ importers:
       '@codemirror/lang-markdown':
         specifier: ^6.5.0
         version: 6.5.0
+      '@codemirror/lang-yaml':
+        specifier: ^6.1.3
+        version: 6.1.3
       '@codemirror/state':
         specifier: ^6.6.0
         version: 6.6.0
@@ -153,7 +162,7 @@ importers:
         version: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.17)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/server:
     dependencies:
@@ -178,7 +187,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.17)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/skill: {}
 
@@ -371,6 +380,10 @@ packages:
       '@types/react':
         optional: true
 
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
   '@biomejs/biome@2.4.12':
     resolution: {integrity: sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA==}
     engines: {node: '>=14.21.3'}
@@ -449,6 +462,9 @@ packages:
 
   '@codemirror/lang-markdown@6.5.0':
     resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
+
+  '@codemirror/lang-yaml@6.1.3':
+    resolution: {integrity: sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==}
 
   '@codemirror/language@6.12.3':
     resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
@@ -940,6 +956,9 @@ packages:
   '@lezer/markdown@1.6.3':
     resolution: {integrity: sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==}
 
+  '@lezer/yaml@1.0.4':
+    resolution: {integrity: sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==}
+
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
@@ -1242,6 +1261,11 @@ packages:
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -1776,6 +1800,15 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/coverage-v8@4.1.5':
+    resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
+    peerDependencies:
+      '@vitest/browser': 4.1.5
+      vitest: 4.1.5
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
@@ -1849,6 +1882,9 @@ packages:
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -2292,6 +2328,11 @@ packages:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2353,6 +2394,10 @@ packages:
     resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -2375,6 +2420,9 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -2500,12 +2548,27 @@ packages:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2656,6 +2719,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
@@ -2879,6 +2949,16 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
@@ -3037,6 +3117,11 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -3167,6 +3252,10 @@ packages:
   supertest@7.2.2:
     resolution: {integrity: sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==}
     engines: {node: '>=14.18.0'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -3732,6 +3821,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@biomejs/biome@2.4.12':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 2.4.12
@@ -3824,6 +3915,16 @@ snapshots:
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
       '@lezer/markdown': 1.6.3
+
+  '@codemirror/lang-yaml@6.1.3':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      '@lezer/yaml': 1.0.4
 
   '@codemirror/language@6.12.3':
     dependencies:
@@ -4178,6 +4279,12 @@ snapshots:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
 
+  '@lezer/yaml@1.0.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@marijn/find-cluster-break@1.0.2': {}
 
   '@mixmark-io/domino@2.2.0': {}
@@ -4385,6 +4492,10 @@ snapshots:
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
       '@noble/hashes': 1.8.0
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -4871,6 +4982,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.5
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+
   '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -4948,6 +5073,12 @@ snapshots:
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   asynckit@0.4.0: {}
 
@@ -5439,6 +5570,9 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5493,6 +5627,8 @@ snapshots:
 
   graphql@16.13.2: {}
 
+  has-flag@4.0.0: {}
+
   has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
@@ -5515,6 +5651,8 @@ snapshots:
       '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -5602,9 +5740,24 @@ snapshots:
 
   isexe@3.1.5: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jiti@2.6.1: {}
 
   jose@6.2.2: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -5749,6 +5902,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   marked@15.0.12: {}
 
@@ -5986,6 +6149,14 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   postcss-selector-parser@7.1.1:
     dependencies:
       cssesc: 3.0.0
@@ -6194,6 +6365,8 @@ snapshots:
 
   semver@6.3.1: {}
 
+  semver@7.7.4: {}
+
   send@1.2.1:
     dependencies:
       debug: 4.4.3
@@ -6382,6 +6555,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   symbol-tree@3.2.4: {}
 
   tagged-tag@1.0.0: {}
@@ -6509,7 +6686,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.5(@types/node@22.19.17)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -6533,6 +6710,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
       jsdom: 29.0.2(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## Summary
- Add ADRs documenting Roughdraft local-file, CriticMarkup, markdown round-trip, and CLI/server state contracts.
- Add Playwright smoke tests for opening files, CriticMarkup review flows, stale-write conflicts, and markdown round trips.
- Add coverage thresholds and CI jobs for browser smoke tests and coverage, plus markdown fixtures and editor tests.

Fixes #35.

## Testing
- pnpm check
- pnpm test:coverage
- pnpm test:smoke