### PR TITLE
Add in-memory preview route

### DIFF
--- a/packages/app/e2e/preview.spec.ts
+++ b/packages/app/e2e/preview.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+import { appendInCodeEditor, logE2eEvent } from "./helpers";
+
+test.describe("in-memory preview", () => {
+  test("edits the preview document without persisting it @smoke", async ({
+    page,
+  }) => {
+    await page.goto("/preview?editor=code");
+
+    await expect(page.locator(".cm-content")).toContainText("Live Preview");
+    await appendInCodeEditor(page, "\n\nPreview-only edit.");
+    await expect(page.locator(".cm-content")).toContainText(
+      "Preview-only edit.",
+    );
+
+    const roughdraftStorageKeys = await page.evaluate(() =>
+      Object.keys(window.localStorage).filter((key) =>
+        key.startsWith("roughdraft:"),
+      ),
+    );
+    expect(roughdraftStorageKeys).toEqual([]);
+
+    await page.reload();
+    await expect(page.locator(".cm-content")).toContainText("Live Preview");
+    await expect(page.locator(".cm-content")).not.toContainText(
+      "Preview-only edit.",
+    );
+
+    logE2eEvent("preview.in-memory-edit", {
+      route: "/preview",
+      persistedStorageKeys: roughdraftStorageKeys.length,
+    });
+  });
+});

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -12,13 +12,13 @@ import {
 } from "lucide-react";
 import {
   type DocumentEditorViewMode,
+  PREVIEW_PATH,
   ROUGHDRAFT_FLAVORED_MARKDOWN_PATH,
   buildLocationForDocumentEditorViewMode,
   formatWorkspacePathForDisplay,
   getDocumentEditorViewModeFromLocation,
   getPathLeaf,
   getRequestedPathState,
-  isReservedAppPath,
   joinPath,
   syncRequestedPathInUrl,
 } from "./app-navigation";
@@ -34,6 +34,7 @@ import {
 } from "./components/ui/dialog";
 import { detectBackend } from "./detect-backend";
 import { DocumentWorkspace } from "./DocumentWorkspace";
+import { PreviewBackend } from "./preview-backend";
 import {
   MarkdownFileConflictError,
   type Page,
@@ -46,6 +47,18 @@ type SaveState = "idle" | "saving" | "error";
 type DocumentDiskChangeState = "clean" | "changed" | "conflict" | "paused";
 const AGENT_SETUP_PROMPT =
   "Install Roughdraft for me using `npm i -g roughdraft`, then read https://roughdraft.page/setup.md and set yourself up to use it.";
+const PREVIEW_DOCUMENT_PATH = "preview.md";
+const PREVIEW_INITIAL_MARKDOWN = [
+  "# Live Preview",
+  "",
+  "This draft only lives in memory. Edit it freely, switch between rich text and code view, and reload the page when you want a clean copy.",
+  "",
+  "- Comments and suggested changes use Roughdraft flavored Markdown.",
+  "- Autosave updates the in-memory document, not disk or browser storage.",
+  "",
+  '{==Select this sentence==}{>>Try replying to this comment or suggesting a replacement.<<}{id="preview-comment" by="Roughdraft" at="2026-04-28T12:00:00.000Z"}',
+  "",
+].join("\n");
 const ROUGHDRAFT_MARKDOWN_FEATURES = [
   {
     title: "Comment in the margins",
@@ -233,7 +246,7 @@ export function Homepage({
             ))}
           </div>
 
-          <div className="mt-7 flex flex-col items-center justify-center gap-3 sm:flex-row">
+          <div className="mt-7 flex flex-col items-center justify-center gap-3">
             <Dialog>
               <DialogTrigger
                 render={
@@ -280,21 +293,23 @@ export function Homepage({
               </DialogContent>
             </Dialog>
 
-            <Button
-              className="h-10 gap-2 px-4 text-sm"
-              size="lg"
-              variant="outline"
-              render={
-                <a
-                  href="https://github.com/Lex-Inc/roughdraft"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  <ExternalLink className="size-4" aria-hidden="true" />
-                  View on GitHub
-                </a>
-              }
-            />
+            <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1.5 text-xs font-medium text-stone-500">
+              <Button
+                className="h-6 gap-1.5 px-1 text-xs text-stone-500 hover:bg-transparent hover:text-stone-700"
+                size="sm"
+                variant="ghost"
+                render={
+                  <a
+                    href="https://github.com/Lex-Inc/roughdraft"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    <ExternalLink className="size-3.5" aria-hidden="true" />
+                    View on GitHub
+                  </a>
+                }
+              />
+            </div>
           </div>
         </div>
 
@@ -651,12 +666,84 @@ export function RoughdraftFlavoredMarkdownPage() {
   );
 }
 
+function createPreviewPage(): Page {
+  return {
+    id: "preview",
+    title: "Live Preview",
+    content: PREVIEW_INITIAL_MARKDOWN,
+    version: "memory:initial",
+  };
+}
+
+export function PreviewPage() {
+  const [backend] = useState(() => new PreviewBackend(createPreviewPage()));
+  const [previewPage, setPreviewPage] = useState<Page>(() =>
+    backend.getCurrentPage(),
+  );
+  const [previewForceResetKey, setPreviewForceResetKey] = useState<
+    string | null
+  >(null);
+  const [editorViewMode, setEditorViewMode] = useState<DocumentEditorViewMode>(
+    () => getDocumentEditorViewModeFromLocation("rich-text"),
+  );
+  const [, setSaveState] = useState<SaveState>("idle");
+
+  useEffect(() => () => backend.dispose(), [backend]);
+
+  useEffect(() => {
+    document.title = "Roughdraft Preview";
+  }, []);
+
+  const handleSaveDocument = useCallback(
+    async (_id: string, content: string) => {
+      const savedPage = await backend.saveMarkdownFile(
+        PREVIEW_DOCUMENT_PATH,
+        content,
+      );
+      setPreviewPage(savedPage);
+    },
+    [backend],
+  );
+
+  const handleResetPreview = useCallback(async () => {
+    const freshBackendPage = createPreviewPage();
+    const savedPage = await backend.saveMarkdownFile(
+      PREVIEW_DOCUMENT_PATH,
+      freshBackendPage.content,
+    );
+    setPreviewPage(savedPage);
+    setPreviewForceResetKey(`preview-reset:${Date.now()}`);
+  }, [backend]);
+
+  return (
+    <main className="relative flex h-screen min-w-0 flex-col overflow-hidden bg-[#FCFCFC] text-slate-950">
+      <DocumentWorkspace
+        documentPage={previewPage}
+        activeDocumentPath={PREVIEW_DOCUMENT_PATH}
+        documentFilenameLabel={PREVIEW_DOCUMENT_PATH}
+        documentEditorViewMode={editorViewMode}
+        onDocumentEditorViewModeChange={setEditorViewMode}
+        onSaveDocument={handleSaveDocument}
+        onDocumentSaveStateChange={setSaveState}
+        onDocumentDirtyStateChange={() => {}}
+        onDocumentLocalContentChange={() => {}}
+        documentDiskChangeState="clean"
+        documentForceResetKey={previewForceResetKey}
+        onReloadDocumentFromDisk={handleResetPreview}
+        onKeepEditingWithoutAutosave={() => {}}
+        onOverwriteDocumentOnDisk={() => {}}
+        backend={backend}
+      />
+    </main>
+  );
+}
+
 export function App() {
   const initialRequestedPathState = getRequestedPathState();
   const [requestedPathState] = useState(initialRequestedPathState);
-  const isRoughdraftFlavoredMarkdownRoute = isReservedAppPath(
-    window.location.pathname,
-  );
+  const isRoughdraftFlavoredMarkdownRoute =
+    window.location.pathname === ROUGHDRAFT_FLAVORED_MARKDOWN_PATH;
+  const isPreviewRoute = window.location.pathname === PREVIEW_PATH;
   const [backend, setBackend] = useState<StorageBackend | null>(null);
   const [documentPage, setDocumentPage] = useState<Page | null>(null);
   const [activeDocumentPath, setActiveDocumentPath] = useState<string | null>(
@@ -822,13 +909,16 @@ export function App() {
         )
       : null;
 
-    document.title = isRoughdraftFlavoredMarkdownRoute
-      ? "Roughdraft Flavored Markdown"
-      : (workspaceTitlePath ?? "Roughdraft");
+    document.title = isPreviewRoute
+      ? "Roughdraft Preview"
+      : isRoughdraftFlavoredMarkdownRoute
+        ? "Roughdraft Flavored Markdown"
+        : (workspaceTitlePath ?? "Roughdraft");
   }, [
     activeDocumentPath,
     backend,
     isRoughdraftFlavoredMarkdownRoute,
+    isPreviewRoute,
     requestedPathState.rawPath,
   ]);
 
@@ -988,6 +1078,10 @@ export function App() {
 
   if (isRoughdraftFlavoredMarkdownRoute) {
     return <RoughdraftFlavoredMarkdownPage />;
+  }
+
+  if (isPreviewRoute) {
+    return <PreviewPage />;
   }
 
   if (!requestedPathState.rawPath || loadError) {

--- a/packages/app/src/app-navigation.test.ts
+++ b/packages/app/src/app-navigation.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  PREVIEW_PATH,
   ROUGHDRAFT_FLAVORED_MARKDOWN_PATH,
   getRequestedPathState,
   syncRequestedPathInUrl,
@@ -37,6 +38,14 @@ describe("app navigation", () => {
 
   it("does not treat reserved app pages as file paths", () => {
     window.history.replaceState(null, "", ROUGHDRAFT_FLAVORED_MARKDOWN_PATH);
+
+    expect(getRequestedPathState()).toEqual({
+      rawPath: null,
+      projectPath: null,
+      documentPath: null,
+    });
+
+    window.history.replaceState(null, "", PREVIEW_PATH);
 
     expect(getRequestedPathState()).toEqual({
       rawPath: null,

--- a/packages/app/src/app-navigation.ts
+++ b/packages/app/src/app-navigation.ts
@@ -7,14 +7,16 @@ interface RequestedPathState {
 export type DocumentEditorViewMode = "rich-text" | "code";
 export const ROUGHDRAFT_FLAVORED_MARKDOWN_PATH =
   "/roughdraft-flavored-markdown";
+export const PREVIEW_PATH = "/preview";
 
 function normalizePathSeparators(value: string) {
   return value.replace(/\\/g, "/");
 }
 
 export function isReservedAppPath(pathname: string) {
-  return (
-    normalizePathSeparators(pathname) === ROUGHDRAFT_FLAVORED_MARKDOWN_PATH
+  const normalizedPathname = normalizePathSeparators(pathname);
+  return [ROUGHDRAFT_FLAVORED_MARKDOWN_PATH, PREVIEW_PATH].includes(
+    normalizedPathname,
   );
 }
 

--- a/packages/app/src/preview-backend.ts
+++ b/packages/app/src/preview-backend.ts
@@ -1,0 +1,94 @@
+import type { BackendInfo, Page, StorageBackend, StoredAsset } from "./storage";
+
+function titleFromContent(content: string, fallback: string) {
+  const firstLine = content.split("\n")[0] || "";
+  return firstLine.replace(/^#*\s*/, "").trim() || fallback;
+}
+
+function sanitizeFilename(filename: string): string {
+  const trimmed = filename.trim() || "attachment";
+  return trimmed.replace(/[^a-zA-Z0-9._-]/g, "-");
+}
+
+function nextAssetPath(assets: Map<string, string>, filename: string): string {
+  const safeName = sanitizeFilename(filename);
+  const dotIndex = safeName.lastIndexOf(".");
+  const basename = dotIndex > 0 ? safeName.slice(0, dotIndex) : safeName;
+  const extension = dotIndex > 0 ? safeName.slice(dotIndex) : "";
+  let counter = 0;
+
+  while (true) {
+    const suffix = counter === 0 ? "" : `-${counter}`;
+    const path = `./.roughdraft-preview-assets/${basename}${suffix}${extension}`;
+    if (!assets.has(path)) return path;
+    counter += 1;
+  }
+}
+
+export class PreviewBackend implements StorageBackend {
+  info: BackendInfo = {
+    kind: "local-storage",
+    label: "Live preview",
+    detail: "In memory only",
+  };
+  canManageProjects = false;
+
+  private page: Page;
+  private assets = new Map<string, string>();
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  getCurrentPage(): Page {
+    return this.page;
+  }
+
+  async getMarkdownFile(_relativePath: string): Promise<Page> {
+    return this.page;
+  }
+
+  async saveMarkdownFile(
+    _relativePath: string,
+    content: string,
+  ): Promise<Page> {
+    this.page = {
+      ...this.page,
+      title: titleFromContent(content, this.page.id),
+      content,
+      version: `memory:${Date.now()}`,
+    };
+
+    return this.page;
+  }
+
+  async saveAsset(file: File): Promise<StoredAsset> {
+    const markdownPath = nextAssetPath(this.assets, file.name);
+    const previewUrl = URL.createObjectURL(file);
+    this.assets.set(markdownPath, previewUrl);
+
+    return {
+      markdownPath,
+      previewUrl,
+      mimeType: file.type || "application/octet-stream",
+    };
+  }
+
+  resolveFileUrl(path: string): string | null {
+    const normalized = path.startsWith("./")
+      ? path
+      : `./${path.replace(/^\/+/, "")}`;
+    return this.assets.get(normalized) ?? null;
+  }
+
+  async openProject(_path: string): Promise<void> {
+    return;
+  }
+
+  dispose(): void {
+    for (const previewUrl of this.assets.values()) {
+      URL.revokeObjectURL(previewUrl);
+    }
+    this.assets.clear();
+  }
+}

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -1,7 +1,12 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { Homepage, RoughdraftFlavoredMarkdownPage } from "../src/App";
+import {
+  Homepage,
+  PreviewPage,
+  RoughdraftFlavoredMarkdownPage,
+} from "../src/App";
 
 const AGENT_SETUP_PROMPT =
   "Install Roughdraft for me using `npm i -g roughdraft`, then read https://roughdraft.page/setup.md and set yourself up to use it.";
@@ -19,6 +24,20 @@ describe("Homepage", () => {
   let writeText: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    if (!("ResizeObserver" in globalThis)) {
+      Object.defineProperty(globalThis, "ResizeObserver", {
+        configurable: true,
+        value: class ResizeObserver {
+          observe() {}
+          unobserve() {}
+          disconnect() {}
+        },
+      });
+    }
+
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -36,6 +55,7 @@ describe("Homepage", () => {
     });
     container.remove();
     document.body.innerHTML = "";
+    vi.restoreAllMocks();
   });
 
   it("opens the agent setup prompt from the CTA and copies it", async () => {
@@ -97,6 +117,8 @@ describe("Homepage", () => {
       'a[href="https://github.com/Lex-Inc/roughdraft"]',
     );
 
+    expect(container.textContent).not.toContain("Try live preview");
+    expect(container.querySelector('a[href="/preview"]')).toBeNull();
     expect(githubLink?.textContent).toContain("View on GitHub");
     expect(githubLink?.getAttribute("target")).toBe("_blank");
     expect(githubLink?.getAttribute("rel")).toBe("noreferrer");
@@ -168,5 +190,24 @@ describe("Homepage", () => {
     expect(container.querySelector('a[href="/"]')?.textContent).toContain(
       "Back to Roughdraft",
     );
+  });
+
+  it("renders an in-memory live preview page", async () => {
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+
+    await act(async () => {
+      root.render(
+        <TooltipProvider>
+          <PreviewPage />
+        </TooltipProvider>,
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("preview.md");
+    expect(container.textContent).toContain("Live Preview");
+    expect(container.textContent).toContain("This draft only lives in memory.");
+    expect(container.textContent).toContain("Select this sentence");
+    expect(setItem).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Adds a reserved /preview route backed by an in-memory PreviewBackend so users can try the editor without touching disk or localStorage. Updates homepage CTA layout to keep GitHub secondary and hides the preview link from the homepage. Covers reserved route parsing, homepage rendering, and preview reset behavior with unit and Playwright smoke tests.