### PR TITLE
Bump package version to 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roughdraft",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A local markdown review app",
   "license": "MIT",
   "author": "Nathan Baschez",


### PR DESCRIPTION
Bumps the published root package version from 0.1.3 to 0.1.4. The workspace package versions remain unchanged because they are private.\n\nVerification: pnpm check.