### PR TITLE
Add Roughdraft flavored Markdown spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ ROUGHDRAFT_DEV_WRAPPER_REPO_ROOT
 
 Roughdraft uses [CriticMarkup](https://criticmarkup.com) as the readable review layer inside normal Markdown files. It supports the standard markers for comments, highlights, insertions, deletions, and substitutions:
 
+The canonical Roughdraft Flavored Markdown spec is published at [roughdraft.page/spec/roughdraft-flavored-markdown.md](https://roughdraft.page/spec/roughdraft-flavored-markdown.md). The review-index JSON Schema is published at [roughdraft.page/spec/roughdraft-flavored-markdown.schema.json](https://roughdraft.page/spec/roughdraft-flavored-markdown.schema.json).
+
 ```markdown
 This is {--deleted--} text.
 This is {++inserted++} text.

--- a/docs/spec/fixtures/anchored-comment.json
+++ b/docs/spec/fixtures/anchored-comment.json
@@ -1,0 +1,19 @@
+{
+  "format": "roughdraft-flavored-markdown",
+  "version": "0.1",
+  "source": {
+    "markdown": "Please revisit {==this sentence==}{>>Needs a source.<<}{id=\"c1\" by=\"user\" at=\"2026-04-28T12:00:00.000Z\"}.\\n"
+  },
+  "comments": [
+    {
+      "id": "c1",
+      "body": "Needs a source.",
+      "by": "user",
+      "at": "2026-04-28T12:00:00.000Z",
+      "anchor": {
+        "text": "this sentence"
+      }
+    }
+  ],
+  "suggestions": []
+}

--- a/docs/spec/fixtures/suggestion-with-reply.json
+++ b/docs/spec/fixtures/suggestion-with-reply.json
@@ -1,0 +1,27 @@
+{
+  "format": "roughdraft-flavored-markdown",
+  "version": "0.1",
+  "source": {
+    "markdown": "Add {++one concrete example++}{id=\"s1\" by=\"AI\" at=\"2026-04-28T12:05:00.000Z\"}{>>Use the launch story.<<}{id=\"c2\" by=\"user\" at=\"2026-04-28T12:08:00.000Z\" re=\"s1\"}.\\n"
+  },
+  "comments": [
+    {
+      "id": "c2",
+      "body": "Use the launch story.",
+      "by": "user",
+      "at": "2026-04-28T12:08:00.000Z",
+      "re": "s1",
+      "targetSuggestionId": "s1"
+    }
+  ],
+  "suggestions": [
+    {
+      "id": "s1",
+      "kind": "addition",
+      "text": "one concrete example",
+      "by": "AI",
+      "at": "2026-04-28T12:05:00.000Z",
+      "commentIds": ["c2"]
+    }
+  ]
+}

--- a/docs/spec/roughdraft-flavored-markdown.md
+++ b/docs/spec/roughdraft-flavored-markdown.md
@@ -1,0 +1,193 @@
+# Roughdraft Flavored Markdown 0.1
+
+Status: Draft
+
+Roughdraft Flavored Markdown is regular Markdown plus a portable review layer based on CriticMarkup. Its purpose is to let people and coding agents exchange comments, threaded replies, and pending changes inside the Markdown file itself.
+
+The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" in this document are to be interpreted as described in RFC 2119.
+
+## Scope
+
+This specification defines the review markup that Roughdraft reads and writes. It does not define a replacement for Markdown, a hosted document format, a sync protocol, or a project database.
+
+A conforming document is a Markdown document that may contain Roughdraft review spans. Markdown parsing SHOULD follow CommonMark with GitHub Flavored Markdown extensions. Implementations MAY preserve YAML frontmatter as document metadata, but Roughdraft review state lives in the Markdown body.
+
+## Canonical Markers
+
+Roughdraft uses these CriticMarkup-compatible markers:
+
+```markdown
+{>>comment<<}
+{++inserted text++}
+{--deleted text--}
+{~~old text~>new text~~}
+{==highlighted text==}
+```
+
+An implementation MUST treat the opening and closing marker pairs as review delimiters outside inline code and fenced code blocks.
+
+Implementations MUST treat review markers inside inline code spans and fenced code blocks as literal example text. They MUST NOT create comments, suggestions, or highlights from those code contexts.
+
+## Comments
+
+A comment is written as:
+
+```ebnf
+comment = "{>>" comment-text "<<}" [ metadata ]
+```
+
+Comment text is plain inline Markdown content. Comment text MUST NOT contain the literal closing delimiter `<<}` unless the implementation defines an escaping extension.
+
+A comment MAY appear by itself when the feedback applies to the surrounding paragraph or document:
+
+```markdown
+Add one concrete launch example here.{>>This should come from the customer story.<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z"}
+```
+
+## Anchored Comments
+
+An anchored comment is a highlight immediately followed by one or more comment blocks:
+
+```ebnf
+anchored-comment = highlight 1*comment
+highlight        = "{==" anchor-text "==}"
+```
+
+Example:
+
+```markdown
+Please revisit {==this sentence==}{>>Needs a source.<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z"}.
+```
+
+The highlighted text is the visible anchor. Implementations SHOULD attach all immediately following comment blocks to the same anchor until another token interrupts the sequence.
+
+A standalone highlight is valid CriticMarkup. Roughdraft 0.1 reserves it as review syntax, but standalone highlights are not required to produce a review-thread item unless an implementation explicitly supports highlight-only annotations.
+
+## Suggestions
+
+Suggestions represent pending edits. Implementations MUST NOT silently collapse suggestions into normal prose while reading or writing Roughdraft Flavored Markdown.
+
+### Insertion
+
+```ebnf
+addition = "{++" new-text "++}" [ metadata ] *comment
+```
+
+```markdown
+Add {++one concrete example++}{id="s1" by="AI" at="2026-04-28T12:05:00.000Z"}.
+```
+
+### Deletion
+
+```ebnf
+deletion = "{--" old-text "--}" [ metadata ] *comment
+```
+
+```markdown
+Remove {--vague phrasing--}{id="s2" by="user" at="2026-04-28T12:06:00.000Z"}.
+```
+
+### Substitution
+
+```ebnf
+substitution = "{~~" old-text "~>" new-text "~~}" [ metadata ] *comment
+```
+
+```markdown
+Use {~~rough~>specific~~}{id="s3" by="AI" at="2026-04-28T12:07:00.000Z"} wording.
+```
+
+Trailing comment blocks after a suggestion attach discussion to that suggestion:
+
+```markdown
+Add {++one concrete example++}{id="s1" by="AI" at="2026-04-28T12:05:00.000Z"}{>>Use the launch story.<<}{id="c2" by="user" at="2026-04-28T12:08:00.000Z" re="s1"}.
+```
+
+## Metadata
+
+Roughdraft's canonical metadata format is an attribute block written immediately after a comment or suggestion:
+
+```ebnf
+metadata  = "{" 1*attribute "}"
+attribute = name "=" quoted-value
+name      = ALPHA *( ALPHA / DIGIT / "_" / "-" )
+```
+
+Attribute values are double-quoted strings. Inside a quoted value, `\"` represents a literal quote and `\\` represents a literal backslash.
+
+Canonical attributes:
+
+| Attribute | Applies to | Required when writing | Meaning |
+| --- | --- | --- | --- |
+| `id` | Comments and suggestions | Yes | Stable document-local identifier. |
+| `by` | Comments and suggestions | Yes | Author or agent label. `AI` identifies an agent author. |
+| `at` | Comments and suggestions | Yes | ISO 8601 timestamp. |
+| `re` | Comments | No | Parent comment or suggestion id for threaded replies. |
+
+Example:
+
+```markdown
+{>>Needs a source.<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z"}
+```
+
+Implementations SHOULD generate simple document-local ids. Roughdraft uses `c1`, `c2`, and so on for comments and `s1`, `s2`, and so on for suggestions. Implementations MUST preserve unknown valid attributes when possible, but they MUST NOT require unknown attributes for correct review rendering.
+
+For compatibility, readers MAY accept legacy comment metadata of the form `{@id:c1; by:AI; at:2026-04-28T12:00:00.000Z@}`. Writers SHOULD emit canonical attribute blocks.
+
+## Threads
+
+Threading is represented by `re`.
+
+```markdown
+Review {==this sentence==}{>>Needs a source.<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z"}{>>I can add one from the intro.<<}{id="c2" by="AI" at="2026-04-28T12:05:00.000Z" re="c1"}.
+```
+
+A reply whose `re` points to a missing id SHOULD be treated as a top-level comment. A comment MUST NOT be its own parent.
+
+## Parsing And Round Trips
+
+Implementations SHOULD parse Roughdraft review markers as inline review annotations without rewriting unrelated Markdown.
+
+Round trips SHOULD preserve:
+
+- YAML frontmatter delimiters and content.
+- Local links and image paths.
+- Tables and task lists.
+- Inline code and fenced code blocks.
+- Raw review marker text inside code contexts.
+- Metadata values, including escaped quotes and backslashes.
+
+When importing a valid comment or suggestion without metadata, an implementation MAY synthesize missing `id`, `by`, and `at` values on write.
+
+## Review Interchange JSON
+
+The Markdown file is the normative storage format. For APIs, tests, and integrations, implementations MAY expose a review index JSON document that follows [`roughdraft-flavored-markdown.schema.json`](./roughdraft-flavored-markdown.schema.json).
+
+The review index intentionally does not replace a Markdown AST. It indexes Roughdraft review annotations while leaving block parsing to the Markdown implementation.
+
+Example:
+
+```json
+{
+  "format": "roughdraft-flavored-markdown",
+  "version": "0.1",
+  "source": {
+    "markdown": "Please revisit {==this sentence==}{>>Needs a source.<<}{id=\"c1\" by=\"user\" at=\"2026-04-28T12:00:00.000Z\"}.\\n"
+  },
+  "comments": [
+    {
+      "id": "c1",
+      "body": "Needs a source.",
+      "by": "user",
+      "at": "2026-04-28T12:00:00.000Z",
+      "anchor": {
+        "text": "this sentence"
+      }
+    }
+  ],
+  "suggestions": []
+}
+```
+
+Conformance fixtures live in [`fixtures/`](./fixtures/). A parser that claims Roughdraft Flavored Markdown 0.1 support SHOULD pass those examples or document any intentional differences.
+

--- a/docs/spec/roughdraft-flavored-markdown.schema.json
+++ b/docs/spec/roughdraft-flavored-markdown.schema.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://roughdraft.page/spec/roughdraft-flavored-markdown.schema.json",
+  "title": "Roughdraft Flavored Markdown Review Index",
+  "description": "A JSON review index for comments and suggestions parsed from Roughdraft Flavored Markdown. The Markdown source remains the normative storage format.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format", "version", "source", "comments", "suggestions"],
+  "properties": {
+    "format": {
+      "const": "roughdraft-flavored-markdown"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^0\\.1$"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["markdown"],
+      "properties": {
+        "markdown": {
+          "type": "string",
+          "description": "The complete Markdown source that produced this review index."
+        },
+        "frontmatter": {
+          "type": ["string", "null"],
+          "description": "YAML frontmatter content when exposed separately by the parser."
+        }
+      }
+    },
+    "comments": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/comment"
+      }
+    },
+    "suggestions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/suggestion"
+      }
+    }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Unknown metadata attributes preserved from the source document."
+    },
+    "author": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "anchor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "The highlighted anchor text from {==...==}."
+        },
+        "markdown": {
+          "type": "string",
+          "description": "The highlighted anchor content before inline Markdown rendering, when available."
+        }
+      }
+    },
+    "comment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "body", "by", "at"],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/id"
+        },
+        "body": {
+          "type": "string"
+        },
+        "by": {
+          "$ref": "#/$defs/author"
+        },
+        "at": {
+          "$ref": "#/$defs/timestamp"
+        },
+        "re": {
+          "$ref": "#/$defs/id"
+        },
+        "anchor": {
+          "$ref": "#/$defs/anchor"
+        },
+        "targetSuggestionId": {
+          "$ref": "#/$defs/id"
+        },
+        "metadata": {
+          "$ref": "#/$defs/metadata"
+        }
+      }
+    },
+    "suggestion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "by", "at"],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/id"
+        },
+        "kind": {
+          "enum": ["addition", "deletion", "substitution"]
+        },
+        "by": {
+          "$ref": "#/$defs/author"
+        },
+        "at": {
+          "$ref": "#/$defs/timestamp"
+        },
+        "text": {
+          "type": "string",
+          "description": "The inserted or deleted text for addition and deletion suggestions."
+        },
+        "oldText": {
+          "type": "string",
+          "description": "The replaced text for substitution suggestions."
+        },
+        "newText": {
+          "type": "string",
+          "description": "The replacement text for substitution suggestions."
+        },
+        "commentIds": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/id"
+          },
+          "uniqueItems": true
+        },
+        "metadata": {
+          "$ref": "#/$defs/metadata"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "substitution"
+              }
+            },
+            "required": ["kind"]
+          },
+          "then": {
+            "required": ["oldText", "newText"]
+          },
+          "else": {
+            "required": ["text"]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && node ../../scripts/copy-app-spec.mjs",
     "preview": "vite preview",
     "test": "vitest run"
   },

--- a/packages/app/public/setup.md
+++ b/packages/app/public/setup.md
@@ -72,6 +72,8 @@ After updating your instructions, briefly tell the user which file you changed.
 
 Roughdraft uses CriticMarkup for inline comments and suggested changes while keeping all review state in the Markdown file.
 
+For exact syntax, metadata, and round-trip behavior, read the official Roughdraft Flavored Markdown spec at https://roughdraft.page/spec/roughdraft-flavored-markdown.md. The review-index JSON Schema is available at https://roughdraft.page/spec/roughdraft-flavored-markdown.schema.json.
+
 Base markers:
 
 ```text

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -72,6 +72,20 @@ const ROUGHDRAFT_MARKDOWN_FEATURES = [
     icon: FileText,
   },
 ] as const;
+const HOMEPAGE_WORKFLOWS = [
+  {
+    title: "Review an agent's draft",
+    description:
+      "Ask your agent to write a Markdown file, open it in Roughdraft, then leave comments and suggested changes. When you are done, tell the agent to read the file again so it can reply inline or incorporate your feedback.",
+    icon: MessageSquare,
+  },
+  {
+    title: "Ask the agent to review yours",
+    description:
+      "Start from your own writing and have the agent leave detailed comments, questions, and suggested edits in the document. You can accept the useful parts, push back in replies, or send the file back for another pass.",
+    icon: PencilLine,
+  },
+] as const;
 const ROUGHDRAFT_MARKDOWN_SYNTAX = [
   {
     label: "Comment",
@@ -105,6 +119,12 @@ const ROUGHDRAFT_MARKDOWN_SYNTAX = [
   },
 ] as const;
 const ROUGHDRAFT_MARKDOWN_REFERENCES = [
+  {
+    title: "Official RFM spec",
+    href: "/spec/roughdraft-flavored-markdown.md",
+    description:
+      "The normative syntax, metadata, round-trip, and JSON review-index contract for Roughdraft Flavored Markdown.",
+  },
   {
     title: "CriticMarkup",
     href: "https://criticmarkup.com/",
@@ -343,6 +363,49 @@ export function Homepage({
                 </div>
               ),
             )}
+          </div>
+        </section>
+
+        <section
+          aria-labelledby="homepage-workflow-heading"
+          className="mx-auto mt-16 w-full max-w-5xl border-t border-slate-200 pt-10 text-left"
+        >
+          <div className="grid gap-8 lg:grid-cols-[0.85fr_1.15fr] lg:items-start">
+            <div>
+              <p className="text-xs font-medium tracking-[0.16em] text-stone-500 uppercase">
+                Review workflow
+              </p>
+              <h2
+                className="mt-3 text-3xl leading-tight font-semibold text-balance text-slate-950 sm:text-4xl"
+                id="homepage-workflow-heading"
+              >
+                Pass the same Markdown file back and forth with your agent.
+              </h2>
+              <p className="mt-4 text-base leading-7 text-slate-600">
+                Roughdraft makes review state part of the document, so the next
+                agent turn can see the comments, suggestions, and replies
+                without needing access to a hosted editor.
+              </p>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              {HOMEPAGE_WORKFLOWS.map(({ description, icon: Icon, title }) => (
+                <div
+                  className="rounded-lg border border-slate-200 bg-white p-5 shadow-[0_10px_30px_rgba(15,23,42,0.05)]"
+                  key={title}
+                >
+                  <div className="flex size-10 items-center justify-center rounded-md border border-slate-200 bg-slate-50 text-slate-700">
+                    <Icon className="size-4" aria-hidden="true" />
+                  </div>
+                  <h3 className="mt-4 text-base font-semibold text-slate-950">
+                    {title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-6 text-slate-600">
+                    {description}
+                  </p>
+                </div>
+              ))}
+            </div>
           </div>
         </section>
       </div>

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -68,6 +68,18 @@ describe("Homepage", () => {
       '{==this claim==}{>>Can we source this?<<}{id="c1"',
     );
     expect(container.textContent).toContain('re="s1"');
+    expect(container.textContent).toContain("Review workflow");
+    expect(container.textContent).toContain(
+      "Pass the same Markdown file back and forth with your agent.",
+    );
+    expect(container.textContent).toContain("Review an agent's draft");
+    expect(container.textContent).toContain(
+      "tell the agent to read the file again",
+    );
+    expect(container.textContent).toContain("Ask the agent to review yours");
+    expect(container.textContent).toContain(
+      "leave detailed comments, questions, and suggested edits",
+    );
     expect(
       container.querySelectorAll('[contenteditable="plaintext-only"]'),
     ).toHaveLength(0);
@@ -129,11 +141,16 @@ describe("Homepage", () => {
     );
     expect(container.textContent).toContain("CriticMarkup");
     expect(container.textContent).toContain("Notion-flavored Markdown");
+    expect(container.textContent).toContain("Official RFM spec");
     expect(container.textContent).toContain("Format contract");
     expect(container.textContent).toContain(
       "Review data lives where agents can inspect it",
     );
     expect(container.textContent).toContain("document-local");
+    expect(
+      container.querySelector('a[href="/spec/roughdraft-flavored-markdown.md"]')
+        ?.textContent,
+    ).toContain("Official RFM spec");
     expect(
       container.querySelector('a[href="https://criticmarkup.com/"]')
         ?.textContent,

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -955,6 +955,9 @@ describe("cli", () => {
     expect(test.logs).toContain(
       "  Treat CriticMarkup inside fenced code blocks as literal example text.",
     );
+    expect(test.logs).toContain(
+      "  https://roughdraft.page/spec/roughdraft-flavored-markdown.md",
+    );
   });
 
   it("points general help to agent setup", async () => {

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -14,6 +14,8 @@ import { findAvailablePort } from "./ports.js";
 import { resolveUpdateStatus, type UpdateStatus } from "./update-status.js";
 
 const AGENT_SETUP_URL = "https://roughdraft.page/setup.md";
+const ROUGHDRAFT_FLAVORED_MARKDOWN_SPEC_URL =
+  "https://roughdraft.page/spec/roughdraft-flavored-markdown.md";
 const AGENT_SETUP_PROMPT = `Install Roughdraft for me using \`npm i -g roughdraft\`, then read ${AGENT_SETUP_URL} and set yourself up to use it.`;
 const STATUS_PATH = "/api/status";
 const STATUS_TIMEOUT_MS = 750;
@@ -735,6 +737,9 @@ function printCriticMarkupHelp(log: (message: string) => void) {
   log(
     "  Treat CriticMarkup inside fenced code blocks as literal example text.",
   );
+  log("");
+  log("Full spec:");
+  log(`  ${ROUGHDRAFT_FLAVORED_MARKDOWN_SPEC_URL}`);
 }
 
 function parsePort(value: string | undefined): number {

--- a/scripts/copy-app-spec.mjs
+++ b/scripts/copy-app-spec.mjs
@@ -1,0 +1,14 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const sourceDir = path.join(repoRoot, "docs", "spec");
+const destinationDir = path.join(repoRoot, "packages", "app", "dist", "spec");
+
+fs.rmSync(destinationDir, { force: true, recursive: true });
+fs.mkdirSync(path.dirname(destinationDir), { recursive: true });
+fs.cpSync(sourceDir, destinationDir, { recursive: true });


### PR DESCRIPTION
Adds the draft Roughdraft Flavored Markdown spec, review-index JSON Schema, and conformance fixtures under docs/spec. Updates the app build to publish those spec files at /spec and links them from the README, setup instructions, CLI CriticMarkup help, and homepage spec page. Adds homepage copy for the human-agent Markdown review workflow and covers the new homepage/spec links in tests.\n\nChecks: pnpm check