### PR TITLE
Add Roughdraft flavored Markdown homepage section

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -3,7 +3,49 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Roughdraft</title>
+    <title>Roughdraft - Markdown reviews for coding agents</title>
+    <meta
+      name="description"
+      content="A local-first Markdown review app for commenting, suggesting edits, and collaborating with your coding agent."
+    />
+    <link rel="canonical" href="https://roughdraft.page/" />
+    <meta
+      property="og:title"
+      content="Roughdraft - Markdown reviews for coding agents"
+    />
+    <meta
+      property="og:description"
+      content="A local-first Markdown review app for commenting, suggesting edits, and collaborating with your coding agent."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://roughdraft.page/" />
+    <meta
+      property="og:image"
+      content="https://roughdraft.page/sneak-peek.png"
+    />
+    <meta
+      property="og:image:alt"
+      content="Roughdraft markdown review workspace"
+    />
+    <meta property="og:image:width" content="3456" />
+    <meta property="og:image:height" content="2234" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="Roughdraft - Markdown reviews for coding agents"
+    />
+    <meta
+      name="twitter:description"
+      content="A local-first Markdown review app for commenting, suggesting edits, and collaborating with your coding agent."
+    />
+    <meta
+      name="twitter:image"
+      content="https://roughdraft.page/sneak-peek.png"
+    />
+    <meta
+      name="twitter:image:alt"
+      content="Roughdraft markdown review workspace"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,12 +1,24 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Check, Copy, ExternalLink } from "lucide-react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Braces,
+  Check,
+  Copy,
+  ExternalLink,
+  FileText,
+  MessageSquare,
+  PencilLine,
+} from "lucide-react";
 import {
   type DocumentEditorViewMode,
+  ROUGHDRAFT_FLAVORED_MARKDOWN_PATH,
   buildLocationForDocumentEditorViewMode,
   formatWorkspacePathForDisplay,
   getDocumentEditorViewModeFromLocation,
   getPathLeaf,
   getRequestedPathState,
+  isReservedAppPath,
   joinPath,
   syncRequestedPathInUrl,
 } from "./app-navigation";
@@ -34,6 +46,61 @@ type SaveState = "idle" | "saving" | "error";
 type DocumentDiskChangeState = "clean" | "changed" | "conflict" | "paused";
 const AGENT_SETUP_PROMPT =
   "Install Roughdraft for me using `npm i -g roughdraft`, then read https://roughdraft.page/setup.md and set yourself up to use it.";
+const ROUGHDRAFT_MARKDOWN_FEATURES = [
+  {
+    title: "Comment in the margins",
+    description:
+      "Leave review notes inline, then let your agent read and respond to the same `.md` file.",
+    example: "{>>Can we tighten this claim?<<}",
+    icon: MessageSquare,
+  },
+  {
+    title: "Suggest changes",
+    description:
+      "Mark insertions, deletions, and substitutions without turning Markdown into a proprietary document.",
+    example: "{~~rough notes~>clear next steps~~}",
+    icon: PencilLine,
+  },
+  {
+    title: "Keep Markdown portable",
+    description:
+      "Roughdraft flavored Markdown blends CriticMarkup with Notion-style review affordances for people and agents.",
+    example: "regular.md + review markup",
+    icon: FileText,
+  },
+] as const;
+const ROUGHDRAFT_MARKDOWN_SYNTAX = [
+  {
+    label: "Comment",
+    syntax:
+      '{==selected text==}{>>Comment text<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z"}',
+    description:
+      "Highlights the reviewed text and attaches a margin comment to it.",
+  },
+  {
+    label: "Reply",
+    syntax:
+      '{>>I can make that edit.<<}{id="c2" by="AI" at="2026-04-28T12:01:00.000Z" re="c1"}',
+    description:
+      "Adds a threaded reply by pointing `re` at the parent comment id.",
+  },
+  {
+    label: "Insertion",
+    syntax: '{++new text++}{id="s1" by="AI" at="2026-04-28T12:02:00.000Z"}',
+    description: "Suggests text to add without applying it silently.",
+  },
+  {
+    label: "Deletion",
+    syntax: '{--old text--}{id="s2" by="user" at="2026-04-28T12:03:00.000Z"}',
+    description: "Suggests removing text while keeping the original visible.",
+  },
+  {
+    label: "Substitution",
+    syntax:
+      '{~~old text~>new text~~}{id="s3" by="AI" at="2026-04-28T12:04:00.000Z"}',
+    description: "Suggests replacing one span with another.",
+  },
+] as const;
 
 export function Homepage({
   message,
@@ -161,13 +228,204 @@ export function Homepage({
             className="block aspect-[1728/1117] w-full object-cover"
           />
         </div>
+
+        <section
+          aria-labelledby="roughdraft-markdown-heading"
+          className="mx-auto mt-20 grid w-full max-w-5xl gap-8 text-left sm:mt-24 lg:grid-cols-[0.95fr_1.05fr] lg:items-start"
+        >
+          <div>
+            <p className="text-xs font-medium tracking-[0.16em] text-stone-500 uppercase">
+              Roughdraft flavored Markdown
+            </p>
+            <h2
+              className="mt-3 text-3xl leading-tight font-semibold text-balance text-slate-950 sm:text-4xl"
+              id="roughdraft-markdown-heading"
+            >
+              We extended Markdown to add support for comment threads and
+              suggested changes.
+            </h2>
+            <p className="mt-4 text-base leading-7 text-slate-600">
+              The big idea is simple: keep the file as Markdown, but make it
+              reviewable. Roughdraft uses a small layer of portable markup so
+              you can comment, suggest edits, and send the exact same document
+              back to your coding agent.
+            </p>
+            <Button
+              className="mt-6 h-9 gap-2 px-3 text-sm"
+              variant="outline"
+              render={
+                <a href={ROUGHDRAFT_FLAVORED_MARKDOWN_PATH}>
+                  Read the spec
+                  <ArrowRight className="size-4" aria-hidden="true" />
+                </a>
+              }
+            />
+          </div>
+
+          <div className="grid gap-3">
+            {ROUGHDRAFT_MARKDOWN_FEATURES.map(
+              ({ description, example, icon: Icon, title }) => (
+                <div
+                  className="grid gap-4 rounded-lg border border-slate-200 bg-white p-4 shadow-[0_10px_30px_rgba(15,23,42,0.06)] sm:grid-cols-[2.5rem_1fr]"
+                  key={title}
+                >
+                  <div className="flex size-10 items-center justify-center rounded-md border border-slate-200 bg-slate-50 text-slate-700">
+                    <Icon className="size-4" aria-hidden="true" />
+                  </div>
+                  <div>
+                    <h3 className="text-sm font-semibold text-slate-950">
+                      {title}
+                    </h3>
+                    <p className="mt-1 text-sm leading-6 text-slate-600">
+                      {description}
+                    </p>
+                    <code className="mt-3 block overflow-x-auto rounded-md border border-slate-200 bg-[#FAFAF8] px-3 py-2 text-xs text-slate-700">
+                      {example}
+                    </code>
+                  </div>
+                </div>
+              ),
+            )}
+          </div>
+        </section>
       </div>
     </div>
   );
 }
+
+export function RoughdraftFlavoredMarkdownPage() {
+  return (
+    <main className="min-h-screen bg-[#FCFCFC] px-6 py-8 text-slate-950">
+      <div className="mx-auto max-w-5xl">
+        <Button
+          className="h-9 gap-2 px-3 text-sm"
+          variant="ghost"
+          render={
+            <a href="/">
+              <ArrowLeft className="size-4" aria-hidden="true" />
+              Back to Roughdraft
+            </a>
+          }
+        />
+
+        <section className="mt-12 max-w-3xl">
+          <p className="text-xs font-medium tracking-[0.16em] text-stone-500 uppercase">
+            Roughdraft flavored Markdown
+          </p>
+          <h1 className="mt-3 text-4xl leading-tight font-semibold text-balance text-slate-950 sm:text-5xl">
+            Markdown with review comments and suggested changes
+          </h1>
+          <p className="mt-5 text-lg leading-8 text-slate-600">
+            Roughdraft Flavored Markdown is regular Markdown plus portable
+            review markup. It blends CriticMarkup syntax with Notion-style
+            comment threads, so a person and a coding agent can review the same
+            file without a sidecar database or hosted document format.
+          </p>
+        </section>
+
+        <section className="mt-12 grid gap-4 md:grid-cols-3">
+          {[
+            {
+              title: "Plain text first",
+              description:
+                "The saved file remains readable in editors, terminals, git diffs, and agent context windows.",
+              icon: FileText,
+            },
+            {
+              title: "Threaded review",
+              description:
+                "Comments carry document-local ids, authors, timestamps, and reply links for back-and-forth discussion.",
+              icon: MessageSquare,
+            },
+            {
+              title: "Explicit edits",
+              description:
+                "Suggestions are represented as insertions, deletions, and substitutions until someone accepts them.",
+              icon: PencilLine,
+            },
+          ].map(({ description, icon: Icon, title }) => (
+            <div
+              className="rounded-lg border border-slate-200 bg-white p-5 shadow-[0_10px_30px_rgba(15,23,42,0.05)]"
+              key={title}
+            >
+              <div className="flex size-10 items-center justify-center rounded-md border border-slate-200 bg-slate-50 text-slate-700">
+                <Icon className="size-4" aria-hidden="true" />
+              </div>
+              <h2 className="mt-4 text-base font-semibold text-slate-950">
+                {title}
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-slate-600">
+                {description}
+              </p>
+            </div>
+          ))}
+        </section>
+
+        <section className="mt-14 grid gap-8 lg:grid-cols-[0.8fr_1.2fr]">
+          <div>
+            <p className="text-xs font-medium tracking-[0.16em] text-stone-500 uppercase">
+              Syntax
+            </p>
+            <h2 className="mt-3 text-3xl leading-tight font-semibold text-slate-950">
+              The review layer is small on purpose
+            </h2>
+            <p className="mt-4 text-base leading-7 text-slate-600">
+              Roughdraft uses CriticMarkup-compatible markers for comments,
+              highlights, insertions, deletions, and substitutions. Metadata is
+              stored in a compact attribute block after the markup.
+            </p>
+          </div>
+
+          <div className="grid gap-3">
+            {ROUGHDRAFT_MARKDOWN_SYNTAX.map(
+              ({ description, label, syntax }) => (
+                <div
+                  className="rounded-lg border border-slate-200 bg-white p-4"
+                  key={label}
+                >
+                  <div className="flex items-center gap-2">
+                    <Braces
+                      className="size-4 text-slate-500"
+                      aria-hidden="true"
+                    />
+                    <h3 className="text-sm font-semibold text-slate-950">
+                      {label}
+                    </h3>
+                  </div>
+                  <p className="mt-2 text-sm leading-6 text-slate-600">
+                    {description}
+                  </p>
+                  <code className="mt-3 block overflow-x-auto rounded-md border border-slate-200 bg-[#FAFAF8] px-3 py-2 text-xs text-slate-700">
+                    {syntax}
+                  </code>
+                </div>
+              ),
+            )}
+          </div>
+        </section>
+
+        <section className="mt-14 max-w-3xl border-t border-slate-200 pt-10">
+          <h2 className="text-2xl font-semibold text-slate-950">
+            What this is not
+          </h2>
+          <p className="mt-4 text-base leading-7 text-slate-600">
+            It is not a new replacement for Markdown, and it is not a hidden app
+            state format. If Roughdraft adds review information, that
+            information should stay visible, portable, and understandable in the
+            Markdown file itself.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}
+
 export function App() {
   const initialRequestedPathState = getRequestedPathState();
   const [requestedPathState] = useState(initialRequestedPathState);
+  const isRoughdraftFlavoredMarkdownRoute = isReservedAppPath(
+    window.location.pathname,
+  );
   const [backend, setBackend] = useState<StorageBackend | null>(null);
   const [documentPage, setDocumentPage] = useState<Page | null>(null);
   const [activeDocumentPath, setActiveDocumentPath] = useState<string | null>(
@@ -333,8 +591,15 @@ export function App() {
         )
       : null;
 
-    document.title = workspaceTitlePath ?? "Roughdraft";
-  }, [activeDocumentPath, backend, requestedPathState.rawPath]);
+    document.title = isRoughdraftFlavoredMarkdownRoute
+      ? "Roughdraft Flavored Markdown"
+      : (workspaceTitlePath ?? "Roughdraft");
+  }, [
+    activeDocumentPath,
+    backend,
+    isRoughdraftFlavoredMarkdownRoute,
+    requestedPathState.rawPath,
+  ]);
 
   const handleSaveDocument = useCallback(
     async (id: string, content: string) => {
@@ -488,6 +753,10 @@ export function App() {
 
   if (loading) {
     return <div className="h-screen bg-[#FCFCFC]" aria-hidden="true" />;
+  }
+
+  if (isRoughdraftFlavoredMarkdownRoute) {
+    return <RoughdraftFlavoredMarkdownPage />;
   }
 
   if (!requestedPathState.rawPath || loadError) {

--- a/packages/app/src/app-navigation.test.ts
+++ b/packages/app/src/app-navigation.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  ROUGHDRAFT_FLAVORED_MARKDOWN_PATH,
   getRequestedPathState,
   syncRequestedPathInUrl,
 } from "./app-navigation";
@@ -32,5 +33,15 @@ describe("app navigation", () => {
     expect(window.location.search).toBe(
       "?path=%2FUsers%2Fme%2F.claude%2Fplans%2Fexample.md",
     );
+  });
+
+  it("does not treat reserved app pages as file paths", () => {
+    window.history.replaceState(null, "", ROUGHDRAFT_FLAVORED_MARKDOWN_PATH);
+
+    expect(getRequestedPathState()).toEqual({
+      rawPath: null,
+      projectPath: null,
+      documentPath: null,
+    });
   });
 });

--- a/packages/app/src/app-navigation.ts
+++ b/packages/app/src/app-navigation.ts
@@ -5,9 +5,17 @@ interface RequestedPathState {
 }
 
 export type DocumentEditorViewMode = "rich-text" | "code";
+export const ROUGHDRAFT_FLAVORED_MARKDOWN_PATH =
+  "/roughdraft-flavored-markdown";
 
 function normalizePathSeparators(value: string) {
   return value.replace(/\\/g, "/");
+}
+
+export function isReservedAppPath(pathname: string) {
+  return (
+    normalizePathSeparators(pathname) === ROUGHDRAFT_FLAVORED_MARKDOWN_PATH
+  );
 }
 
 function getRawPathFromLocation(): string | null {
@@ -16,6 +24,8 @@ function getRawPathFromLocation(): string | null {
   if (queryPath) return queryPath;
 
   const normalizedPathname = normalizePathSeparators(window.location.pathname);
+  if (isReservedAppPath(normalizedPathname)) return null;
+
   if (normalizedPathname !== "/" && !normalizedPathname.startsWith("/api")) {
     const decodedPathname = decodeURIComponent(normalizedPathname);
     return decodedPathname.startsWith("/")

--- a/packages/app/test/homepage-metadata.test.ts
+++ b/packages/app/test/homepage-metadata.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const indexHtmlPath = resolve("index.html");
+const previewImageUrl = "https://roughdraft.page/sneak-peek.png";
+const pageTitle = "Roughdraft - Markdown reviews for coding agents";
+const pageDescription =
+  "A local-first Markdown review app for commenting, suggesting edits, and collaborating with your coding agent.";
+
+function readIndexDocument() {
+  return new DOMParser().parseFromString(
+    readFileSync(indexHtmlPath, "utf8"),
+    "text/html",
+  );
+}
+
+function metaContent(
+  document: Document,
+  selector: `meta[${string}]`,
+): string | null {
+  return document.querySelector(selector)?.getAttribute("content") ?? null;
+}
+
+describe("homepage metadata", () => {
+  it("uses the homepage screenshot for social previews", () => {
+    const document = readIndexDocument();
+
+    expect(document.querySelector("title")?.textContent).toBe(pageTitle);
+    expect(metaContent(document, 'meta[name="description"]')).toBe(
+      pageDescription,
+    );
+    expect(
+      document.querySelector('link[rel="canonical"]')?.getAttribute("href"),
+    ).toBe("https://roughdraft.page/");
+
+    expect(metaContent(document, 'meta[property="og:title"]')).toBe(pageTitle);
+    expect(metaContent(document, 'meta[property="og:description"]')).toBe(
+      pageDescription,
+    );
+    expect(metaContent(document, 'meta[property="og:type"]')).toBe("website");
+    expect(metaContent(document, 'meta[property="og:url"]')).toBe(
+      "https://roughdraft.page/",
+    );
+    expect(metaContent(document, 'meta[property="og:image"]')).toBe(
+      previewImageUrl,
+    );
+    expect(metaContent(document, 'meta[property="og:image:alt"]')).toBe(
+      "Roughdraft markdown review workspace",
+    );
+    expect(metaContent(document, 'meta[property="og:image:width"]')).toBe(
+      "3456",
+    );
+    expect(metaContent(document, 'meta[property="og:image:height"]')).toBe(
+      "2234",
+    );
+
+    expect(metaContent(document, 'meta[name="twitter:card"]')).toBe(
+      "summary_large_image",
+    );
+    expect(metaContent(document, 'meta[name="twitter:title"]')).toBe(pageTitle);
+    expect(metaContent(document, 'meta[name="twitter:description"]')).toBe(
+      pageDescription,
+    );
+    expect(metaContent(document, 'meta[name="twitter:image"]')).toBe(
+      previewImageUrl,
+    );
+    expect(metaContent(document, 'meta[name="twitter:image:alt"]')).toBe(
+      "Roughdraft markdown review workspace",
+    );
+  });
+});

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -1,7 +1,7 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { Homepage } from "../src/App";
+import { Homepage, RoughdraftFlavoredMarkdownPage } from "../src/App";
 
 const AGENT_SETUP_PROMPT =
   "Install Roughdraft for me using `npm i -g roughdraft`, then read https://roughdraft.page/setup.md and set yourself up to use it.";
@@ -57,6 +57,16 @@ describe("Homepage", () => {
     expect(container.textContent).toContain("Free");
     expect(container.textContent).toContain("Open-source");
     expect(container.textContent).toContain("Runs locally");
+    expect(container.textContent).toContain("Roughdraft flavored Markdown");
+    expect(container.textContent).toContain(
+      "We extended Markdown to add support for comment threads and suggested changes.",
+    );
+    expect(container.textContent).toContain(
+      "blends CriticMarkup with Notion-style review affordances",
+    );
+    expect(container.textContent).toContain(
+      "{~~rough notes~>clear next steps~~}",
+    );
     expect(
       container.querySelectorAll('[contenteditable="plaintext-only"]'),
     ).toHaveLength(0);
@@ -77,6 +87,10 @@ describe("Homepage", () => {
     expect(githubLink?.textContent).toContain("View on GitHub");
     expect(githubLink?.getAttribute("target")).toBe("_blank");
     expect(githubLink?.getAttribute("rel")).toBe("noreferrer");
+    expect(
+      container.querySelector('a[href="/roughdraft-flavored-markdown"]')
+        ?.textContent,
+    ).toContain("Read the spec");
 
     expect(cta).toBeDefined();
     if (!cta) throw new Error("CTA not found");
@@ -99,5 +113,24 @@ describe("Homepage", () => {
 
     expect(writeText).toHaveBeenCalledWith(AGENT_SETUP_PROMPT);
     expect(document.body.textContent).toContain("Copied");
+  });
+
+  it("renders the Roughdraft flavored Markdown spec page", async () => {
+    await act(async () => {
+      root.render(<RoughdraftFlavoredMarkdownPage />);
+    });
+
+    expect(container.textContent).toContain(
+      "Markdown with review comments and suggested changes",
+    );
+    expect(container.textContent).toContain(
+      "regular Markdown plus portable review markup",
+    );
+    expect(container.textContent).toContain("Threaded review");
+    expect(container.textContent).toContain("Substitution");
+    expect(container.textContent).toContain("{~~old text~>new text~~}");
+    expect(container.querySelector('a[href="/"]')?.textContent).toContain(
+      "Back to Roughdraft",
+    );
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,11 @@
   "buildCommand": "cd packages/app && pnpm install && pnpm build",
   "outputDirectory": "packages/app/dist",
   "installCommand": "pnpm install",
-  "framework": null
+  "framework": null,
+  "rewrites": [
+    {
+      "source": "/roughdraft-flavored-markdown",
+      "destination": "/index.html"
+    }
+  ]
 }


### PR DESCRIPTION
Adds homepage messaging for Roughdraft Flavored Markdown, including a linked spec page at /roughdraft-flavored-markdown with syntax examples for comments, replies, and suggestions. Reserves the route in navigation and adds a Vercel rewrite for direct visits. Adds homepage social metadata and coverage for metadata, homepage, and reserved-route behavior. Tests: pnpm check.