### PR TITLE
Detect stale markdown writes by content hash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,10 +88,11 @@ Before creating or updating a PR:
 1. Run `pnpm check`.
 2. Fix any lint, format, test, or build failures.
 3. Confirm `git status --short` only shows intended changes.
-4. Rebase the current branch on the latest `origin/main`.
-5. Commit and push.
-6. Create the PR with `gh pr create --base main`.
-7. If the PR resolves GitHub issues, include closing keywords such as `Fixes #123` in the PR body.
+4. Make sure the current branch name is descriptive. If it is random or unclear, rename it before pushing.
+5. Rebase the current branch on the latest `origin/main`.
+6. Commit and push.
+7. Create the PR with `gh pr create --base main`.
+8. If the PR resolves GitHub issues, include closing keywords such as `Fixes #123` in the PR body.
 
 ## Plan Writing Workflow
 

--- a/packages/app/e2e/stale-write.spec.ts
+++ b/packages/app/e2e/stale-write.spec.ts
@@ -48,4 +48,32 @@ test.describe("stale writes", () => {
       file: "conflict.md",
     });
   });
+
+  test("rejects autosave after external content changes with stable metadata", async ({
+    page,
+  }) => {
+    const fixedTimestamp = new Date("2026-01-01T00:00:00.000Z");
+    const filePath = writeProjectFile(
+      projectDir,
+      "metadata-conflict.md",
+      "# Original\n",
+    );
+    fs.utimesSync(filePath, fixedTimestamp, fixedTimestamp);
+
+    await openMarkdownFile(page, filePath, "code");
+    await expect(page.locator(".cm-content")).toContainText("Original");
+
+    fs.writeFileSync(filePath, "# External\n");
+    fs.utimesSync(filePath, fixedTimestamp, fixedTimestamp);
+    await appendInCodeEditor(page, "\nLocal body.\n");
+
+    await expect(page.getByText("Save conflict")).toBeVisible();
+    expect(readProjectFile(projectDir, "metadata-conflict.md")).toBe(
+      "# External\n",
+    );
+
+    logE2eEvent("stale-write.metadata-conflict-surfaced", {
+      file: "metadata-conflict.md",
+    });
+  });
 });

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -193,6 +193,48 @@ describe("createApp", () => {
     );
   });
 
+  it("rejects stale markdown-file writes when file metadata is unchanged", async () => {
+    const filePath = path.join(projectDir, "draft.md");
+    const fixedTimestamp = new Date("2026-01-01T00:00:00.000Z");
+    fs.writeFileSync(filePath, "# Original\n");
+    fs.utimesSync(filePath, fixedTimestamp, fixedTimestamp);
+
+    const { app } = createApp({
+      homeDir,
+      staticDirPath: projectDir,
+    });
+
+    const readResponse = await request(app).get("/api/markdown-file").query({
+      projectPath: projectDir,
+      path: "draft.md",
+    });
+
+    fs.writeFileSync(filePath, "# External\n");
+    fs.utimesSync(filePath, fixedTimestamp, fixedTimestamp);
+
+    const staleWriteResponse = await request(app)
+      .put("/api/markdown-file")
+      .query({
+        projectPath: projectDir,
+        path: "draft.md",
+      })
+      .send({
+        content: "# Roughdraft\n",
+        expectedVersion: readResponse.body.version,
+      });
+
+    expect(staleWriteResponse.status).toBe(409);
+    expect(staleWriteResponse.body).toMatchObject({
+      error: "Markdown file changed on disk",
+      current: {
+        id: "draft",
+        title: "External",
+        content: "# External\n",
+      },
+    });
+    expect(fs.readFileSync(filePath, "utf-8")).toBe("# External\n");
+  });
+
   it("rejects markdown-file reads outside the project directory", async () => {
     const { app } = createApp({
       homeDir,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,5 @@
 import express, { type Express, type Request, type Response } from "express";
+import crypto from "node:crypto";
 import os from "node:os";
 import { createServer as createHttpServer } from "node:http";
 import { fileURLToPath } from "node:url";
@@ -82,8 +83,18 @@ function titleFromContent(content: string, fallback: string): string {
   return firstLine.replace(/^#*\s*/, "").trim() || fallback;
 }
 
-function fileVersionFromStats(stats: fs.Stats): string {
-  return `${stats.mtimeMs}:${stats.size}`;
+function fileVersionFromContent(
+  stats: fs.Stats,
+  content: string | Buffer,
+): string {
+  const contentHash = crypto.createHash("sha256").update(content).digest("hex");
+  return `${stats.mtimeMs}:${stats.size}:${contentHash}`;
+}
+
+function fileVersionFromFile(filePath: string): string {
+  const content = fs.readFileSync(filePath);
+  const stats = fs.statSync(filePath);
+  return fileVersionFromContent(stats, content);
 }
 
 function markdownPageFromFile(
@@ -103,7 +114,7 @@ function markdownPageFromFile(
     id: pageIdFromRelativePath(relativePath),
     title: titleFromContent(content, fallbackTitle),
     content,
-    version: fileVersionFromStats(stats),
+    version: fileVersionFromContent(stats, content),
   };
 }
 
@@ -425,7 +436,7 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
         `event: change\ndata: ${JSON.stringify({
           path: relativePath,
           exists,
-          version: exists ? fileVersionFromStats(stats) : null,
+          version: exists ? fileVersionFromFile(absolutePath) : null,
         })}\n\n`,
       );
     };
@@ -486,7 +497,7 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
       content: string;
       expectedVersion?: string;
     };
-    const currentVersion = fileVersionFromStats(fs.statSync(absolutePath));
+    const currentVersion = fileVersionFromFile(absolutePath);
 
     if (expectedVersion && expectedVersion !== currentVersion) {
       res.status(409).json({


### PR DESCRIPTION
## Summary
- Include a SHA-256 content hash in markdown file versions so unchanged metadata cannot hide external edits.
- Add server and e2e coverage for stale writes when size and mtime are stable.
- Document branch-name validation in the PR workflow.

Fixes #30

## Tests
- pnpm check