### PR TITLE
Document Roughdraft flavored markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,9 +243,9 @@ ROUGHDRAFT_DEV_WRAPPER_PATH
 ROUGHDRAFT_DEV_WRAPPER_REPO_ROOT
 ```
 
-## CriticMarkup
+## Roughdraft-flavored CriticMarkup
 
-Roughdraft uses [CriticMarkup](https://criticmarkup.com) for inline annotations and revision workflows:
+Roughdraft uses [CriticMarkup](https://criticmarkup.com) as the readable review layer inside normal Markdown files. It supports the standard markers for comments, highlights, insertions, deletions, and substitutions:
 
 ```markdown
 This is {--deleted--} text.
@@ -253,8 +253,48 @@ This is {++inserted++} text.
 This is {~~old~>new~~} substituted text.
 This is {>>a comment<<} in the margin.
 This is {==highlighted==} text.
-This is anchored text.
 ```
+
+Roughdraft extends those markers with compact attribute blocks so review state can round-trip through the file. Attribute blocks are written immediately after the comment or suggestion:
+
+```markdown
+Please revisit {==this sentence==}{>>Needs a source<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z"}.
+```
+
+Supported attributes:
+
+*   `id` gives the comment or suggested change a stable document-local id.
+    
+*   `by` records the reviewer or agent that created it.
+    
+*   `at` records an ISO timestamp.
+    
+*   `re` links a reply to another comment or suggestion id.
+    
+
+Replies are stored as additional comment blocks that point at the parent id:
+
+```markdown
+Please revisit {==this sentence==}{>>Needs a source<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z"}{>>I can add one from the intro.<<}{id="c2" by="AI" at="2026-04-28T12:05:00.000Z" re="c1"}.
+```
+
+Suggested changes can also carry ids and discussion:
+
+```markdown
+Add {++one concrete example++}{id="s1" by="AI" at="2026-04-28T12:10:00.000Z"}{>>Use the customer story here.<<}{id="c3" by="user" at="2026-04-28T12:12:00.000Z" re="s1"}.
+Remove {--vague phrasing--}{id="s2" by="user" at="2026-04-28T12:13:00.000Z"}.
+Use {~~rough~>specific~~}{id="s3" by="AI" at="2026-04-28T12:14:00.000Z"} wording.
+```
+
+CriticMarkup inside inline code and fenced code blocks is treated as literal example text, not live review feedback:
+
+````markdown
+Inline code stays literal: `{==not a comment==}`.
+
+```text
+{++not a suggestion++}
+```
+````
 
 This matters because the main workflow is often:
 

--- a/packages/app/public/setup.md
+++ b/packages/app/public/setup.md
@@ -49,16 +49,30 @@ If Roughdraft is not running, `roughdraft open` will start it automatically.
 
 After the user finishes reviewing in Roughdraft, read the Markdown file from disk and respond to any CriticMarkup comments or suggested changes.
 
-Use CriticMarkup when reading or writing inline review feedback in Markdown.
+Use Roughdraft-flavored CriticMarkup when reading or writing inline review feedback in Markdown. The base markers are:
+
+Comment: `{>>comment<<}`
+Insertion: `{++new text++}`
+Deletion: `{--old text--}`
+Substitution: `{~~old~>new~~}`
+Highlight: `{==text==}`
+
+When you add a new comment or suggested change, use the extended Roughdraft format with an attribute block, such as `{id="c1" by="AI" at="2026-04-28T12:00:00.000Z"}`. Generate a stable document-local id (`c1`, `c2`, etc. for comments; `s1`, `s2`, etc. for suggestions), set `by` to your agent or author label, set `at` to the current ISO timestamp, and set `re` when replying to an existing comment or suggestion.
+
+Roughdraft may already have attribute blocks after comments and suggestions. Preserve these attributes unless you are intentionally removing the associated comment or suggestion. The common attributes are `id` for a stable document-local id, `by` for the author, `at` for an ISO timestamp, and `re` for the parent comment or suggestion id in a reply thread.
+
+Anchored comments usually look like `{==selected text==}{>>Comment text<<}{id="c1" by="AI" at="2026-04-28T12:00:00.000Z"}`. Suggested changes usually look like `{++new text++}{id="s1" by="AI" at="2026-04-28T12:10:00.000Z"}` or `{~~old text~>new text~~}{id="s2" by="AI" at="2026-04-28T12:11:00.000Z"}`. Replies usually look like `{>>Reply text<<}{id="c2" by="AI" at="2026-04-28T12:05:00.000Z" re="c1"}`.
 
 Use `roughdraft help` and `roughdraft help criticmarkup` for local command and syntax details.
 ```
 
 After updating your instructions, briefly tell the user which file you changed.
 
-## CriticMarkup Reference
+## Roughdraft-flavored CriticMarkup Reference
 
-Roughdraft uses CriticMarkup for inline comments and suggested changes:
+Roughdraft uses CriticMarkup for inline comments and suggested changes while keeping all review state in the Markdown file.
+
+Base markers:
 
 ```text
 Comment: `{>>comment<<}`
@@ -66,6 +80,39 @@ Insertion: `{++new text++}`
 Deletion: `{--old text--}`
 Substitution: `{~~old~>new~~}`
 Highlight: `{==text==}`
+```
+
+When adding review feedback, prefer the extended Roughdraft format so comments and suggested changes keep ids, authors, timestamps, and thread relationships.
+
+Roughdraft extensions:
+
+```text
+Anchored comment:
+{==selected text==}{>>Comment text<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z"}
+
+Reply:
+{>>I can make that edit.<<}{id="c2" by="AI" at="2026-04-28T12:05:00.000Z" re="c1"}
+
+Insertion suggestion:
+{++new text++}{id="s1" by="AI" at="2026-04-28T12:10:00.000Z"}
+
+Deletion suggestion:
+{--old text--}{id="s2" by="user" at="2026-04-28T12:11:00.000Z"}
+
+Substitution suggestion:
+{~~old text~>new text~~}{id="s3" by="AI" at="2026-04-28T12:12:00.000Z"}
+
+Comment on a suggestion:
+{++new text++}{id="s1" by="AI" at="2026-04-28T12:10:00.000Z"}{>>Use the customer example here.<<}{id="c3" by="user" at="2026-04-28T12:13:00.000Z" re="s1"}
+```
+
+Attribute blocks are written immediately after the markup they describe:
+
+```text
+id  Stable document-local id for a comment or suggested change
+by  Author or agent label
+at  ISO timestamp
+re  Parent comment or suggestion id for replies
 ```
 
 CriticMarkup inside fenced code blocks is literal example text. Do not treat it as review feedback.

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -51,21 +51,24 @@ const ROUGHDRAFT_MARKDOWN_FEATURES = [
     title: "Comment in the margins",
     description:
       "Leave review notes inline, then let your agent read and respond to the same `.md` file.",
-    example: "{>>Can we tighten this claim?<<}",
+    example:
+      '{==this claim==}{>>Can we source this?<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z"}',
     icon: MessageSquare,
   },
   {
     title: "Suggest changes",
     description:
       "Mark insertions, deletions, and substitutions without turning Markdown into a proprietary document.",
-    example: "{~~rough notes~>clear next steps~~}",
+    example:
+      '{++clear next step++}{id="s1" by="AI" at="2026-04-28T12:05:00.000Z"}{>>Use the launch example.<<}{id="c2" by="user" at="2026-04-28T12:06:00.000Z" re="s1"}',
     icon: PencilLine,
   },
   {
     title: "Keep Markdown portable",
     description:
       "Roughdraft flavored Markdown blends CriticMarkup with Notion-style review affordances for people and agents.",
-    example: "regular.md + review markup",
+    example:
+      'regular.md + {>>Review note<<}{id="c3" by="AI" at="2026-04-28T12:07:00.000Z"}',
     icon: FileText,
   },
 ] as const;
@@ -99,6 +102,60 @@ const ROUGHDRAFT_MARKDOWN_SYNTAX = [
     syntax:
       '{~~old text~>new text~~}{id="s3" by="AI" at="2026-04-28T12:04:00.000Z"}',
     description: "Suggests replacing one span with another.",
+  },
+] as const;
+const ROUGHDRAFT_MARKDOWN_REFERENCES = [
+  {
+    title: "CriticMarkup",
+    href: "https://criticmarkup.com/",
+    description:
+      "The plain-text review syntax Roughdraft builds on for comments, highlights, insertions, deletions, and substitutions.",
+  },
+  {
+    title: "Notion-flavored Markdown",
+    href: "https://developers.notion.com/guides/data-apis/enhanced-markdown",
+    description:
+      "The product precedent for rich document affordances that still serialize to inspectable Markdown-like text.",
+  },
+] as const;
+const ROUGHDRAFT_MARKDOWN_CONTRACT = [
+  {
+    title: "Metadata",
+    description:
+      "Attribute blocks come immediately after review markup. `id` is document-local, `by` is a human or agent label, `at` is an ISO timestamp, and `re` points to the parent comment for replies.",
+  },
+  {
+    title: "Anchors",
+    description:
+      "Comments attach to highlighted text when a highlight precedes the comment. A bare comment is allowed when the feedback applies to the surrounding paragraph or document.",
+  },
+  {
+    title: "Pending changes",
+    description:
+      "Insertions, deletions, and substitutions stay visible until accepted or rejected. Roughdraft should not silently collapse suggested edits into normal prose.",
+  },
+  {
+    title: "Round trips",
+    description:
+      "Normal Markdown should remain normal Markdown. Frontmatter, tables, task lists, links, image paths, code spans, and fenced code blocks should survive review edits with minimal serialization churn.",
+  },
+] as const;
+const ROUGHDRAFT_MARKDOWN_EXTENSION_DETAILS = [
+  {
+    title: "Attribute metadata",
+    body: 'Roughdraft stores ids, authors, timestamps, and reply links in an attribute block after review markup, such as {>>Looks right.<<}{id="c1" by="AI" at="2026-04-28T12:00:00.000Z" re="c0"}.',
+  },
+  {
+    title: "Threaded comments",
+    body: "A comment can stand alone, attach to a highlighted span, or reply to another comment by setting `re` to the parent comment id.",
+  },
+  {
+    title: "Reviewable suggestions",
+    body: "Insertions, deletions, and substitutions can carry their own ids, then comments can reply to those ids to discuss a proposed edit before accepting it.",
+  },
+  {
+    title: "Literal examples stay literal",
+    body: "CriticMarkup inside inline code and fenced code blocks is preserved as example text instead of becoming live review feedback.",
   },
 ] as const;
 
@@ -317,10 +374,55 @@ export function RoughdraftFlavoredMarkdownPage() {
           </h1>
           <p className="mt-5 text-lg leading-8 text-slate-600">
             Roughdraft Flavored Markdown is regular Markdown plus portable
-            review markup. It blends CriticMarkup syntax with Notion-style
-            comment threads, so a person and a coding agent can review the same
-            file without a sidecar database or hosted document format.
+            review markup. It builds on{" "}
+            <a
+              className="font-medium text-slate-950 underline decoration-slate-300 underline-offset-4 hover:decoration-slate-950"
+              href="https://criticmarkup.com/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              CriticMarkup
+            </a>{" "}
+            syntax and the text-first model behind{" "}
+            <a
+              className="font-medium text-slate-950 underline decoration-slate-300 underline-offset-4 hover:decoration-slate-950"
+              href="https://developers.notion.com/guides/data-apis/enhanced-markdown"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Notion-flavored Markdown
+            </a>
+            {", "}
+            so a person and a coding agent can review the same file without a
+            sidecar database or hosted document format.
           </p>
+        </section>
+
+        <section className="mt-10 grid gap-3 md:grid-cols-2">
+          {ROUGHDRAFT_MARKDOWN_REFERENCES.map(
+            ({ description, href, title }) => (
+              <a
+                className="group rounded-lg border border-slate-200 bg-white p-5 shadow-[0_10px_30px_rgba(15,23,42,0.05)] transition hover:border-slate-300 hover:shadow-[0_14px_34px_rgba(15,23,42,0.08)]"
+                href={href}
+                key={title}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <h2 className="text-base font-semibold text-slate-950">
+                    {title}
+                  </h2>
+                  <ExternalLink
+                    className="size-4 text-slate-400 transition group-hover:text-slate-700"
+                    aria-hidden="true"
+                  />
+                </div>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  {description}
+                </p>
+              </a>
+            ),
+          )}
         </section>
 
         <section className="mt-12 grid gap-4 md:grid-cols-3">
@@ -361,6 +463,40 @@ export function RoughdraftFlavoredMarkdownPage() {
           ))}
         </section>
 
+        <section className="mt-14 grid gap-8 lg:grid-cols-[0.75fr_1.25fr]">
+          <div>
+            <p className="text-xs font-medium tracking-[0.16em] text-stone-500 uppercase">
+              Format contract
+            </p>
+            <h2 className="mt-3 text-3xl leading-tight font-semibold text-slate-950">
+              Review data lives where agents can inspect it
+            </h2>
+            <p className="mt-4 text-base leading-7 text-slate-600">
+              Roughdraft treats the Markdown file as the durable source of
+              truth. The rich editor can add affordances around the text, but
+              the saved representation needs to be readable in a terminal,
+              reviewable in git, and understandable to another agent without
+              loading Roughdraft.
+            </p>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            {ROUGHDRAFT_MARKDOWN_CONTRACT.map(({ description, title }) => (
+              <div
+                className="rounded-lg border border-slate-200 bg-white p-4"
+                key={title}
+              >
+                <h3 className="text-sm font-semibold text-slate-950">
+                  {title}
+                </h3>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  {description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
         <section className="mt-14 grid gap-8 lg:grid-cols-[0.8fr_1.2fr]">
           <div>
             <p className="text-xs font-medium tracking-[0.16em] text-stone-500 uppercase">
@@ -371,8 +507,10 @@ export function RoughdraftFlavoredMarkdownPage() {
             </h2>
             <p className="mt-4 text-base leading-7 text-slate-600">
               Roughdraft uses CriticMarkup-compatible markers for comments,
-              highlights, insertions, deletions, and substitutions. Metadata is
-              stored in a compact attribute block after the markup.
+              highlights, insertions, deletions, and substitutions. Roughdraft
+              extends those markers with document-local metadata so review
+              threads, authorship, timestamps, and suggested-change discussions
+              can survive in the Markdown file itself.
             </p>
           </div>
 
@@ -401,6 +539,36 @@ export function RoughdraftFlavoredMarkdownPage() {
                 </div>
               ),
             )}
+          </div>
+        </section>
+
+        <section className="mt-14 grid gap-8 border-t border-slate-200 pt-10 lg:grid-cols-[0.8fr_1.2fr]">
+          <div>
+            <p className="text-xs font-medium tracking-[0.16em] text-stone-500 uppercase">
+              Roughdraft extensions
+            </p>
+            <h2 className="mt-3 text-3xl leading-tight font-semibold text-slate-950">
+              The extra fields make review state portable
+            </h2>
+            <p className="mt-4 text-base leading-7 text-slate-600">
+              Standard CriticMarkup captures the visible annotation. Roughdraft
+              keeps the same readable markers and adds a small attribute block
+              after comments and suggestions when it needs stable review state.
+            </p>
+          </div>
+
+          <div className="grid gap-3">
+            {ROUGHDRAFT_MARKDOWN_EXTENSION_DETAILS.map(({ body, title }) => (
+              <div
+                className="rounded-lg border border-slate-200 bg-white p-4"
+                key={title}
+              >
+                <h3 className="text-sm font-semibold text-slate-950">
+                  {title}
+                </h3>
+                <p className="mt-2 text-sm leading-6 text-slate-600">{body}</p>
+              </div>
+            ))}
           </div>
         </section>
 

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -65,8 +65,9 @@ describe("Homepage", () => {
       "blends CriticMarkup with Notion-style review affordances",
     );
     expect(container.textContent).toContain(
-      "{~~rough notes~>clear next steps~~}",
+      '{==this claim==}{>>Can we source this?<<}{id="c1"',
     );
+    expect(container.textContent).toContain('re="s1"');
     expect(
       container.querySelectorAll('[contenteditable="plaintext-only"]'),
     ).toHaveLength(0);
@@ -126,7 +127,25 @@ describe("Homepage", () => {
     expect(container.textContent).toContain(
       "regular Markdown plus portable review markup",
     );
+    expect(container.textContent).toContain("CriticMarkup");
+    expect(container.textContent).toContain("Notion-flavored Markdown");
+    expect(container.textContent).toContain("Format contract");
+    expect(container.textContent).toContain(
+      "Review data lives where agents can inspect it",
+    );
+    expect(container.textContent).toContain("document-local");
+    expect(
+      container.querySelector('a[href="https://criticmarkup.com/"]')
+        ?.textContent,
+    ).toContain("CriticMarkup");
+    expect(
+      container.querySelector(
+        'a[href="https://developers.notion.com/guides/data-apis/enhanced-markdown"]',
+      )?.textContent,
+    ).toContain("Notion-flavored Markdown");
     expect(container.textContent).toContain("Threaded review");
+    expect(container.textContent).toContain("Roughdraft extensions");
+    expect(container.textContent).toContain("Attribute metadata");
     expect(container.textContent).toContain("Substitution");
     expect(container.textContent).toContain("{~~old text~>new text~~}");
     expect(container.querySelector('a[href="/"]')?.textContent).toContain(

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -925,12 +925,26 @@ describe("cli", () => {
     );
   });
 
-  it("documents reply syntax in criticmarkup help", async () => {
+  it("documents extended review syntax in criticmarkup help", async () => {
     const test = createTestDependencies();
 
     const exitCode = await runCli(["help", "criticmarkup"], test.deps);
 
     expect(exitCode).toBe(0);
+    expect(test.logs).toContain("When adding new review feedback:");
+    expect(test.logs).toContain(
+      '  Prefer the extended Roughdraft format with `id`, `by`, and `at` metadata, for example {>>Comment<<}{id="c1" by="AI" at="2026-04-28T12:00:00.000Z"}.',
+    );
+    expect(test.logs).toContain(
+      "  Use `c1`, `c2`, etc. for comment ids and `s1`, `s2`, etc. for suggested-change ids.",
+    );
+    expect(test.logs).toContain("Suggested changes with ids:");
+    expect(test.logs).toContain(
+      '  Add {++one concrete example++}{id="s1" by="AI" at="2026-04-28T12:05:00.000Z"}.',
+    );
+    expect(test.logs).toContain(
+      '  Replace {~~vague phrasing~>specific wording~~}{id="s2" by="AI" at="2026-04-28T12:06:00.000Z"}.',
+    );
     expect(test.logs).toContain("Reply to an existing comment:");
     expect(test.logs).toContain(
       '  Use explicit `id="..."` and `re="..."` metadata for replies.',

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -696,14 +696,33 @@ function printCriticMarkupHelp(log: (message: string) => void) {
   log("  The intro {~~is vague~>needs a tighter claim~~}.");
   log("  Add {>>one concrete example here<<} before the conclusion.");
   log("");
+  log("When adding new review feedback:");
+  log(
+    '  Prefer the extended Roughdraft format with `id`, `by`, and `at` metadata, for example {>>Comment<<}{id="c1" by="AI" at="2026-04-28T12:00:00.000Z"}.',
+  );
+  log(
+    "  Use `c1`, `c2`, etc. for comment ids and `s1`, `s2`, etc. for suggested-change ids.",
+  );
+  log(
+    "  Set `by` to your agent or author label and `at` to the current ISO timestamp.",
+  );
+  log("");
   log("Anchored comment with id:");
   log(
-    '  Review {==this sentence==}{>>Needs a source<<}{id="c1" by="user" at="2026-04-23T18:00:00.000Z"}.',
+    '  Review {==this sentence==}{>>Needs a source<<}{id="c1" by="AI" at="2026-04-28T12:00:00.000Z"}.',
+  );
+  log("");
+  log("Suggested changes with ids:");
+  log(
+    '  Add {++one concrete example++}{id="s1" by="AI" at="2026-04-28T12:05:00.000Z"}.',
+  );
+  log(
+    '  Replace {~~vague phrasing~>specific wording~~}{id="s2" by="AI" at="2026-04-28T12:06:00.000Z"}.',
   );
   log("");
   log("Reply to an existing comment:");
   log(
-    '  Review {==this sentence==}{>>Needs a source<<}{id="c1" by="user" at="2026-04-23T18:00:00.000Z"}{>>I can add one from the intro.<<}{id="c2" by="AI" at="2026-04-23T18:05:00.000Z" re="c1"}.',
+    '  Review {==this sentence==}{>>Needs a source<<}{id="c1" by="AI" at="2026-04-28T12:00:00.000Z"}{>>I can add one from the intro.<<}{id="c2" by="AI" at="2026-04-28T12:10:00.000Z" re="c1"}.',
   );
   log("");
   log("Reply guidance:");


### PR DESCRIPTION
Updates the Roughdraft flavored Markdown spec page with links to CriticMarkup and Notion-flavored Markdown, plus more detail on metadata, anchors, suggestions, round trips, and Roughdraft extensions. Expands README and setup guidance so agents use extended review markup with id, by, at, and re metadata when creating comments or suggested changes. Updates CLI CriticMarkup help with the same guidance and examples, with tests covering the new help and spec content. Verified with pnpm check.