### PR TITLE
Add Markdown doctor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ open <path>        Open one Markdown file, starting the server if needed
 start              Start or reuse the background server
 status             Show server status
 stop               Stop the managed background server
-doctor             Diagnose local setup issues
+doctor [path]      Diagnose setup or validate Markdown
 help agent         Print the agent setup prompt
 help criticmarkup  Show CriticMarkup examples
 agent-setup        Print the agent setup prompt
@@ -209,6 +209,8 @@ roughdraft start --port <port>
 roughdraft status --json
 roughdraft stop --all
 roughdraft doctor --json
+roughdraft doctor ./draft.md
+roughdraft doctor ./draft.md --json
 ```
 
 Usage errors return exit code `2`. Runtime failures return exit code `1`. `roughdraft status --json` returns exit code `0` even when the JSON says `"running": false`.

--- a/package.json
+++ b/package.json
@@ -21,22 +21,25 @@
     "lint:fix": "biome check --write . --assist-enabled=false",
     "unused": "knip --no-progress",
     "format": "biome format --write .",
-    "test": "pnpm --filter @roughdraft/app test && pnpm --filter @roughdraft/server test",
+    "test": "pnpm --filter @roughdraft/rfm test && pnpm --filter @roughdraft/app test && pnpm --filter @roughdraft/server test",
     "test:e2e": "playwright test --config packages/app/playwright.config.ts",
     "test:smoke": "playwright test --config packages/app/playwright.config.ts --grep @smoke",
     "test:coverage": "pnpm --filter @roughdraft/app exec vitest run --coverage && pnpm --filter @roughdraft/server exec vitest run --coverage",
     "check": "pnpm lint && pnpm test && pnpm build",
-    "build": "pnpm --filter @roughdraft/app build && pnpm --filter @roughdraft/server build",
+    "build": "pnpm --filter @roughdraft/rfm build && pnpm --filter @roughdraft/app build && pnpm --filter @roughdraft/server build",
     "preview": "node packages/server/bin/roughdraft.mjs open README.md"
   },
   "files": [
     "packages/app/dist",
+    "packages/rfm/dist",
+    "packages/rfm/package.json",
     "packages/server/dist",
     "packages/server/bin",
     "packages/server/defaults.mjs",
     "packages/server/defaults.d.mts"
   ],
   "dependencies": {
+    "@roughdraft/rfm": "file:packages/rfm",
     "express": "^5.1.0"
   },
   "devDependencies": {

--- a/packages/rfm/package.json
+++ b/packages/rfm/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@roughdraft/rfm",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/rfm/src/index.test.ts
+++ b/packages/rfm/src/index.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { validateRoughdraftMarkdown } from "./index";
+
+function codes(markdown: string): string[] {
+  return validateRoughdraftMarkdown(markdown).diagnostics.map(
+    (diagnostic) => diagnostic.code,
+  );
+}
+
+describe("validateRoughdraftMarkdown", () => {
+  it("accepts valid comments, anchored comments, and suggestions", () => {
+    const result = validateRoughdraftMarkdown(
+      [
+        'Please revisit {==this sentence==}{>>Needs a source.<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z"}.',
+        'Add {++one concrete example++}{id="s1" by="AI" at="2026-04-28T12:05:00.000Z"}.',
+        'Use {~~rough~>specific~~}{id="s2" by="user" at="2026-04-28T12:07:00.000Z"} wording.',
+      ].join("\n"),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.summary).toMatchObject({
+      comments: 1,
+      suggestions: 2,
+      legacyMetadata: 0,
+    });
+  });
+
+  it("ignores review markers inside fenced code blocks and inline code spans", () => {
+    const result = validateRoughdraftMarkdown(
+      [
+        "```md",
+        "This is {>>not a comment<<}.",
+        "This is {++not a suggestion++}.",
+        "```",
+        "Literal `{>>not a comment<<}` text.",
+      ].join("\n"),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.summary).toMatchObject({
+      comments: 0,
+      suggestions: 0,
+    });
+  });
+
+  it("reports missing canonical metadata attributes", () => {
+    expect(codes("{>>Needs metadata<<}\n")).toEqual([
+      "missing-metadata-id",
+      "missing-metadata-by",
+      "missing-metadata-at",
+    ]);
+  });
+
+  it("reports invalid timestamps", () => {
+    expect(
+      codes('{>>Bad time<<}{id="c1" by="user" at="yesterday"}\n'),
+    ).toContain("invalid-metadata-at");
+  });
+
+  it("reports unclosed review markers", () => {
+    expect(codes("{++unfinished\n")).toEqual(["unclosed-addition"]);
+    expect(codes("{--unfinished\n")).toEqual(["unclosed-deletion"]);
+    expect(codes("{~~old text\n")).toEqual(["unclosed-substitution"]);
+  });
+
+  it("reports duplicate ids across comments and suggestions", () => {
+    expect(
+      codes(
+        [
+          '{>>First<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z"}',
+          '{++Second++}{id="c1" by="user" at="2026-04-28T12:01:00.000Z"}',
+        ].join("\n"),
+      ),
+    ).toContain("duplicate-id");
+  });
+
+  it("reports self replies as errors and missing reply targets as warnings", () => {
+    const result = validateRoughdraftMarkdown(
+      [
+        '{>>Self<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z" re="c1"}',
+        '{>>Missing parent<<}{id="c2" by="user" at="2026-04-28T12:01:00.000Z" re="missing"}',
+      ].join("\n"),
+    );
+
+    expect(result.errors.map((diagnostic) => diagnostic.code)).toContain(
+      "self-reply",
+    );
+    expect(result.warnings.map((diagnostic) => diagnostic.code)).toContain(
+      "missing-reply-target",
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepts legacy metadata with a warning", () => {
+    const result = validateRoughdraftMarkdown(
+      "{>>Legacy<<}{@id:c1; by:AI; at:2026-04-28T12:00:00.000Z@}\n",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings.map((diagnostic) => diagnostic.code)).toEqual([
+      "legacy-metadata",
+    ]);
+    expect(result.summary.legacyMetadata).toBe(1);
+  });
+
+  it("reports CRLF source locations with one-based line and column", () => {
+    const result = validateRoughdraftMarkdown(
+      "First line\r\n{>>Needs metadata<<}\r\n",
+    );
+
+    expect(result.errors[0]).toMatchObject({
+      line: 2,
+      column: 1,
+    });
+  });
+});

--- a/packages/rfm/src/index.ts
+++ b/packages/rfm/src/index.ts
@@ -1,0 +1,629 @@
+export type RfmDiagnosticSeverity = "error" | "warning";
+
+export interface RfmDiagnostic {
+  severity: RfmDiagnosticSeverity;
+  code: string;
+  message: string;
+  offset: number;
+  line: number;
+  column: number;
+}
+
+export interface RfmValidationSummary {
+  comments: number;
+  suggestions: number;
+  legacyMetadata: number;
+}
+
+export interface RfmValidationResult {
+  format: "roughdraft-flavored-markdown";
+  version: "0.1";
+  ok: boolean;
+  diagnostics: RfmDiagnostic[];
+  errors: RfmDiagnostic[];
+  warnings: RfmDiagnostic[];
+  summary: RfmValidationSummary;
+}
+
+interface Metadata {
+  attrs: Map<string, string>;
+  kind: "canonical" | "legacy";
+  offset: number;
+  endOffset: number;
+}
+
+interface IdReference {
+  id: string;
+  kind: "comment" | "suggestion";
+  offset: number;
+}
+
+interface ReplyReference {
+  id: string;
+  parentId: string;
+  offset: number;
+}
+
+interface FenceState {
+  marker: "`" | "~";
+  length: number;
+}
+
+const requiredMetadataAttributes = ["id", "by", "at"] as const;
+const dateTimePattern =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+const attributeNamePattern = /^[A-Za-z][A-Za-z0-9_-]*$/;
+
+export function validateRoughdraftMarkdown(
+  markdown: string,
+): RfmValidationResult {
+  const lineStarts = createLineStarts(markdown);
+  const diagnostics: RfmDiagnostic[] = [];
+  const ids = new Map<string, IdReference>();
+  const replies: ReplyReference[] = [];
+  const summary: RfmValidationSummary = {
+    comments: 0,
+    suggestions: 0,
+    legacyMetadata: 0,
+  };
+
+  const addDiagnostic = (
+    severity: RfmDiagnosticSeverity,
+    code: string,
+    message: string,
+    offset: number,
+  ) => {
+    diagnostics.push({
+      severity,
+      code,
+      message,
+      offset,
+      ...locationForOffset(lineStarts, offset),
+    });
+  };
+
+  const validateMetadata = (
+    metadata: Metadata | null,
+    kind: "comment" | "suggestion",
+    markerOffset: number,
+  ) => {
+    if (!metadata) {
+      for (const attribute of requiredMetadataAttributes) {
+        addDiagnostic(
+          "error",
+          `missing-metadata-${attribute}`,
+          `Missing required metadata attribute \`${attribute}\`.`,
+          markerOffset,
+        );
+      }
+      return;
+    }
+
+    if (metadata.kind === "legacy") {
+      summary.legacyMetadata += 1;
+      addDiagnostic(
+        "warning",
+        "legacy-metadata",
+        "Legacy metadata is accepted, but canonical attribute metadata is preferred.",
+        metadata.offset,
+      );
+    }
+
+    for (const attribute of requiredMetadataAttributes) {
+      if (!metadata.attrs.get(attribute)) {
+        addDiagnostic(
+          "error",
+          `missing-metadata-${attribute}`,
+          `Missing required metadata attribute \`${attribute}\`.`,
+          metadata.offset,
+        );
+      }
+    }
+
+    const at = metadata.attrs.get("at");
+    if (at && !isValidDateTime(at)) {
+      addDiagnostic(
+        "error",
+        "invalid-metadata-at",
+        `Metadata attribute \`at\` must be an ISO 8601 date-time.`,
+        metadata.offset,
+      );
+    }
+
+    const id = metadata.attrs.get("id");
+    if (id) {
+      const existing = ids.get(id);
+      if (existing) {
+        addDiagnostic(
+          "error",
+          "duplicate-id",
+          `Duplicate review id \`${id}\`.`,
+          metadata.offset,
+        );
+      } else {
+        ids.set(id, { id, kind, offset: metadata.offset });
+      }
+    }
+
+    const parentId = metadata.attrs.get("re");
+    if (kind === "comment" && id && parentId) {
+      replies.push({ id, parentId, offset: metadata.offset });
+    }
+  };
+
+  let offset = 0;
+  let fence: FenceState | null = null;
+
+  while (offset < markdown.length) {
+    if (isLineStart(markdown, offset)) {
+      const fenceMatch = matchFence(markdown, offset, fence);
+      if (fenceMatch) {
+        fence = fence ? null : fenceMatch.fence;
+        offset = nextLineOffset(markdown, offset);
+        continue;
+      }
+    }
+
+    if (fence) {
+      offset = nextLineOffset(markdown, offset);
+      continue;
+    }
+
+    const codeSpanEnd = matchInlineCodeSpan(markdown, offset);
+    if (codeSpanEnd !== null) {
+      offset = codeSpanEnd;
+      continue;
+    }
+
+    if (markdown.startsWith("{==", offset)) {
+      const end = markdown.indexOf("==}", offset + 3);
+      if (end === -1) {
+        addDiagnostic(
+          "error",
+          "unclosed-highlight",
+          "Highlight marker is missing closing `==}`.",
+          offset,
+        );
+        offset += 3;
+        continue;
+      }
+
+      let nextOffset = end + 3;
+      let anchoredComments = 0;
+      while (markdown.startsWith("{>>", nextOffset)) {
+        const parsed = parseComment(markdown, nextOffset, addDiagnostic);
+        if (!parsed) break;
+        summary.comments += 1;
+        anchoredComments += 1;
+        validateMetadata(parsed.metadata, "comment", nextOffset);
+        nextOffset = parsed.endOffset;
+      }
+
+      offset = anchoredComments > 0 ? nextOffset : end + 3;
+      continue;
+    }
+
+    if (markdown.startsWith("{>>", offset)) {
+      const parsed = parseComment(markdown, offset, addDiagnostic);
+      if (parsed) {
+        summary.comments += 1;
+        validateMetadata(parsed.metadata, "comment", offset);
+        offset = parsed.endOffset;
+        continue;
+      }
+    }
+
+    const parsedSuggestion = parseSuggestion(markdown, offset, addDiagnostic);
+    if (parsedSuggestion) {
+      summary.suggestions += 1;
+      validateMetadata(parsedSuggestion.metadata, "suggestion", offset);
+      offset = parsedSuggestion.endOffset;
+      continue;
+    }
+
+    offset += 1;
+  }
+
+  for (const reply of replies) {
+    if (reply.id === reply.parentId) {
+      addDiagnostic(
+        "error",
+        "self-reply",
+        `Comment \`${reply.id}\` must not reply to itself.`,
+        reply.offset,
+      );
+      continue;
+    }
+
+    if (!ids.has(reply.parentId)) {
+      addDiagnostic(
+        "warning",
+        "missing-reply-target",
+        `Comment reply \`re="${reply.parentId}"\` points to a missing id.`,
+        reply.offset,
+      );
+    }
+  }
+
+  diagnostics.sort((a, b) => a.offset - b.offset);
+  const errors = diagnostics.filter(
+    (diagnostic) => diagnostic.severity === "error",
+  );
+  const warnings = diagnostics.filter(
+    (diagnostic) => diagnostic.severity === "warning",
+  );
+
+  return {
+    format: "roughdraft-flavored-markdown",
+    version: "0.1",
+    ok: errors.length === 0,
+    diagnostics,
+    errors,
+    warnings,
+    summary,
+  };
+}
+
+function createLineStarts(markdown: string): number[] {
+  const lineStarts = [0];
+
+  for (let index = 0; index < markdown.length; index += 1) {
+    if (markdown[index] === "\n") {
+      lineStarts.push(index + 1);
+    }
+  }
+
+  return lineStarts;
+}
+
+function locationForOffset(
+  lineStarts: readonly number[],
+  offset: number,
+): { line: number; column: number } {
+  let low = 0;
+  let high = lineStarts.length - 1;
+
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const lineStart = lineStarts[middle] ?? 0;
+    const nextLineStart = lineStarts[middle + 1] ?? Number.POSITIVE_INFINITY;
+
+    if (offset < lineStart) {
+      high = middle - 1;
+    } else if (offset >= nextLineStart) {
+      low = middle + 1;
+    } else {
+      return {
+        line: middle + 1,
+        column: offset - lineStart + 1,
+      };
+    }
+  }
+
+  const lastLineStart = lineStarts[lineStarts.length - 1] ?? 0;
+  return {
+    line: lineStarts.length,
+    column: offset - lastLineStart + 1,
+  };
+}
+
+function isLineStart(markdown: string, offset: number): boolean {
+  return offset === 0 || markdown[offset - 1] === "\n";
+}
+
+function nextLineOffset(markdown: string, offset: number): number {
+  const nextNewline = markdown.indexOf("\n", offset);
+  return nextNewline === -1 ? markdown.length : nextNewline + 1;
+}
+
+function matchFence(
+  markdown: string,
+  offset: number,
+  fence: FenceState | null,
+): { fence: FenceState } | null {
+  const lineEnd = nextLineOffset(markdown, offset);
+  const line = markdown.slice(offset, lineEnd).replace(/\r?\n$/, "");
+  const match = line.match(/^[ \t]{0,3}(`{3,}|~{3,})/);
+  if (!match) return null;
+
+  const markerText = match[1] ?? "";
+  const marker = markerText[0] as "`" | "~";
+
+  if (!fence) {
+    return {
+      fence: {
+        marker,
+        length: markerText.length,
+      },
+    };
+  }
+
+  if (fence.marker !== marker || markerText.length < fence.length) {
+    return null;
+  }
+
+  return { fence };
+}
+
+function matchInlineCodeSpan(markdown: string, offset: number): number | null {
+  if (markdown[offset] !== "`") return null;
+
+  let length = 1;
+  while (markdown[offset + length] === "`") {
+    length += 1;
+  }
+
+  const closing = markdown.indexOf("`".repeat(length), offset + length);
+  return closing === -1 ? null : closing + length;
+}
+
+function parseComment(
+  markdown: string,
+  offset: number,
+  addDiagnostic: (
+    severity: RfmDiagnosticSeverity,
+    code: string,
+    message: string,
+    offset: number,
+  ) => void,
+): { metadata: Metadata | null; endOffset: number } | null {
+  const close = markdown.indexOf("<<}", offset + 3);
+  if (close === -1) {
+    addDiagnostic(
+      "error",
+      "unclosed-comment",
+      "Comment marker is missing closing `<<}`.",
+      offset,
+    );
+    return null;
+  }
+
+  const metadata = parseMetadata(markdown, close + 3, true, addDiagnostic);
+
+  return {
+    metadata,
+    endOffset: metadata?.endOffset ?? close + 3,
+  };
+}
+
+function parseSuggestion(
+  markdown: string,
+  offset: number,
+  addDiagnostic: (
+    severity: RfmDiagnosticSeverity,
+    code: string,
+    message: string,
+    offset: number,
+  ) => void,
+): { metadata: Metadata | null; endOffset: number } | null {
+  const addition = parseWrappedMarker(markdown, offset, "{++", "++}");
+  if (addition) {
+    const metadata = parseMetadata(
+      markdown,
+      addition.endOffset,
+      false,
+      addDiagnostic,
+    );
+    return {
+      metadata,
+      endOffset: metadata?.endOffset ?? addition.endOffset,
+    };
+  }
+  if (markdown.startsWith("{++", offset)) {
+    addDiagnostic(
+      "error",
+      "unclosed-addition",
+      "Addition marker is missing closing `++}`.",
+      offset,
+    );
+    return null;
+  }
+
+  const deletion = parseWrappedMarker(markdown, offset, "{--", "--}");
+  if (deletion) {
+    const metadata = parseMetadata(
+      markdown,
+      deletion.endOffset,
+      false,
+      addDiagnostic,
+    );
+    return {
+      metadata,
+      endOffset: metadata?.endOffset ?? deletion.endOffset,
+    };
+  }
+  if (markdown.startsWith("{--", offset)) {
+    addDiagnostic(
+      "error",
+      "unclosed-deletion",
+      "Deletion marker is missing closing `--}`.",
+      offset,
+    );
+    return null;
+  }
+
+  if (markdown.startsWith("{~~", offset)) {
+    const separator = markdown.indexOf("~>", offset + 3);
+    const close =
+      separator === -1 ? -1 : markdown.indexOf("~~}", separator + 2);
+
+    if (separator === -1 || close === -1) {
+      addDiagnostic(
+        "error",
+        "unclosed-substitution",
+        "Substitution marker is missing `~>` or closing `~~}`.",
+        offset,
+      );
+      return null;
+    }
+
+    const endOffset = close + 3;
+    const metadata = parseMetadata(markdown, endOffset, false, addDiagnostic);
+    return {
+      metadata,
+      endOffset: metadata?.endOffset ?? endOffset,
+    };
+  }
+
+  return null;
+}
+
+function parseWrappedMarker(
+  markdown: string,
+  offset: number,
+  open: string,
+  close: string,
+): { endOffset: number } | null {
+  if (!markdown.startsWith(open, offset)) return null;
+
+  const closeOffset = markdown.indexOf(close, offset + open.length);
+  return closeOffset === -1 ? null : { endOffset: closeOffset + close.length };
+}
+
+function parseMetadata(
+  markdown: string,
+  offset: number,
+  allowLegacy: boolean,
+  addDiagnostic: (
+    severity: RfmDiagnosticSeverity,
+    code: string,
+    message: string,
+    offset: number,
+  ) => void,
+): Metadata | null {
+  if (allowLegacy && markdown.startsWith("{@", offset)) {
+    const close = markdown.indexOf("@}", offset + 2);
+    if (close === -1) {
+      addDiagnostic(
+        "error",
+        "invalid-metadata-syntax",
+        "Legacy metadata is missing closing `@}`.",
+        offset,
+      );
+      return null;
+    }
+
+    return {
+      attrs: parseLegacyAttributes(markdown.slice(offset + 2, close)),
+      kind: "legacy",
+      offset,
+      endOffset: close + 2,
+    };
+  }
+
+  if (markdown[offset] !== "{") return null;
+
+  const parsed = parseCanonicalMetadata(markdown, offset);
+  if (parsed) return parsed;
+
+  if (looksLikeMetadata(markdown, offset)) {
+    addDiagnostic(
+      "error",
+      "invalid-metadata-syntax",
+      'Metadata must use quoted attributes such as `{id="c1" by="user" at="2026-04-28T12:00:00.000Z"}`.',
+      offset,
+    );
+  }
+
+  return null;
+}
+
+function parseCanonicalMetadata(
+  markdown: string,
+  offset: number,
+): Metadata | null {
+  let cursor = offset + 1;
+  const attrs = new Map<string, string>();
+  let sawAttribute = false;
+
+  while (cursor < markdown.length) {
+    cursor = skipSpaces(markdown, cursor);
+
+    if (markdown[cursor] === "}") {
+      if (!sawAttribute) return null;
+      return {
+        attrs,
+        kind: "canonical",
+        offset,
+        endOffset: cursor + 1,
+      };
+    }
+
+    const nameStart = cursor;
+    while (
+      cursor < markdown.length &&
+      /[A-Za-z0-9_-]/.test(markdown[cursor] ?? "")
+    ) {
+      cursor += 1;
+    }
+    const name = markdown.slice(nameStart, cursor);
+    if (!attributeNamePattern.test(name) || markdown[cursor] !== "=") {
+      return null;
+    }
+    cursor += 1;
+
+    if (markdown[cursor] !== '"') return null;
+    cursor += 1;
+
+    let value = "";
+    while (cursor < markdown.length) {
+      const character = markdown[cursor];
+      if (character === "\\") {
+        const next = markdown[cursor + 1];
+        if (next === undefined) return null;
+        value += next;
+        cursor += 2;
+        continue;
+      }
+
+      if (character === '"') {
+        cursor += 1;
+        attrs.set(name, value);
+        sawAttribute = true;
+        break;
+      }
+
+      if (character === "\n" || character === "\r") return null;
+      value += character;
+      cursor += 1;
+    }
+
+    if (!attrs.has(name)) return null;
+  }
+
+  return null;
+}
+
+function parseLegacyAttributes(metadata: string): Map<string, string> {
+  const attrs = new Map<string, string>();
+
+  for (const part of metadata.split(";")) {
+    const [rawKey, ...valueParts] = part.split(":");
+    const key = rawKey?.trim();
+    const value = valueParts.join(":").trim();
+    if (!key || !value) continue;
+    attrs.set(key, value);
+  }
+
+  return attrs;
+}
+
+function skipSpaces(markdown: string, offset: number): number {
+  let cursor = offset;
+  while (markdown[cursor] === " " || markdown[cursor] === "\t") {
+    cursor += 1;
+  }
+  return cursor;
+}
+
+function looksLikeMetadata(markdown: string, offset: number): boolean {
+  const close = markdown.indexOf("}", offset + 1);
+  if (close === -1) return false;
+
+  const content = markdown.slice(offset + 1, close);
+  return /\b(?:id|by|at|re)\b/.test(content);
+}
+
+function isValidDateTime(value: string): boolean {
+  return dateTimePattern.test(value) && !Number.isNaN(Date.parse(value));
+}

--- a/packages/rfm/tsconfig.json
+++ b/packages/rfm/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/rfm/vitest.config.ts
+++ b/packages/rfm/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,11 +4,12 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "pnpm --filter @roughdraft/rfm build && tsc",
     "dev": "tsx watch src/dev.ts",
     "test": "vitest run"
   },
   "dependencies": {
+    "@roughdraft/rfm": "workspace:*",
     "express": "^5.1.0"
   },
   "devDependencies": {

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -1035,6 +1035,15 @@ describe("cli", () => {
     );
   });
 
+  it("shows doctor help with the optional markdown path", async () => {
+    const test = createTestDependencies();
+
+    const exitCode = await runCli(["doctor", "--help"], test.deps);
+
+    expect(exitCode).toBe(0);
+    expect(test.logs).toContain("  roughdraft doctor [path] [--json]");
+  });
+
   it("rejects unknown command typos with suggestions", async () => {
     const test = createTestDependencies();
 
@@ -1101,6 +1110,96 @@ describe("cli", () => {
       repoRootMatches: true,
       stateDir: devStateDir,
     });
+  });
+
+  it("validates a conforming markdown file from doctor path", async () => {
+    const test = createTestDependencies();
+    const documentPath = path.join(projectDir, "draft.md");
+    fs.writeFileSync(
+      documentPath,
+      'Please revisit {==this sentence==}{>>Needs a source.<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z"}.\n',
+    );
+
+    const exitCode = await runCli(["doctor", documentPath], test.deps);
+
+    expect(exitCode).toBe(0);
+    expect(test.logs).toContain("Roughdraft Markdown doctor: draft.md");
+    expect(test.logs).toContain("Status: passed");
+    expect(test.logs).toContain("Found 1 comment(s) and 0 suggestion(s).");
+  });
+
+  it("returns validation errors from doctor path", async () => {
+    const test = createTestDependencies();
+    const documentPath = path.join(projectDir, "draft.md");
+    fs.writeFileSync(documentPath, "{>>Needs metadata<<}\n");
+
+    const exitCode = await runCli(["doctor", documentPath], test.deps);
+
+    expect(exitCode).toBe(1);
+    expect(test.logs).toContain("Status: failed");
+    expect(test.logs).toContain("Errors:");
+    expect(test.logs).toContain(
+      "  1:1  Missing required metadata attribute `id`.",
+    );
+  });
+
+  it("emits JSON validation output from doctor path --json", async () => {
+    const test = createTestDependencies();
+    const documentPath = path.join(projectDir, "draft.md");
+    fs.writeFileSync(
+      documentPath,
+      [
+        '{>>First<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z"}',
+        '{++Second++}{id="c1" by="user" at="2026-04-28T12:01:00.000Z"}',
+      ].join("\n"),
+    );
+
+    const exitCode = await runCli(
+      ["doctor", documentPath, "--json"],
+      test.deps,
+    );
+    const payload = parseOnlyJsonLog<{
+      kind: string;
+      path: string;
+      ok: boolean;
+      errors: Array<{ code: string }>;
+      summary: { comments: number; suggestions: number };
+    }>(test.logs);
+
+    expect(exitCode).toBe(1);
+    expect(payload).toMatchObject({
+      kind: "markdown",
+      path: documentPath,
+      ok: false,
+      summary: {
+        comments: 1,
+        suggestions: 1,
+      },
+    });
+    expect(payload.errors.map((error) => error.code)).toContain("duplicate-id");
+  });
+
+  it("rejects missing markdown files from doctor path before validation", async () => {
+    const test = createTestDependencies();
+    const documentPath = path.join(projectDir, "missing.md");
+
+    const exitCode = await runCli(["doctor", documentPath], test.deps);
+
+    expect(exitCode).toBe(2);
+    expect(test.errors).toContain(`Path not found: ${documentPath}`);
+  });
+
+  it("rejects non-markdown doctor paths as usage errors", async () => {
+    const test = createTestDependencies();
+    const documentPath = path.join(projectDir, "draft.txt");
+    fs.writeFileSync(documentPath, "# Draft\n");
+
+    const exitCode = await runCli(["doctor", documentPath], test.deps);
+
+    expect(exitCode).toBe(2);
+    expect(test.errors).toContain(
+      `Roughdraft doctor can only validate .md files: ${documentPath}`,
+    );
   });
 
   it("starts a new server when the preferred port belongs to another checkout", async () => {

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -5,6 +5,10 @@ import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { setTimeout as sleep } from "node:timers/promises";
 import {
+  type RfmDiagnostic,
+  validateRoughdraftMarkdown,
+} from "@roughdraft/rfm";
+import {
   ROUGHDRAFT_BIND_HOST,
   ROUGHDRAFT_DEFAULT_PORT,
   ROUGHDRAFT_LOOPBACK_HOSTS,
@@ -561,7 +565,7 @@ function printHelp(log: (message: string) => void) {
   log("  start              Start or reuse the background server");
   log("  status             Show server status");
   log("  stop               Stop the managed background server");
-  log("  doctor             Diagnose local setup issues");
+  log("  doctor [path]      Diagnose setup or validate Markdown");
   log("  help agent         Print the agent setup prompt");
   log("  help criticmarkup  Show CriticMarkup examples");
   log("  agent-setup        Print the agent setup prompt");
@@ -650,9 +654,11 @@ function printCommandHelp(
 
   if (command === "doctor") {
     log("Usage:");
-    log("  roughdraft doctor [--json]");
+    log("  roughdraft doctor [path] [--json]");
     log("");
-    log("Diagnoses local Roughdraft setup and server state.");
+    log(
+      "Diagnoses local Roughdraft setup and server state, or validates one Markdown file.",
+    );
     log("");
     log("Flags:");
     log("  --json               Print machine-readable output");
@@ -1401,6 +1407,102 @@ async function runDoctor(
   return 0;
 }
 
+async function runMarkdownDoctor(
+  deps: CliDependencies,
+  targetPath: string,
+  json: boolean,
+): Promise<number> {
+  if (!isMarkdownPath(targetPath)) {
+    deps.error(`Roughdraft doctor can only validate .md files: ${targetPath}`);
+    return USAGE_ERROR;
+  }
+
+  const absolutePath = path.resolve(deps.cwd, targetPath);
+  let markdown: string;
+
+  try {
+    const stat = fs.statSync(absolutePath);
+    if (!stat.isFile()) {
+      deps.error(`Path is not a file: ${absolutePath}`);
+      return USAGE_ERROR;
+    }
+    markdown = fs.readFileSync(absolutePath, "utf8");
+  } catch (error) {
+    const code =
+      error instanceof Error && "code" in error
+        ? String((error as NodeJS.ErrnoException).code)
+        : "";
+    deps.error(
+      code === "ENOENT"
+        ? `Path not found: ${absolutePath}`
+        : `Could not read path: ${absolutePath}`,
+    );
+    return USAGE_ERROR;
+  }
+
+  const validation = validateRoughdraftMarkdown(markdown);
+  const payload = {
+    kind: "markdown" as const,
+    path: absolutePath,
+    format: validation.format,
+    version: validation.version,
+    ok: validation.ok,
+    errors: validation.errors,
+    warnings: validation.warnings,
+    summary: validation.summary,
+  };
+
+  if (json) {
+    emitJson(deps.log, payload);
+    return validation.ok ? 0 : 1;
+  }
+
+  const displayPath = relativeDisplayPath(deps.cwd, absolutePath);
+  deps.log(`Roughdraft Markdown doctor: ${displayPath}`);
+  deps.log(`Status: ${validation.ok ? "passed" : "failed"}`);
+
+  if (validation.errors.length > 0) {
+    deps.log("");
+    deps.log("Errors:");
+    for (const diagnostic of validation.errors) {
+      deps.log(formatMarkdownDiagnostic(diagnostic));
+    }
+  }
+
+  if (validation.warnings.length > 0) {
+    deps.log("");
+    deps.log("Warnings:");
+    for (const diagnostic of validation.warnings) {
+      deps.log(formatMarkdownDiagnostic(diagnostic));
+    }
+  }
+
+  if (validation.errors.length === 0 && validation.warnings.length === 0) {
+    deps.log("");
+    deps.log(
+      `Found ${validation.summary.comments} comment(s) and ${validation.summary.suggestions} suggestion(s).`,
+    );
+  }
+
+  return validation.ok ? 0 : 1;
+}
+
+function isMarkdownPath(targetPath: string): boolean {
+  const extension = path.extname(targetPath).toLowerCase();
+  return extension === ".md";
+}
+
+function relativeDisplayPath(cwd: string, absolutePath: string): string {
+  const relativePath = path.relative(cwd, absolutePath);
+  return relativePath && !relativePath.startsWith("..")
+    ? relativePath
+    : absolutePath;
+}
+
+function formatMarkdownDiagnostic(diagnostic: RfmDiagnostic): string {
+  return `  ${diagnostic.line}:${diagnostic.column}  ${diagnostic.message}`;
+}
+
 function getConfidentStopCandidate(
   payload: StatusPayload | null,
 ): number | null {
@@ -1810,13 +1912,17 @@ export async function runCli(
         return 0;
       }
 
-      if (options.positionals.length > 0) {
-        deps.error("Usage: roughdraft doctor [--json]");
+      if (options.positionals.length > 1) {
+        deps.error("Usage: roughdraft doctor [path] [--json]");
         return USAGE_ERROR;
       }
 
       deps = applyCliEnvOverrides(deps, options);
       const json = parsed.global.json || options.json;
+      if (options.positionals.length === 1) {
+        return runMarkdownDoctor(deps, options.positionals[0] ?? "", json);
+      }
+
       shouldPrintUpdateNotice = !json;
       return runDoctor(deps, json);
     }

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,6 +1,15 @@
 import { defineConfig } from "vitest/config";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@roughdraft/rfm": path.resolve(dirname, "../rfm/src/index.ts"),
+    },
+  },
   test: {
     coverage: {
       provider: "v8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@roughdraft/rfm':
+        specifier: file:packages/rfm
+        version: link:packages/rfm
       express:
         specifier: ^5.1.0
         version: 5.2.1
@@ -164,8 +167,20 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/rfm:
+    devDependencies:
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/server:
     dependencies:
+      '@roughdraft/rfm':
+        specifier: workspace:*
+        version: link:../rfm
       express:
         specifier: ^5.1.0
         version: 5.2.1


### PR DESCRIPTION
Adds a new `roughdraft doctor <path>` mode that validates one Markdown file against Roughdraft Flavored Markdown while preserving the existing no-path setup diagnostics. Introduces a lightweight `@roughdraft/rfm` validator package with coverage for metadata, duplicate ids, reply targets, code-context skipping, legacy metadata warnings, CRLF locations, and unclosed markers. Updates CLI tests, README examples, package wiring, and build/test scripts so the validator is checked and packaged.