### PR TITLE
Reuse Roughdraft windows for repeated file opens

### DIFF
--- a/packages/app/e2e/open-file.spec.ts
+++ b/packages/app/e2e/open-file.spec.ts
@@ -80,4 +80,38 @@ test.describe("opening local markdown files", () => {
       file: "review.md",
     });
   });
+
+  test("focuses an existing window for a repeated open request", async ({
+    page,
+  }) => {
+    const filePath = writeProjectFile(
+      projectDir,
+      "repeat.md",
+      "# Repeat Open\n\nExisting window body.\n",
+    );
+
+    await openMarkdownFile(page, filePath, "code");
+    await expect(page.locator(".cm-content")).toContainText(
+      "Existing window body.",
+    );
+
+    const targetUrl = `/?${new URLSearchParams({
+      path: filePath,
+      editor: "code",
+    }).toString()}`;
+    const response = await page.request.post("/api/open-request", {
+      data: { path: filePath, url: targetUrl },
+    });
+
+    expect(response.ok()).toBe(true);
+    await expect(response.json()).resolves.toEqual({ delivered: true });
+    await expect(page.locator(".cm-content")).toContainText(
+      "Existing window body.",
+    );
+
+    logE2eEvent("open-file.reused-existing-window", {
+      projectDir,
+      file: "repeat.md",
+    });
+  });
 });

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -153,6 +153,38 @@ export function App() {
   }, []);
 
   useEffect(() => {
+    const sourceUrl = new URL("/api/open-requests", window.location.origin);
+    if (requestedPathState.rawPath) {
+      sourceUrl.searchParams.set("path", requestedPathState.rawPath);
+    }
+
+    const source = new EventSource(`${sourceUrl.pathname}${sourceUrl.search}`);
+    const handleOpenRequest = (event: Event) => {
+      try {
+        const payload = JSON.parse((event as MessageEvent<string>).data) as {
+          url?: unknown;
+        };
+        if (typeof payload.url !== "string" || !payload.url.trim()) return;
+
+        const nextUrl = new URL(payload.url, window.location.origin);
+        window.focus();
+        if (nextUrl.href !== window.location.href) {
+          window.location.assign(nextUrl.href);
+        }
+      } catch (error) {
+        console.error("Failed to handle Roughdraft open request:", error);
+      }
+    };
+
+    source.addEventListener("open-request", handleOpenRequest);
+
+    return () => {
+      source.removeEventListener("open-request", handleOpenRequest);
+      source.close();
+    };
+  }, [requestedPathState.rawPath]);
+
+  useEffect(() => {
     let cancelled = false;
 
     const initialize = async () => {

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -232,6 +232,81 @@ describe("cli", () => {
     expect(fs.existsSync(getServerStateFilePath(test.deps.env))).toBeTruthy();
   });
 
+  it("reuses a connected document window before opening another browser window", async () => {
+    const documentPath = path.join(projectDir, "draft.md");
+    fs.writeFileSync(documentPath, "# Draft\n");
+
+    let postedOpenRequest: { path?: string; url?: string } | null = null;
+    let lastOpenedUrl: string | null = null;
+    const deps = createCliDependencies({
+      env: {
+        ...process.env,
+        ROUGHDRAFT_STATE_DIR: stateDir,
+      },
+      cwd: projectDir,
+      fetchImpl: async (input, init) => {
+        const url =
+          input instanceof URL
+            ? input
+            : new URL(
+                typeof input === "string" ? input : input.url,
+                "http://localhost",
+              );
+
+        if (
+          url.pathname === "/api/status" &&
+          url.port === String(ROUGHDRAFT_DEFAULT_PORT)
+        ) {
+          return new Response(
+            JSON.stringify({
+              backend: "local-files",
+              port: ROUGHDRAFT_DEFAULT_PORT,
+              projectDir,
+              serverRoot,
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        }
+
+        if (url.pathname === "/api/open-request" && init?.method === "POST") {
+          postedOpenRequest = JSON.parse(String(init.body));
+          return new Response(JSON.stringify({ delivered: true }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        throw new Error("connect ECONNREFUSED");
+      },
+      isProcessRunning: () => false,
+      stopProcess: async () => {},
+      spawnServerProcess: async () => {
+        throw new Error("should not spawn");
+      },
+      openUrl: (url) => {
+        lastOpenedUrl = url;
+        return "browser";
+      },
+      log: () => {},
+      error: () => {},
+    });
+
+    const exitCode = await runCli(["open", documentPath], deps);
+
+    expect(exitCode).toBe(0);
+    expect(postedOpenRequest).toEqual({
+      path: documentPath,
+      url: expectedOpenUrl(
+        `http://localhost:${ROUGHDRAFT_DEFAULT_PORT}`,
+        documentPath,
+      ),
+    });
+    expect(lastOpenedUrl).toBeNull();
+  });
+
   it("prints only the document URL from open --print-url", async () => {
     const test = createTestDependencies();
     const documentPath = path.join(projectDir, "draft.md");

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -77,7 +77,12 @@ export interface CliDependencies {
   error: (message: string) => void;
 }
 
-type OpenMode = "browser" | "chrome-app" | "disabled" | "none";
+type OpenMode =
+  | "browser"
+  | "chrome-app"
+  | "disabled"
+  | "existing-window"
+  | "none";
 
 interface EnsureRunningResult {
   server: {
@@ -732,6 +737,32 @@ function buildTargetUrl(baseUrl: string, openPath: string): string {
   url.pathname = "/";
   url.searchParams.set("path", openPath);
   return url.toString();
+}
+
+async function sendOpenRequestToExistingWindow(
+  deps: CliDependencies,
+  baseUrl: string,
+  targetUrl: string,
+  openPath: string,
+): Promise<boolean> {
+  try {
+    const requestUrl = new URL("/api/open-request", baseUrl);
+    const response = await deps.fetchImpl(requestUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: openPath, url: targetUrl }),
+      signal: AbortSignal.timeout(STATUS_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      return false;
+    }
+
+    const payload = (await response.json()) as { delivered?: unknown };
+    return payload.delivered === true;
+  } catch {
+    return false;
+  }
 }
 
 function resolveTargetPath(inputPath: string): ResolvedTargetPath {
@@ -1783,10 +1814,17 @@ export async function runCli(
     }
 
     const targetUrl = buildTargetUrl(baseUrl, openPath);
-    const openMode =
-      options.noOpen || deps.env.ROUGHDRAFT_NO_OPEN === "1"
-        ? "disabled"
+    let openMode: OpenMode = "disabled";
+    if (!options.noOpen && deps.env.ROUGHDRAFT_NO_OPEN !== "1") {
+      openMode = (await sendOpenRequestToExistingWindow(
+        deps,
+        baseUrl,
+        targetUrl,
+        openPath,
+      ))
+        ? "existing-window"
         : deps.openUrl(targetUrl);
+    }
 
     if (result?.portChanged) {
       const message = `Preferred port ${getPreferredPort(deps.env)} is busy, using ${result.server.port}.`;
@@ -1815,6 +1853,11 @@ export async function runCli(
 
     if (openMode === "chrome-app") {
       deps.log(`Opened Roughdraft in a Chrome app window: ${targetUrl}`);
+      return 0;
+    }
+
+    if (openMode === "existing-window") {
+      deps.log(`Reused an existing Roughdraft window: ${targetUrl}`);
       return 0;
     }
 

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -425,6 +425,24 @@ describe("createApp", () => {
     expect(fs.statSync(createdDir).isDirectory()).toBe(true);
   });
 
+  it("reports an undelivered open request when no matching window is listening", async () => {
+    const { app } = createApp({
+      homeDir,
+      staticDirPath: projectDir,
+      port: 4312,
+    });
+
+    const response = await request(app)
+      .post("/api/open-request")
+      .send({
+        path: path.join(projectDir, "draft.md"),
+        url: "http://localhost:4312/?path=/tmp/draft.md",
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ delivered: false });
+  });
+
   it("serves local files and stores uploaded assets inside the project", async () => {
     fs.writeFileSync(path.join(projectDir, "image.txt"), "asset text\n");
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -67,6 +67,19 @@ interface CreateAppResult {
   port: number;
 }
 
+interface OpenRequestClient {
+  id: number;
+  path: string | null;
+  response: Response;
+}
+
+interface OpenRequestPayload {
+  path?: string;
+  url?: string;
+}
+
+let nextOpenRequestClientId = 1;
+
 function listMdFiles(projectDir: string): string[] {
   try {
     return fs
@@ -316,6 +329,7 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
   const staticDirPath = options.staticDirPath ?? staticDir;
   const fetchImpl = options.fetchImpl ?? fetch;
   const app = express();
+  const openRequestClients = new Set<OpenRequestClient>();
 
   app.use(express.json({ limit: "50mb" }));
 
@@ -557,6 +571,71 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
         fileSystemBrowsing: true,
       },
     });
+  });
+
+  app.get("/api/open-requests", (req, res) => {
+    const requestedPath =
+      typeof req.query.path === "string" && req.query.path.trim().length > 0
+        ? req.query.path.trim()
+        : null;
+    const client: OpenRequestClient = {
+      id: nextOpenRequestClientId,
+      path: requestedPath,
+      response: res,
+    };
+    nextOpenRequestClientId += 1;
+
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache, no-transform");
+    res.setHeader("Connection", "keep-alive");
+    res.flushHeaders?.();
+    res.write(
+      `event: connected\ndata: ${JSON.stringify({ id: client.id })}\n\n`,
+    );
+
+    openRequestClients.add(client);
+    const keepAlive = setInterval(() => {
+      res.write(": keep-alive\n\n");
+    }, 15_000);
+
+    req.on("close", () => {
+      clearInterval(keepAlive);
+      openRequestClients.delete(client);
+    });
+  });
+
+  app.post("/api/open-request", (req, res) => {
+    const payload = req.body as OpenRequestPayload;
+    const targetPath =
+      typeof payload.path === "string" && payload.path.trim().length > 0
+        ? payload.path.trim()
+        : null;
+    const targetUrl =
+      typeof payload.url === "string" && payload.url.trim().length > 0
+        ? payload.url.trim()
+        : null;
+
+    if (!targetPath || !targetUrl) {
+      res.status(400).json({ error: "path and url are required" });
+      return;
+    }
+
+    const matchingClient = Array.from(openRequestClients)
+      .reverse()
+      .find((client) => client.path === targetPath);
+
+    if (!matchingClient) {
+      res.json({ delivered: false });
+      return;
+    }
+
+    matchingClient.response.write(
+      `event: open-request\ndata: ${JSON.stringify({
+        path: targetPath,
+        url: targetUrl,
+      })}\n\n`,
+    );
+    res.json({ delivered: true });
   });
 
   app.get("/api/update-status", async (_req, res) => {


### PR DESCRIPTION
## Summary
- Add a server-side open-request channel for already-connected Roughdraft windows
- Have `roughdraft open` focus an existing window for the same Markdown path before opening a new browser window
- Cover repeated-open behavior with CLI, server, and e2e tests

## Verification
- `pnpm check`
- `source .context/slog/current.env && pnpm test:e2e --grep "focuses an existing window"`

Fixes #34: Make multi-document switching safer