### PR TITLE
Add homepage format preview

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ArrowLeft,
-  ArrowRight,
   Braces,
   Check,
   Copy,
@@ -35,6 +34,7 @@ import {
 import { detectBackend } from "./detect-backend";
 import { DocumentWorkspace } from "./DocumentWorkspace";
 import { PreviewBackend } from "./preview-backend";
+import { RoughdraftFormatDemo } from "./RoughdraftFormatDemo";
 import {
   MarkdownFileConflictError,
   type Page,
@@ -59,32 +59,6 @@ const PREVIEW_INITIAL_MARKDOWN = [
   '{==Select this sentence==}{>>Try replying to this comment or suggesting a replacement.<<}{id="preview-comment" by="Roughdraft" at="2026-04-28T12:00:00.000Z"}',
   "",
 ].join("\n");
-const ROUGHDRAFT_MARKDOWN_FEATURES = [
-  {
-    title: "Comment in the margins",
-    description:
-      "Leave review notes inline, then let your agent read and respond to the same `.md` file.",
-    example:
-      '{==this claim==}{>>Can we source this?<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z"}',
-    icon: MessageSquare,
-  },
-  {
-    title: "Suggest changes",
-    description:
-      "Mark insertions, deletions, and substitutions without turning Markdown into a proprietary document.",
-    example:
-      '{++clear next step++}{id="s1" by="AI" at="2026-04-28T12:05:00.000Z"}{>>Use the launch example.<<}{id="c2" by="user" at="2026-04-28T12:06:00.000Z" re="s1"}',
-    icon: PencilLine,
-  },
-  {
-    title: "Keep Markdown portable",
-    description:
-      "Roughdraft flavored Markdown blends CriticMarkup with Notion-style review affordances for people and agents.",
-    example:
-      'regular.md + {>>Review note<<}{id="c3" by="AI" at="2026-04-28T12:07:00.000Z"}',
-    icon: FileText,
-  },
-] as const;
 const HOMEPAGE_WORKFLOWS = [
   {
     title: "Review an agent's draft",
@@ -220,7 +194,7 @@ export function Homepage({
           <UpdateNotice updateStatus={updateStatus} />
         </div>
       ) : null}
-      <div className="w-full max-w-6xl text-center">
+      <div className="w-full text-center">
         <div className="mx-auto max-w-2xl">
           <p className="mb-3 text-xs font-medium tracking-[0.16em] text-slate-500 dark:text-slate-400 uppercase">
             Roughdraft
@@ -250,7 +224,7 @@ export function Homepage({
             <Dialog>
               <DialogTrigger
                 render={
-                  <Button className="h-10 gap-2 px-4 text-sm" size="lg">
+                  <Button className="h-12 gap-2 px-6 text-base" size="lg">
                     Install Now
                   </Button>
                 }
@@ -296,6 +270,7 @@ export function Homepage({
             <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1.5 text-xs font-medium text-stone-500">
               <Button
                 className="h-6 gap-1.5 px-1 text-xs text-stone-500 hover:bg-transparent hover:text-stone-700"
+                nativeButton={false}
                 size="sm"
                 variant="ghost"
                 render={
@@ -321,65 +296,7 @@ export function Homepage({
           />
         </div>
 
-        <section
-          aria-labelledby="roughdraft-markdown-heading"
-          className="mx-auto mt-20 grid w-full max-w-5xl gap-8 text-left sm:mt-24 lg:grid-cols-[0.95fr_1.05fr] lg:items-start"
-        >
-          <div>
-            <p className="text-xs font-medium tracking-[0.16em] text-stone-500 dark:text-stone-400 uppercase">
-              Roughdraft flavored Markdown
-            </p>
-            <h2
-              className="mt-3 text-3xl leading-tight font-semibold text-balance text-slate-950 dark:text-slate-50 sm:text-4xl"
-              id="roughdraft-markdown-heading"
-            >
-              We extended Markdown to add support for comment threads and
-              suggested changes.
-            </h2>
-            <p className="mt-4 text-base leading-7 text-slate-600 dark:text-slate-400">
-              The big idea is simple: keep the file as Markdown, but make it
-              reviewable. Roughdraft uses a small layer of portable markup so
-              you can comment, suggest edits, and send the exact same document
-              back to your coding agent.
-            </p>
-            <Button
-              className="mt-6 h-9 gap-2 px-3 text-sm"
-              variant="outline"
-              render={
-                <a href={ROUGHDRAFT_FLAVORED_MARKDOWN_PATH}>
-                  Read the spec
-                  <ArrowRight className="size-4" aria-hidden="true" />
-                </a>
-              }
-            />
-          </div>
-
-          <div className="grid gap-3">
-            {ROUGHDRAFT_MARKDOWN_FEATURES.map(
-              ({ description, example, icon: Icon, title }) => (
-                <div
-                  className="grid gap-4 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4 shadow-[0_10px_30px_rgba(15,23,42,0.06)] dark:shadow-[0_10px_30px_rgba(0,0,0,0.3)] sm:grid-cols-[2.5rem_1fr]"
-                  key={title}
-                >
-                  <div className="flex size-10 items-center justify-center rounded-md border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 text-slate-700 dark:text-slate-300">
-                    <Icon className="size-4" aria-hidden="true" />
-                  </div>
-                  <div>
-                    <h3 className="text-sm font-semibold text-slate-950 dark:text-slate-50">
-                      {title}
-                    </h3>
-                    <p className="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-400">
-                      {description}
-                    </p>
-                    <code className="mt-3 block overflow-x-auto rounded-md border border-slate-200 dark:border-slate-700 bg-[#FAFAF8] dark:bg-slate-800 px-3 py-2 text-xs text-slate-700 dark:text-slate-300">
-                      {example}
-                    </code>
-                  </div>
-                </div>
-              ),
-            )}
-          </div>
-        </section>
+        <RoughdraftFormatDemo />
 
         <section
           aria-labelledby="homepage-workflow-heading"
@@ -434,6 +351,7 @@ export function RoughdraftFlavoredMarkdownPage() {
       <div className="mx-auto max-w-5xl">
         <Button
           className="h-9 gap-2 px-3 text-sm"
+          nativeButton={false}
           variant="ghost"
           render={
             <a href="/">

--- a/packages/app/src/MarkdownCodeEditor.tsx
+++ b/packages/app/src/MarkdownCodeEditor.tsx
@@ -4,12 +4,14 @@ import { yamlFrontmatter } from "@codemirror/lang-yaml";
 import { EditorState, type Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { useEffect, useRef } from "react";
+import { cn } from "./lib/utils";
 
 interface MarkdownCodeEditorProps {
   value: string;
   onChange: (value: string) => void;
   autoFocus?: boolean;
   readOnly?: boolean;
+  className?: string;
 }
 
 export function createMarkdownCodeEditorExtensions(
@@ -86,6 +88,7 @@ export function MarkdownCodeEditor({
   onChange,
   autoFocus = false,
   readOnly = false,
+  className,
 }: MarkdownCodeEditorProps) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const editorViewRef = useRef<EditorView | null>(null);
@@ -146,5 +149,7 @@ export function MarkdownCodeEditor({
     });
   }, [value]);
 
-  return <div ref={hostRef} className="markdown-code-editor" />;
+  return (
+    <div ref={hostRef} className={cn("markdown-code-editor", className)} />
+  );
 }

--- a/packages/app/src/RoughdraftFormatDemo.tsx
+++ b/packages/app/src/RoughdraftFormatDemo.tsx
@@ -1,0 +1,190 @@
+import { ArrowRight } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { Button } from "./components/ui/button";
+import { MarkdownCodeEditor } from "./MarkdownCodeEditor";
+import { PageCard } from "./PageCard";
+import type { Page, StorageBackend } from "./storage";
+
+interface FormatExample {
+  id: string;
+  label: string;
+  markdown: string;
+}
+
+const FORMAT_EXAMPLES: FormatExample[] = [
+  {
+    id: "spec-review",
+    label: "Review a spec",
+    markdown:
+      '# Checkout Spec Review\nGoal: reduce trial checkout abandonment by 8%. Scope: ship {==guest checkout for returning teams==}{>>PM: confirm whether this excludes SSO-only workspaces.<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z"} in the first beta.\n\nMetric: replace {~~activation~>first successful team purchase~~}{id="s1" by="user" at="2026-04-28T12:03:00.000Z"} before engineering sizing.\n',
+  },
+  {
+    id: "plan-review",
+    label: "Review a plan",
+    markdown:
+      '# Agent Plan Review\nPlan: scaffold the settings page, wire save/load through `settings.ts`, then {==run the full suite after styling==}{>>Can we add the failing state test before implementation so the agent has a guardrail?<<}{id="c1" by="user" at="2026-04-28T12:10:00.000Z"}.\n\nAdd {++a rollback note for the migration step++}{id="s1" by="user" at="2026-04-28T12:12:00.000Z"}{>>I want to keep this easy to undo if the vibe pass gets messy.<<}{id="c2" by="user" at="2026-04-28T12:13:00.000Z" re="s1"} before implementation starts.\n',
+  },
+  {
+    id: "writing-edit",
+    label: "Edit writing",
+    markdown:
+      '## Draft Intro\nRoughdraft lets me stay in flow while an agent marks up {==my argument==}{>>AI: this is the claim readers need to understand first.<<}{id="c1" by="AI" at="2026-04-28T12:20:00.000Z"}.\n\nIt turns feedback from {~~a confusing pile of notes~>specific comments and suggested edits inside the Markdown file~~}{id="s1" by="AI" at="2026-04-28T12:21:00.000Z"}{>>User: keep the plain-English phrasing, but avoid making it sound like a docs product.<<}{id="c2" by="user" at="2026-04-28T12:22:00.000Z" re="s1"}.\n',
+  },
+];
+
+const demoBackend: StorageBackend = {
+  info: {
+    kind: "local-storage",
+    label: "Homepage demo",
+    detail: "In-memory Roughdraft format preview",
+  },
+  canManageProjects: false,
+  async getMarkdownFile() {
+    return {
+      id: "homepage-format-preview",
+      title: "homepage-format-preview.md",
+      content: FORMAT_EXAMPLES[0].markdown,
+    };
+  },
+  async saveMarkdownFile(_relativePath, content) {
+    return {
+      id: "homepage-format-preview",
+      title: "homepage-format-preview.md",
+      content,
+    };
+  },
+  async saveAsset(file) {
+    return {
+      markdownPath: file.name,
+      previewUrl: "",
+      mimeType: file.type || "application/octet-stream",
+    };
+  },
+  resolveFileUrl() {
+    return null;
+  },
+  async openProject() {},
+};
+
+export function RoughdraftFormatDemo() {
+  const [selectedExampleId, setSelectedExampleId] = useState<string | null>(
+    FORMAT_EXAMPLES[0].id,
+  );
+  const [source, setSource] = useState(FORMAT_EXAMPLES[0].markdown);
+  const page: Page = useMemo(
+    () => ({
+      id: "homepage-format-preview",
+      title: "homepage-format-preview.md",
+      content: source,
+    }),
+    [source],
+  );
+
+  const handleSelectExample = useCallback((example: FormatExample) => {
+    setSelectedExampleId(example.id);
+    setSource(example.markdown);
+  }, []);
+
+  const handleSourceChange = useCallback((nextSource: string) => {
+    setSelectedExampleId(null);
+    setSource(nextSource);
+  }, []);
+
+  const handleResultChange = useCallback((nextSource: string) => {
+    setSelectedExampleId(null);
+    setSource(nextSource);
+  }, []);
+
+  return (
+    <section
+      aria-labelledby="roughdraft-markdown-heading"
+      className="rfm-format-demo mx-auto mt-20 w-full max-w-none border-t border-slate-200 pt-10 text-left dark:border-slate-700 sm:mt-24"
+    >
+      <div className="mx-auto w-full">
+        <div className="max-w-3xl">
+          <p className="text-xs font-medium tracking-[0.16em] text-stone-500 uppercase dark:text-stone-400">
+            Roughdraft flavored Markdown
+          </p>
+          <h2
+            className="mt-3 text-3xl leading-tight font-semibold text-balance text-slate-950 dark:text-slate-50 sm:text-4xl"
+            id="roughdraft-markdown-heading"
+          >
+            It's just Markdown
+          </h2>
+          <p className="mt-4 text-base leading-7 text-slate-600 dark:text-slate-400">
+            We extended the markdown format, building on prior art like{" "}
+            <a
+              className="font-medium text-slate-950 underline decoration-slate-300 underline-offset-4 hover:decoration-slate-950 dark:text-slate-50 dark:decoration-slate-600 dark:hover:decoration-slate-50"
+              href="https://criticmarkup.com/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              CriticMarkup
+            </a>
+            , to support full comment threads, and suggesting changes. Read the{" "}
+            <a
+              className="font-medium text-slate-950 underline decoration-slate-300 underline-offset-4 hover:decoration-slate-950 dark:text-slate-50 dark:decoration-slate-600 dark:hover:decoration-slate-50"
+              href="/roughdraft-flavored-markdown"
+            >
+              spec
+            </a>
+            . We are working with other major Markdown apps to rally support for
+            this initiative.
+          </p>
+        </div>
+      </div>
+
+      <div
+        className="mx-auto mt-5 flex w-full flex-wrap gap-2"
+        role="group"
+        aria-label="Format examples"
+      >
+        {FORMAT_EXAMPLES.map((example) => (
+          <Button
+            className="h-8 px-3 text-xs"
+            key={example.id}
+            type="button"
+            variant={selectedExampleId === example.id ? "default" : "outline"}
+            onClick={() => handleSelectExample(example)}
+          >
+            {example.label}
+          </Button>
+        ))}
+      </div>
+
+      <div className="mx-auto mt-5 grid w-full gap-3 lg:grid-cols-[minmax(20rem,0.72fr)_2.5rem_minmax(0,1.28fr)] lg:items-stretch">
+        <div className="rfm-demo-pane">
+          <div className="rfm-demo-pane-header">
+            <span>Source</span>
+          </div>
+          <MarkdownCodeEditor
+            className="rfm-source-editor"
+            value={source}
+            onChange={handleSourceChange}
+          />
+        </div>
+
+        <div className="hidden items-start justify-center pt-3 text-slate-400 dark:text-slate-500 lg:flex">
+          <ArrowRight className="size-5" aria-hidden="true" />
+        </div>
+
+        <div className="rfm-demo-pane">
+          <div className="rfm-demo-pane-header">
+            <span>Result</span>
+          </div>
+          <div className="rfm-result-editor">
+            <PageCard
+              page={page}
+              selected
+              backend={demoBackend}
+              interactionMode="editing"
+              onSave={async () => {}}
+              onLocalContentChange={handleResultChange}
+              saveBlocked
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/app/src/critic-markup/index.ts
+++ b/packages/app/src/critic-markup/index.ts
@@ -997,6 +997,22 @@ export function criticMarkdownHasReviewRail(
   return comments.size > 0 || changes.size > 0;
 }
 
+export function criticMarkdownToRenderedHtml(
+  markdown: string,
+  options?: MarkdownOptions,
+): {
+  html: string;
+  comments: Map<string, CriticComment>;
+  changes: Map<string, CriticChangeAttrs>;
+  frontmatter: string | null;
+} {
+  const { frontmatter, body } = splitYamlFrontmatter(markdown);
+  const { parser, comments, changes } = createCriticMarked(options);
+  const html = parser.parse(protectRichTextRoundTripMarkdown(body)) as string;
+
+  return { html, comments, changes, frontmatter };
+}
+
 export function criticMarkdownToEditorState(
   markdown: string,
   options?: MarkdownOptions,

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -561,6 +561,109 @@
       margin-right: auto;
     }
   }
+
+  .rfm-demo-pane {
+    @apply min-w-0 overflow-hidden rounded-lg border border-slate-200 bg-white shadow-[0_10px_30px_rgba(15,23,42,0.06)] dark:border-slate-700 dark:bg-slate-900 dark:shadow-[0_10px_30px_rgba(0,0,0,0.3)];
+  }
+
+  .rfm-demo-pane-header {
+    @apply flex h-10 items-center border-b border-slate-200 px-4 text-xs font-semibold tracking-[0.14em] text-slate-500 uppercase dark:border-slate-700 dark:text-slate-400;
+  }
+
+  .rfm-source-editor {
+    color: rgb(15 23 42);
+  }
+
+  .rfm-source-editor .cm-editor {
+    min-height: 19rem;
+  }
+
+  .rfm-source-editor .cm-scroller {
+    max-height: 30rem;
+  }
+
+  .rfm-source-editor .cm-content {
+    min-height: 19rem;
+    padding: 1rem;
+  }
+
+  .rfm-source-editor .cm-line {
+    padding: 0;
+  }
+
+  .dark .rfm-source-editor {
+    color: rgb(226 232 240);
+  }
+
+  .rfm-result-editor .document-page-shell {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.75rem;
+    padding: 1rem;
+  }
+
+  .rfm-result-editor .document-page-main {
+    max-width: none;
+    width: 100%;
+  }
+
+  .rfm-result-editor .document-page-main > .pb-24 {
+    padding-bottom: 0;
+  }
+
+  .rfm-result-editor .document-page-main > .pb-24 > div {
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    padding: 1.25rem;
+  }
+
+  .rfm-result-editor .document-comment-fallback {
+    display: none;
+  }
+
+  .rfm-result-editor .document-comment-rail {
+    display: block;
+    padding: 0 1rem 1rem;
+  }
+
+  .rfm-result-editor .document-comment-rail [data-comment-thread-container],
+  .rfm-result-editor .document-comment-rail [data-suggestion-thread-container] {
+    position: relative;
+    top: auto;
+    transform: none;
+  }
+
+  .rfm-result-editor .tiptap {
+    min-height: 17rem;
+    --editor-font-size: 14px;
+  }
+
+  .rfm-result-editor .tiptap h1 {
+    font-size: 1.65em;
+  }
+
+  .rfm-result-editor .tiptap h2 {
+    margin-top: 1.2em;
+    font-size: 1.3em;
+  }
+
+  .rfm-result-editor .tiptap h3 {
+    margin-top: 1em;
+    font-size: 1.12em;
+  }
+
+  @media (min-width: 900px) {
+    .rfm-result-editor .document-page-shell {
+      grid-template-columns: minmax(0, min(100%, 42rem)) minmax(13rem, 16rem);
+      align-items: start;
+      justify-content: start;
+    }
+
+    .rfm-result-editor .document-comment-rail {
+      padding: 0;
+    }
+  }
 }
 
 @theme inline {

--- a/packages/app/test/critic-markup.test.ts
+++ b/packages/app/test/critic-markup.test.ts
@@ -8,6 +8,7 @@ import {
   createNextCommentId,
   criticMarkdownHasReviewRail,
   criticMarkdownToEditorState,
+  criticMarkdownToRenderedHtml,
   editorStateToCriticMarkdown,
   getCommentDescendantIds,
 } from "../src/critic-markup";
@@ -452,6 +453,38 @@ const command = "{==roughdraft open==}{>>test<<}{id="c1" by="user" at="2026-04-2
     const { doc, comments } = criticMarkdownToEditorState(input);
 
     expect(editorStateToCriticMarkdown(doc, comments)).toBe(input);
+  });
+
+  it("round-trips a substitution suggestion with an attached comment", () => {
+    const input =
+      'Use {~~old text~>new text~~}{id="s3" by="AI" at="2024-01-15T10:32:00.000Z"}{>>Confirm this with legal.<<}{id="c1" by="user" at="2024-01-15T10:33:00.000Z" re="s3"} here.\n';
+
+    const { doc, comments } = criticMarkdownToEditorState(input);
+
+    expect(comments.get("c1")).toMatchObject({
+      id: "c1",
+      content: "Confirm this with legal.",
+      parentCommentId: "s3",
+    });
+    expect(editorStateToCriticMarkdown(doc, comments)).toBe(input);
+  });
+
+  it("renders review markup to HTML with comments and changes", () => {
+    const input =
+      'Keep {==the launch date==}{>>Verify this.<<}{id="c1" by="user" at="2024-01-15T10:33:00.000Z"} and add {++the customer quote++}{id="s1" by="AI" at="2024-01-15T10:34:00.000Z"}.\n';
+
+    const { html, comments, changes, frontmatter } =
+      criticMarkdownToRenderedHtml(input);
+
+    expect(frontmatter).toBeNull();
+    expect(comments.get("c1")?.content).toBe("Verify this.");
+    expect(changes.get("s1")).toMatchObject({
+      changeId: "s1",
+      kind: "addition",
+      authorType: "ai",
+    });
+    expect(html).toContain('data-comment-ids="[&quot;c1&quot;]"');
+    expect(html).toContain('data-critic-change-kind="addition"');
   });
 
   it("imports suggestions without metadata and serializes generated metadata", () => {

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -10,6 +12,36 @@ import {
 
 const AGENT_SETUP_PROMPT =
   "Install Roughdraft for me using `npm i -g roughdraft`, then read https://roughdraft.page/setup.md and set yourself up to use it.";
+const APP_STYLES = readFileSync(
+  resolve(process.cwd(), "src/style.css"),
+  "utf8",
+);
+
+function createDomRect({
+  left = 0,
+  top = 0,
+  width = 120,
+  height = 24,
+}: {
+  left?: number;
+  top?: number;
+  width?: number;
+  height?: number;
+} = {}) {
+  return {
+    x: left,
+    y: top,
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    toJSON() {
+      return this;
+    },
+  } as DOMRect;
+}
 
 async function click(element: Element) {
   await act(async () => {
@@ -47,6 +79,33 @@ describe("Homepage", () => {
       configurable: true,
       value: { writeText },
     });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue(
+      createDomRect({ width: 640, height: 480 }),
+    );
+    Object.defineProperty(Range.prototype, "getBoundingClientRect", {
+      configurable: true,
+      value() {
+        return createDomRect({ width: 80, height: 20 });
+      },
+    });
+    Object.defineProperty(Range.prototype, "getClientRects", {
+      configurable: true,
+      value() {
+        return [createDomRect({ width: 80, height: 20 })];
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, "getClientRects", {
+      configurable: true,
+      value() {
+        return [this.getBoundingClientRect()];
+      },
+    });
+    Object.defineProperty(Text.prototype, "getClientRects", {
+      configurable: true,
+      value() {
+        return [createDomRect({ width: 80, height: 20 })];
+      },
+    });
   });
 
   afterEach(async () => {
@@ -66,6 +125,7 @@ describe("Homepage", () => {
           updateStatus={null}
         />,
       );
+      await Promise.resolve();
     });
 
     expect(container.textContent).toContain(
@@ -78,16 +138,44 @@ describe("Homepage", () => {
     expect(container.textContent).toContain("Open-source");
     expect(container.textContent).toContain("Runs locally");
     expect(container.textContent).toContain("Roughdraft flavored Markdown");
+    expect(container.textContent).toContain("It's just Markdown");
     expect(container.textContent).toContain(
-      "We extended Markdown to add support for comment threads and suggested changes.",
+      "We extended the markdown format, building on prior art like CriticMarkup",
     );
+    expect(
+      container.querySelector('a[href="https://criticmarkup.com/"]')
+        ?.textContent,
+    ).toContain("CriticMarkup");
     expect(container.textContent).toContain(
-      "blends CriticMarkup with Notion-style review affordances",
+      "working with other major Markdown apps to rally support",
     );
+    expect(container.textContent).toContain("# Checkout Spec Review");
     expect(container.textContent).toContain(
-      '{==this claim==}{>>Can we source this?<<}{id="c1"',
+      "PM: confirm whether this excludes SSO-only workspaces.",
     );
-    expect(container.textContent).toContain('re="s1"');
+    expect(container.textContent).toContain("first successful team purchase");
+    expect(container.textContent).toContain("Review a spec");
+    expect(container.textContent).toContain("Review a plan");
+    expect(container.textContent).toContain("Edit writing");
+    expect(container.querySelector(".rfm-format-demo")?.className).toContain(
+      "max-w-none",
+    );
+    const formatDemoGrid = container.querySelector(
+      ".rfm-format-demo > div:nth-of-type(3)",
+    );
+    const formatDemoArrow = formatDemoGrid?.children.item(1);
+    expect(formatDemoArrow?.className).toContain("items-start");
+    expect(APP_STYLES).toMatch(
+      /\.rfm-result-editor \.document-page-shell \{[^}]*grid-template-columns:\s*minmax\(0,\s*min\(100%,\s*42rem\)\)\s+minmax\(13rem,\s*16rem\);[^}]*justify-content:\s*start;/s,
+    );
+    expect(APP_STYLES).not.toContain("rfm-token-");
+    expect(container.querySelector('[class*="rfm-token-"]')).toBeNull();
+    expect(
+      container.querySelector(".comment-anchor[data-comment-ids]"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector(".critic-change[data-critic-change-id]"),
+    ).not.toBeNull();
     expect(container.textContent).toContain("Review workflow");
     expect(container.textContent).toContain(
       "Pass the same Markdown file back and forth with your agent.",
@@ -125,7 +213,22 @@ describe("Homepage", () => {
     expect(
       container.querySelector('a[href="/roughdraft-flavored-markdown"]')
         ?.textContent,
-    ).toContain("Read the spec");
+    ).toContain("spec");
+
+    const planReviewButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.includes("Review a plan"),
+    );
+
+    expect(planReviewButton).toBeDefined();
+    if (!planReviewButton) throw new Error("Plan review example not found");
+
+    await click(planReviewButton);
+
+    expect(container.textContent).toContain("Agent Plan Review");
+    expect(container.textContent).toContain(
+      "rollback note for the migration step",
+    );
+    expect(container.textContent).toContain('re="s1"');
 
     expect(cta).toBeDefined();
     if (!cta) throw new Error("CTA not found");


### PR DESCRIPTION
Adds an interactive Roughdraft flavored Markdown demo to the homepage with source editing, rendered review output, and selectable examples for spec, plan, and writing review flows. Extracts the demo into `RoughdraftFormatDemo`, adds styling for the source/result panes, exposes a rendered-html helper for critic markup, and expands coverage for homepage rendering plus CriticMarkup round trips.

Checks: `pnpm check`.