### PR TITLE
feat: Remote document mode

### DIFF
--- a/.compound-engineering/config.local.example.yaml
+++ b/.compound-engineering/config.local.example.yaml
@@ -1,0 +1,12 @@
+# Compound Engineering -- local config
+# Copy to .compound-engineering/config.local.yaml in your project root.
+# All settings are optional. Invalid values fall through to defaults.
+
+# --- Work delegation (Codex) ---
+
+# work_delegate: codex           # codex | false (default: false)
+# work_delegate_consent: true    # true | false (default: false)
+# work_delegate_sandbox: yolo    # yolo | full-auto (default: yolo)
+# work_delegate_decision: auto   # auto | ask (default: auto)
+# work_delegate_model: gpt-5.4  # any valid codex model (default: gpt-5.4)
+# work_delegate_effort: high     # minimal | low | medium | high | xhigh (default: high)

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ sandbox
 .mcp.json
 .roughdraft-state
 /roughdraft.json
+.compound-engineering/*.local.yaml

--- a/docs/adr/0001-single-local-markdown-file.md
+++ b/docs/adr/0001-single-local-markdown-file.md
@@ -15,3 +15,11 @@ The CLI and app should optimize for quick open, review, edit, save, and close fl
 ## What This Explicitly Does Not Mean
 
 This does not make Roughdraft a vault manager, note database, git client, desktop shell, or multi-document workspace.
+
+## Clarification (2026-04-30): Remote Document Mode
+
+The "single markdown file" unit of work is preserved when the file lives on a different machine than the Roughdraft server. Remote document mode (see `docs/plans/2026-04-30-001-feat-remote-document-mode-plan.md`) lets a CLI on a remote host register one markdown file with a hosted Roughdraft over HTTP/SSE; the server holds the bytes in memory for the duration of the session and never browses or indexes a remote filesystem. The user-facing invariant is the same: open one file, edit it, save it, close it.
+
+The "local-file boundary" wording above should be read as the **resolved file boundary** — Roughdraft still resolves and operates on a single markdown file. Whether the bytes originate from local disk or from a CLI-owned session does not change the unit of work.
+
+This clarification does not extend Roughdraft into a vault manager, note database, or multi-document workspace.

--- a/docs/adr/0004-cli-server-state-model.md
+++ b/docs/adr/0004-cli-server-state-model.md
@@ -21,3 +21,16 @@ The state file is not a project database, collaboration backend, sync system, or
 Remote document mode (see `docs/plans/2026-04-30-001-feat-remote-document-mode-plan.md`) introduces in-memory session state on the server: a map of registered remote-document sessions, each holding a CLI-supplied markdown file's bytes for the lifetime of the SSE connection.
 
 This state is **deliberately not persisted in the state file**. Sessions live only in the running server process and are evicted on disconnect or server restart. The state file's role — managed background process, port, URL, start time — is unchanged. Treating remote-document sessions as transient in-memory state preserves the boundary above: the state file does not become a document model just because the server now hosts other machines' edits.
+
+### Trust model and `ROUGHDRAFT_TOKEN`
+
+The hosted Roughdraft is a write-capable peer for every connected CLI: a PUT to a session causes the CLI on the source machine to atomically rewrite the registered file on disk. Loopback-only deployments can rely on the OS for trust, but the moment the server binds to a non-loopback host (e.g. `ROUGHDRAFT_BIND_HOST=0.0.0.0` for Tailscale access), anyone reachable on that interface can register, read, or PUT.
+
+The mitigation is a shared bearer token, `ROUGHDRAFT_TOKEN`:
+
+- The server reads `ROUGHDRAFT_TOKEN` at startup. When set, all `/api/remote-document/*` endpoints require it (Authorization: Bearer header, or `?token=` query for the SSE endpoint specifically since `EventSource` can't set headers).
+- `createServer()` refuses to bind to any non-loopback host without a token, returning a clear actionable error before listening.
+- The CLI sends the same token via `Authorization: Bearer` on its register POST and SSE GET, and surfaces a 401 explicitly (suggesting the user set `ROUGHDRAFT_TOKEN`).
+- The viewerUrl printed by the CLI includes `?token=...` so the browser tab can authenticate. The frontend forwards the token as a header on fetches and as `?token=` on the EventSource.
+
+Loopback-only deployments stay back-compatible: no token required, no behavior change. The token is the contract that lets non-loopback deployments be safe; the secure-by-default startup guard is the contract that lets us ship the feature without expecting users to read documentation before exposing the endpoints.

--- a/docs/adr/0004-cli-server-state-model.md
+++ b/docs/adr/0004-cli-server-state-model.md
@@ -15,3 +15,9 @@ State handling must remain deterministic and testable. Stale-write protection an
 ## What This Explicitly Does Not Mean
 
 The state file is not a project database, collaboration backend, sync system, or persistent document model.
+
+## Clarification (2026-04-30): Remote Document Sessions
+
+Remote document mode (see `docs/plans/2026-04-30-001-feat-remote-document-mode-plan.md`) introduces in-memory session state on the server: a map of registered remote-document sessions, each holding a CLI-supplied markdown file's bytes for the lifetime of the SSE connection.
+
+This state is **deliberately not persisted in the state file**. Sessions live only in the running server process and are evicted on disconnect or server restart. The state file's role — managed background process, port, URL, start time — is unchanged. Treating remote-document sessions as transient in-memory state preserves the boundary above: the state file does not become a document model just because the server now hosts other machines' edits.

--- a/docs/brainstorms/remote-document-mode-requirements.md
+++ b/docs/brainstorms/remote-document-mode-requirements.md
@@ -100,6 +100,15 @@ This feature pushes against two recorded decisions; neither is fatal but both de
 - The hosted Roughdraft is reachable from each SSH box on a stable URL.
 - The CLI process on the SSH box is long-lived enough to hold the SSE/WS open (i.e. the agent doesn't exit immediately after `roughdraft open`).
 
+## Security Model (added 2026-04-30 after code review)
+
+The hosted server is a write-capable peer for every connected CLI: an authenticated PUT triggers a disk rewrite on the source machine. Two layers gate that:
+
+1. **Token-based auth.** A shared secret `ROUGHDRAFT_TOKEN` is required on every `/api/remote-document/*` request when set on the server. The CLI sends it via `Authorization: Bearer`; the browser viewer URL embeds it as `?token=...` so the frontend forwards it on fetches and EventSource. The server rejects unauthenticated requests with 401 and a remediation hint.
+2. **Secure-by-default startup.** `createServer()` refuses to bind to a non-loopback host (e.g. `0.0.0.0` for Tailscale exposure) unless `ROUGHDRAFT_TOKEN` is set. Loopback-only deployments stay back-compatible — no token, no behavior change.
+
+The trust model is "Tailscale ACLs + a shared token." We are not solving multi-user collaboration, end-to-end encryption beyond TLS, or token rotation. Compromise of the host still implies file overwrites on connected CLIs; the token is defense in depth, not a complete answer.
+
 ## Open Questions
 
 - **Save-back mechanism**: SSE (server-sent events, simpler) vs WebSocket (bidirectional, easier for ack). Either works; planning decision.

--- a/docs/brainstorms/remote-document-mode-requirements.md
+++ b/docs/brainstorms/remote-document-mode-requirements.md
@@ -1,0 +1,121 @@
+---
+date: 2026-04-30
+status: brainstorm
+scope: deep-feature
+---
+
+# Remote Document Mode — Requirements
+
+## Problem
+
+Kieran's daily setup: he uses a laptop as the human-facing surface and SSHes into other machines (Mac mini, Hetzner Linux runner, etc.) where coding agents do work. Markdown files (plans, drafts, ADR drafts) live on the SSH-target machine because that's where the agent is reading and writing them.
+
+Roughdraft today assumes the file lives on the same machine the server runs on. So today the only ways to review those remote-authored files in Roughdraft are:
+
+1. Run Roughdraft *on* the SSH box, set up an SSH tunnel from the laptop, browse to it. — One Roughdraft per SSH session, port clutter, no roaming.
+2. Copy files back and forth manually. — Defeats the point of the agent owning the file.
+3. Editor-shells like VS Code Remote-SSH. — Not Roughdraft.
+
+The user wants: open Roughdraft once on a stable host he can browse to, and have the SSH-side agent say "open this remote file" — saves round-trip back to the SSH box's disk transparently.
+
+## Goals
+
+- An agent on any SSH/Tailscale-reachable machine can run a CLI command that surfaces a markdown file in a single, persistent Roughdraft instance.
+- Edits made in the browser save back to the file's home machine.
+- The user views the editor from any device with a browser (laptop, phone) without per-box Roughdraft instances.
+- Works over Tailscale (assume both sides are reachable to each other on the tailnet); no inbound ports on the SSH box required.
+- Default-on persistence: the hosted Roughdraft survives laptop sleep.
+
+## Non-Goals
+
+- Not a multi-user collaboration product (single-user-across-machines is the target).
+- Not a vault, note database, or document index. The unit of work is still one markdown file, per ADR-0001.
+- Not a replacement for local Roughdraft on the laptop; both modes coexist.
+- Not a generic remote filesystem mount. Documents are surfaced one at a time.
+- Not a public-internet hosted SaaS. Tailnet/LAN scope only.
+
+## Recommended Approach: Remote-Document API
+
+A single Roughdraft instance runs persistently (default: Mac mini, since `Mijn Tuin` already provides launchd + overmind for it). The CLI gains a remote mode:
+
+1. CLI on the SSH box reads `ROUGHDRAFT_HOST` env or repo config.
+2. `roughdraft open foo.md` reads the file content from local disk, POSTs it to a new endpoint on the hosted Roughdraft (e.g. registers a "remote document session" with content + a unique session id).
+3. The CLI process keeps a long-lived SSE/WebSocket connection open to receive save-back events.
+4. The hosted Roughdraft displays the document under a new `backend: "remote"` mode that lives alongside `local-files`. The editor itself is unchanged.
+5. When the user saves in the browser, the hosted server pushes the updated bytes through the SSE/WS connection back to the CLI, which writes them to disk on the SSH box.
+6. CLI exit (Ctrl-C, agent finished) closes the session; the document stays viewable but read-only or marked disconnected.
+
+Key properties:
+
+- Only **outbound** connectivity required from the SSH box. No inbound port on the SSH side.
+- The CLI process *is* the source of truth for that file's bytes; the hosted Roughdraft owns no persistent storage.
+- One `ROUGHDRAFT_HOST` env var is the only configuration the agent needs to add.
+
+## Hosting Recommendation
+
+Default to **Mac mini, accessible via Tailscale**. Browser tab opens from any device.
+
+Why:
+- Already always-on (launchd + overmind in `~/tuin/`).
+- Tailscale-reachable from every machine in the user's network.
+- Decoupling the server (always-on box) from the viewer (whichever browser is convenient) matches the actual workflow.
+
+Keep `ROUGHDRAFT_HOST` overrideable so the user can point at his laptop, a teammate's instance, or any other host without code changes.
+
+## Alternatives Considered
+
+**B. Local Roughdraft as SSH/SFTP client.** Roughdraft on laptop opens SSH to the remote and reads/writes files itself. Rejected: embeds an SSH client in Roughdraft, key/identity mapping, file-watching over SFTP is awkward, and laptop must be on for any agent to surface a doc.
+
+**C. Reverse tunnel, per-box Roughdraft.** Run Roughdraft on each SSH box bound to a Tailscale-reachable host; CLI prints the URL. Rejected: this is the "load a local version" pattern the user is explicitly trying to avoid. Scales poorly across many SSH targets, no roaming, port-state proliferation.
+
+**D. Multi-tenant persistent dashboard (challenger).** Same as A, but the hosted Roughdraft surfaces a list of all currently-registered documents from all CLIs across all machines. Deferred to a later phase — once the single-document remote primitive ships, this becomes mostly a UI affordance over multiple sessions, not a separate architecture.
+
+## Scope Boundaries
+
+### Deferred for later
+
+- Multi-document dashboard view (Approach D).
+- Mobile/phone usability tweaks beyond what the existing UI already provides.
+- Push-style notifications (e.g. "agent X just opened a doc").
+- File watching / auto-reload when the file changes on disk *outside* the open session.
+- Conflict resolution if the same file is opened from two CLIs simultaneously.
+- Authentication beyond Tailscale ACLs.
+
+### Outside this product's identity
+
+- Becoming a vault, document database, or sync engine. This stays "open one markdown file at a time."
+- Public-internet hosting or multi-user collaboration.
+- A real-time collaborative editor.
+
+## ADR Conflicts to Surface
+
+This feature pushes against two recorded decisions; neither is fatal but both deserve an explicit nod (or a follow-up ADR) before implementation:
+
+- **`docs/adr/0001-single-local-markdown-file.md`** — currently states "the server resolves that file within local-file boundaries." Remote-document mode keeps "one markdown file at a time" but breaks the *local-filesystem* boundary. Proposed update: clarify that the unit of work is still one markdown file, but the file may be owned by a CLI process rather than the local disk under the server.
+- **`docs/adr/0004-cli-server-state-model.md`** — explicitly says the state model "is not a collaboration backend, sync system, or persistent document model." Remote-document mode introduces session state (registered remote documents) that lives only in the running server's memory, not in the state file. Worth confirming this is acceptable as transient in-memory state.
+
+## Dependencies / Assumptions
+
+- Tailscale (or equivalent) is present on every machine that participates. Without bidirectional reachability the user must arrange it themselves.
+- The hosted Roughdraft is reachable from each SSH box on a stable URL.
+- The CLI process on the SSH box is long-lived enough to hold the SSE/WS open (i.e. the agent doesn't exit immediately after `roughdraft open`).
+
+## Open Questions
+
+- **Save-back mechanism**: SSE (server-sent events, simpler) vs WebSocket (bidirectional, easier for ack). Either works; planning decision.
+- **Session lifecycle on CLI disconnect**: should the document stay on screen as read-only with a "disconnected" badge, or close the tab automatically?
+- **Concurrent opens**: if two CLIs from two boxes register the same logical doc (`foo.md`), are they the same session or two? Probably two, distinguished by a session id, but UX needs a call.
+- **CriticMarkup comments produced in the browser** — they round-trip to the file on the SSH box like any other edit. Worth confirming nothing else (e.g. comment authorship, timestamps) needs persistence outside the file.
+- **What if `ROUGHDRAFT_HOST` is unset and the CLI is on a non-laptop host?** Fall back to local mode (current behavior), or error out, or print install instructions?
+
+## Success Criteria
+
+- From a fresh SSH session into the Hetzner runner: `ROUGHDRAFT_HOST=<mac-mini-url> roughdraft open plan.md` shows the file in a browser tab on the laptop within ~1 second.
+- Edit in the browser; save; SSH back to Hetzner; `cat plan.md` shows the new content.
+- Close the laptop lid, reopen it, browse to the same URL: document is still there (or gracefully marked disconnected if the CLI session ended).
+- Running `roughdraft open` *without* `ROUGHDRAFT_HOST` set still works exactly as today.
+- No new inbound ports on the SSH box.
+
+## Suggested Next Step
+
+`/ce-plan` to produce an implementation plan covering: the new remote backend type, the `/api/remote-documents` endpoint shape, SSE-vs-WS choice, CLI session lifecycle, and ADR-0001/0004 updates.

--- a/docs/plans/2026-04-30-001-feat-remote-document-mode-plan.md
+++ b/docs/plans/2026-04-30-001-feat-remote-document-mode-plan.md
@@ -1,0 +1,435 @@
+---
+title: "feat: Remote document mode"
+type: feat
+status: active
+date: 2026-04-30
+origin: docs/brainstorms/remote-document-mode-requirements.md
+---
+
+# feat: Remote document mode
+
+## Overview
+
+Add a "remote document" mode that lets a CLI on one machine surface a markdown file in a Roughdraft instance running on another machine. The CLI reads the file's bytes from local disk, registers a remote-document session against a hosted Roughdraft (configured via `ROUGHDRAFT_HOST`), and holds an SSE connection open to receive save events. Saves stream back through the SSE channel; the CLI writes them to disk on the source machine.
+
+The hosted Roughdraft gains a new `backend: "remote"` mode that lives alongside the existing `local-files` backend. Local mode is unchanged.
+
+---
+
+## Problem Frame
+
+Kieran's daily workflow: laptop is the human-facing surface; agents run on SSH-targeted machines (Mac mini, Hetzner runner) where markdown files actually live. Today, surfacing those files in Roughdraft requires either running Roughdraft on the SSH box (per-box clutter, no roaming) or copying files manually. We want one persistent Roughdraft instance the user browses to from any device, with the SSH-side agent able to push files into it.
+
+See origin: `docs/brainstorms/remote-document-mode-requirements.md`.
+
+---
+
+## Requirements Trace
+
+- R1. An agent on any Tailscale-reachable machine can run `roughdraft open foo.md` and see it appear in a hosted Roughdraft instance.
+- R2. Edits made in the browser save back to the file's home machine on disk.
+- R3. The hosted Roughdraft survives laptop sleep — it runs on an always-on box (Mac mini default) reachable via Tailscale.
+- R4. Only outbound connectivity is required from the SSH-side machine. No inbound port on the SSH box.
+- R5. `ROUGHDRAFT_HOST` is overrideable. When unset, the CLI falls back to today's local-mode behavior unchanged.
+- R6. The hosted Roughdraft owns no persistent storage for remote documents. The CLI process is the source of truth for bytes; server holds session state in memory only (preserving ADR-0004's stance).
+- R7. One markdown file at a time per session, preserving ADR-0001's product identity.
+
+---
+
+## Scope Boundaries
+
+- Multi-document dashboard view (challenger Approach D from origin) — out of scope for v1.
+- Public-internet hosting, multi-user collaboration, real-time CRDT editing.
+- File watching / auto-reload when the file changes on disk *outside* the open session.
+- Conflict resolution for two CLIs opening the same logical path simultaneously beyond "each gets its own session id."
+- Authentication beyond what Tailscale ACLs already provide.
+- Phone-specific UI affordances.
+
+### Deferred to Follow-Up Work
+
+- Multi-tenant dashboard listing all active remote sessions: future plan once the single-doc primitive ships.
+- Optional reconnect-on-drop UX for the CLI: v1 keeps it simple — CLI exits cleanly when the SSE drops, user reruns the command.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/server/src/index.ts` — Single-file Express app. `createApp()` builds it; capability flag already exists in `GET /api/status` (`backend: "local-files"`). SSE is in-use at `/api/markdown-file/events` and `/api/open-requests`. Optimistic-concurrency with `expectedVersion` is in `PUT /api/markdown-file`.
+- `packages/server/src/cli.ts` — Open command at line ~1824 follows a DI pattern via `CliDependencies`. `sendOpenRequestToExistingWindow` (line ~784) is the model for "POST a JSON payload to a known endpoint." `resolveTargetPath` (line ~810) handles disk reads.
+- `packages/server/src/network.ts` — Currently hardcodes `ROUGHDRAFT_BIND_HOST = "127.0.0.1"` and a loopback list. Needs to be made env-configurable for the hosted instance.
+- `packages/app/src/storage.ts` — `StorageBackend` interface with `BackendInfo.kind: "local-files" | "local-storage"` union. Extending the union is the established way to add a backend.
+- `packages/app/src/api-backend.ts` and `local-storage-backend.ts` — Existing backend implementations to mirror.
+- `packages/app/src/detect-backend.ts` — Branches on `payload.backend === "local-files"`. Add a `"remote"` branch here.
+- `packages/app/src/App.tsx` (~L810-840) — Frontend listens to `/api/open-requests` SSE and navigates on `event: open-request`. Reusable pattern for "session ready" notifications.
+- `packages/server/src/index.test.ts` — Vitest + supertest against the Express app, with `mkdtempSync` fixtures. Convention to follow.
+- `packages/server/src/cli.test.ts` — Fully fake `CliDependencies`. New CLI test scenarios use the same DI pattern; do not spawn real processes.
+
+### Institutional Learnings
+
+- `docs/solutions/` does not exist in this repo. No prior learnings to draw from. After this lands, capture via `/ce-compound`.
+
+### ADR Constraints
+
+- `docs/adr/0001-single-local-markdown-file.md` — "single local markdown file." Remote mode keeps the one-file unit but breaks the *local-filesystem* clause. ADR needs a clarifying revision (handled in U6).
+- `docs/adr/0004-cli-server-state-model.md` — State file "is not a collaboration backend, sync system, or persistent document model." Remote sessions therefore live in **server-process memory only**, never in the state file. U6 acknowledges this.
+
+---
+
+## Key Technical Decisions
+
+- **SSE + POST, not WebSocket.** SSE for server→CLI save events; POST for CLI→server registration and content updates. Matches existing codebase patterns (`/api/markdown-file/events`, `/api/open-requests`). Lower complexity than introducing `ws`. Bidirectionality is achieved via two channels.
+- **In-memory session store on the hosted server.** A `Map<sessionId, RemoteSession>` lives in the Express process. Session contains `{ id, originalPath, currentContent, version, createdAt, sseClient | null }`. No persistence — server restart drops sessions. Preserves ADR-0004's "no document model in state file."
+- **Session lifecycle:** CLI generates a session id (UUID), POSTs `/api/remote-document` to register, then opens `/api/remote-document/:id/events` SSE. When SSE drops (CLI exit, network blip), session is marked `disconnected` and frontend shows a banner. After a 5-minute TTL with no reconnect, server evicts the session.
+- **Concurrent opens of the same path = two sessions.** Each CLI invocation gets its own session id. The server does not deduplicate by path.
+- **`ROUGHDRAFT_HOST` unset on a CLI = fall back to local mode.** Today's behavior is unchanged. We print a one-line hint about remote mode the first time `roughdraft open` runs without it (low priority polish; can drop if it bloats the diff).
+- **Hosted-server bind host is env-driven.** New `ROUGHDRAFT_BIND_HOST` env var (defaults to current loopback list). Setting it to `0.0.0.0` exposes the server on all interfaces, including Tailscale. The `ROUGHDRAFT_PUBLIC_HOST` constant becomes a derived hint, not a binding.
+- **Save semantics.** When the browser saves, server pushes `event: save` over the session SSE with `{ content, version }`. CLI applies to disk via the same atomic-write pattern used for local files. Optimistic concurrency: server tracks `version`, browser sends `expectedVersion`, server returns 409 if stale (mirroring `/api/markdown-file`).
+- **Path validation bypass.** Remote-document endpoints do not run through `ensureProjectPath()`. The CLI is responsible for reading/writing only the file it registered. The server treats the path as opaque metadata.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **SSE vs WebSocket?** SSE+POST. See decisions above.
+- **Where does session state live?** In-process memory on the hosted server only. ADR-0004-aligned.
+- **Concurrent opens?** Allowed; each gets a session id.
+- **Fallback when `ROUGHDRAFT_HOST` is unset?** Local mode (current behavior).
+- **Server binding for the hosted instance?** New env `ROUGHDRAFT_BIND_HOST`; default is today's loopback.
+
+### Deferred to Implementation
+
+- **Exact session-disconnect UI affordance** — banner copy, dismiss behavior, whether the editor goes read-only. Decide once the working integration is visible.
+- **CLI reconnect on transient SSE drops** — out of scope for v1, but the session-id mechanism is reconnect-friendly if we add it later.
+- **Hint copy when `ROUGHDRAFT_HOST` is unset** — wording can wait until the rest is wired.
+- **Whether to persist a small client-id → host mapping** for nicer multi-source UI later. Defer; v1 displays one document at a time.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
++-------------------+        +---------------------------+        +-----------------+
+|  CLI on SSH box   |        |  Hosted Roughdraft        |        |  Browser tab    |
+|  (file owner)     |        |  (server + frontend)      |        |  (any device)   |
++---------+---------+        +-------------+-------------+        +--------+--------+
+          |                                |                                |
+   1. read foo.md                          |                                |
+   2. POST /api/remote-document            |                                |
+      { sessionId, path, content, version }|                                |
+          |--------------------------------|>                               |
+          |                                |  store in Map<id, session>     |
+          |                                |                                |
+   3. GET /api/remote-document/:id/events  |                                |
+      (SSE)                                |                                |
+          |<-------------------------------|  open SSE channel              |
+          |                                |                                |
+          |                                |  4. browser navigates to       |
+          |                                |     /?session=<id>             |
+          |                                |<-------------------------------|
+          |                                |  5. GET /api/remote-document/:id|
+          |                                |     return { content, version }|
+          |                                |------------------------------->|
+          |                                |                                |
+          |                                |  6. user edits + saves         |
+          |                                |  PUT /api/remote-document/:id  |
+          |                                |     { content, expectedVersion}|
+          |                                |<-------------------------------|
+          |                                |  update Map, increment version |
+          |                                |                                |
+   7. SSE event "save"                     |                                |
+      { content, version }                 |                                |
+          |<-------------------------------|                                |
+   8. fs.writeFile(originalPath, content)  |                                |
+          |                                |                                |
+```
+
+---
+
+## Implementation Units
+
+- U1. **Make server bind host env-configurable**
+
+**Goal:** Allow the hosted Roughdraft to bind to a non-loopback host (e.g. Tailscale interface or `0.0.0.0`) without code changes. Enables every later unit to be testable across machines.
+
+**Requirements:** R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/server/src/network.ts`
+- Modify: `packages/server/src/index.ts` (the `createServer()` listen loop)
+- Test: `packages/server/src/network.test.ts` *(new)*
+
+**Approach:**
+- Introduce `ROUGHDRAFT_BIND_HOST` env var. When set, replaces the loopback list with a single host (or comma-separated list).
+- Keep `ROUGHDRAFT_LOOPBACK_HOSTS` as the default for back-compat.
+- `network.ts` exposes a small `resolveBindHosts(env)` helper.
+- No CLI flag in v1 — env-only is sufficient and matches `ROUGHDRAFT_HOST`/`ROUGHDRAFT_STATE_DIR` precedent.
+
+**Patterns to follow:**
+- `packages/server/src/network.ts` style (small constant module, no class wrapper).
+- `ROUGHDRAFT_STATE_DIR` env handling in `cli.ts` for env-resolution shape.
+
+**Test scenarios:**
+- Happy path: `resolveBindHosts({})` returns the existing loopback list.
+- Happy path: `resolveBindHosts({ ROUGHDRAFT_BIND_HOST: "0.0.0.0" })` returns `["0.0.0.0"]`.
+- Edge case: `resolveBindHosts({ ROUGHDRAFT_BIND_HOST: "" })` returns the loopback list (empty string treated as unset).
+- Edge case: comma-separated hosts (`"0.0.0.0,::"`) parse to a list.
+
+**Verification:**
+- `pnpm test` passes new test cases.
+- Manual smoke: `ROUGHDRAFT_BIND_HOST=0.0.0.0 roughdraft start` is reachable from another Tailscale device.
+
+---
+
+- U2. **Server-side remote document endpoints and session store**
+
+**Goal:** Add the in-memory `RemoteSession` store and the four endpoints that drive remote-document mode: register, fetch, save, and SSE save-stream.
+
+**Requirements:** R1, R2, R6
+
+**Dependencies:** U1 (recommended for testability across machines, but not strictly required for unit tests)
+
+**Files:**
+- Modify: `packages/server/src/index.ts` (new module-scope `Map<string, RemoteSession>`, four new routes, status payload extension)
+- Test: `packages/server/src/index.test.ts` (new describe block for `/api/remote-document`)
+
+**Approach:**
+- Routes:
+  - `POST /api/remote-document` — body `{ sessionId, path, content, version? }`. Stores the session, returns `{ id, version, viewerUrl }`.
+  - `GET /api/remote-document/:id` — returns `{ id, path, content, version }`.
+  - `PUT /api/remote-document/:id` — body `{ content, expectedVersion }`. Writes new content + version, returns `{ version }`. Returns 409 with `{ current }` on stale-write, mirroring `/api/markdown-file`.
+  - `GET /api/remote-document/:id/events` — SSE channel held by the CLI. Server emits `event: save\ndata: { content, version }` on PUT. Heartbeat every 15s like existing SSE handlers.
+- Status payload (`GET /api/status`) extends `capabilities` with `{ remoteDocuments: true }` so the frontend can detect support.
+- Session eviction: 5-minute TTL after SSE disconnect. Use a timestamp + interval sweep, not a per-session timer.
+- Path is opaque to the server. **Do not** call `ensureProjectPath()` for remote endpoints.
+
+**Technical design:** *(directional guidance, not implementation specification)*
+
+```
+RemoteSession {
+  id            : string  // UUID, generated by CLI
+  originalPath  : string  // for display only; opaque to server
+  content       : string
+  version       : string  // sha256+size+timestamp; reuse fileVersionFromContent
+  sseClient     : Response | null
+  lastSeenAt    : number
+}
+```
+
+**Patterns to follow:**
+- Existing SSE handler at `packages/server/src/index.ts` `app.get("/api/open-requests", ...)` — same heartbeat shape, same client cleanup on `req.on("close")`.
+- Optimistic-concurrency pattern in `PUT /api/markdown-file`.
+- Capability flag pattern in `GET /api/status`.
+
+**Test scenarios:**
+- Happy path: POST register → GET returns the same content.
+- Happy path: PUT with correct `expectedVersion` updates content and bumps version.
+- Happy path (Covers F1 from origin success criteria): PUT triggers an SSE `save` event on the registered SSE channel.
+- Edge case: GET on unknown session id returns 404.
+- Edge case: PUT with wrong `expectedVersion` returns 409 with `{ current }`.
+- Edge case: SSE stream sends a heartbeat every 15s (use fake timers).
+- Edge case: SSE client disconnect followed by 5+ min wait → session is evicted; subsequent GET returns 404.
+- Integration: register session, open SSE, PUT new content, assert SSE emits `save` with the new bytes.
+
+**Verification:**
+- All test scenarios pass.
+- `GET /api/status` returns `capabilities.remoteDocuments === true`.
+- No path-validation gate (`ensureProjectPath`) is invoked on the new routes (asserted by the absence of a path traversal test failing — i.e., a `..` in the path field is accepted because path is opaque).
+
+---
+
+- U3. **CLI: remote-mode `open` command**
+
+**Goal:** When `ROUGHDRAFT_HOST` is set, `roughdraft open <file>` reads the file, registers a remote-document session, holds the SSE channel open, applies save events to disk, and exits cleanly when the channel drops.
+
+**Requirements:** R1, R2, R4, R5
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `packages/server/src/cli.ts` (new `openRemote` branch in the open command)
+- Modify: `packages/server/src/index.ts` (only if the remote-mode CLI needs additional contract surface — likely not; included here as a placeholder)
+- Test: `packages/server/src/cli.test.ts` (new describe block for remote-mode open)
+
+**Approach:**
+- Branch decision lives at the top of the open command: if `env.ROUGHDRAFT_HOST` is set, take the remote path; otherwise behave exactly as today.
+- Remote path:
+  1. Read file via `fs.readFile` (reuse `resolveTargetPath` for path normalization, but skip the project-dir scoping since there is no local server).
+  2. Generate session id via `crypto.randomUUID()`.
+  3. POST `${ROUGHDRAFT_HOST}/api/remote-document` with `{ sessionId, path: absolutePath, content, version }`. On non-2xx, exit 1 with a helpful message.
+  4. Open EventSource (or `fetch` + ReadableStream — the codebase doesn't depend on EventSource yet) to `${ROUGHDRAFT_HOST}/api/remote-document/:id/events`.
+  5. `deps.openUrl(viewerUrl)` to open the browser tab on the user's local machine. (For SSH agents that have no local browser, the URL is also printed to stdout so the user can paste it.)
+  6. On `event: save`, write content to the original disk path atomically (write to `path.tmp`, rename) and POST a no-op acknowledgement back to the server (or rely on the next save's version check; v1 can skip an explicit ack).
+  7. On SSE close or process signal, flush any pending writes and exit.
+- Exit code: 0 on clean shutdown, 1 on register failure, 130 on SIGINT.
+
+**Execution note:** Test-first for the SSE-handler save-to-disk path. The DI pattern in `cli.test.ts` makes this cheap; verify save-to-disk via the fake `fetchImpl` driving an in-memory ReadableStream.
+
+**Patterns to follow:**
+- DI structure in `cli.ts` (`CliDependencies` — extend with a `createSseStream` impl so tests can inject a controllable stream).
+- `sendOpenRequestToExistingWindow` for the POST shape.
+- The existing atomic-write pattern in the server-side `PUT /api/markdown-file` — port the same approach (write tmp, rename) to the CLI.
+
+**Test scenarios:**
+- Happy path (Covers R1, R2): with `ROUGHDRAFT_HOST` set, `open foo.md` reads bytes, POSTs to register, opens SSE, browser URL is opened, exits cleanly when SSE closes.
+- Happy path (Covers R2): SSE delivers a `save` event → CLI writes new content to the original path on disk.
+- Edge case: SSE delivers consecutive saves; only the latest content lands on disk.
+- Edge case: file path is a non-`.md` extension → CLI rejects before registering (preserves existing `Roughdraft can only open .md files` behavior).
+- Error path: POST `/api/remote-document` returns 5xx → CLI exits 1 with a "could not register remote session" message; nothing is opened.
+- Error path: SSE drops mid-session → CLI logs disconnect and exits 0 (or 130 if SIGINT).
+- Error path: file does not exist → CLI exits 1 before any network call.
+- Integration: `ROUGHDRAFT_HOST` unset → CLI runs the existing local flow unchanged (regression guard).
+
+**Verification:**
+- Manual: from the SSH host, `ROUGHDRAFT_HOST=http://mac-mini.tailnet:7373 roughdraft open plan.md` shows the file in a browser tab on the laptop within ~1s. Edits in browser save back; `cat plan.md` on the SSH host reflects the new content.
+- Test suite: all new scenarios pass; existing local-mode tests are untouched.
+
+---
+
+- U4. **Frontend: `remote` backend support**
+
+**Goal:** Detect `backend: "remote"` capability, build a `RemoteBackend` implementation, and route document operations through `/api/remote-document/:id` instead of the path-scoped local-files endpoints.
+
+**Requirements:** R1, R2, R7
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `packages/app/src/storage.ts` (extend `BackendInfo.kind` union with `"remote"`, add a session-id field to the storage shape)
+- Create: `packages/app/src/remote-backend.ts`
+- Modify: `packages/app/src/detect-backend.ts` (new branch when `payload.capabilities.remoteDocuments && url.searchParams.has("session")`)
+- Modify: `packages/app/src/App.tsx` (read `?session=<id>` from URL; route through the remote backend when present)
+- Test: `packages/app/src/remote-backend.test.ts` *(new)*
+- Test: `packages/app/src/detect-backend.test.ts` (extend with a remote-mode branch)
+
+**Approach:**
+- `RemoteBackend` mirrors `ApiBackend`'s shape but ignores `projectPath`. It uses the session id from `BackendInfo` for every request.
+- `getMarkdownFile` → `GET /api/remote-document/:id`.
+- `saveMarkdownFile` → `PUT /api/remote-document/:id` with `expectedVersion`.
+- `watchMarkdownFile` → SSE on `/api/remote-document/:id/events` to refresh on remote saves (a save from the CLI pushing content change later, if we ever add it; v1 may emit only browser-originated saves).
+- `saveAsset` and `resolveFileUrl` — out of scope in v1; remote sessions don't have an asset directory. Throw a clear error if invoked.
+- `openProject` — N/A in remote mode; throw or no-op.
+
+**Patterns to follow:**
+- `packages/app/src/api-backend.ts` for HTTP wrapper shape.
+- `packages/app/src/local-storage-backend.ts` for the "minimal backend that throws on unsupported ops" pattern.
+
+**Test scenarios:**
+- Happy path: `RemoteBackend.getMarkdownFile()` issues `GET /api/remote-document/<id>` and returns content + version.
+- Happy path: `saveMarkdownFile` issues `PUT` with `expectedVersion`; success returns new version.
+- Edge case: 409 conflict surfaces as `MarkdownFileConflictError` (mirroring `ApiBackend`).
+- Edge case: `saveAsset` throws a clear "remote sessions do not support asset uploads" error.
+- Edge case: `detect-backend` chooses `RemoteBackend` when both `capabilities.remoteDocuments` is true and `?session=` is present in the URL; falls back to `ApiBackend` otherwise.
+
+**Verification:**
+- `pnpm test` passes.
+- Manual: load `http://hosted/?session=<uuid>` after registering via CLI → editor renders the file content, save round-trips to disk on the CLI side.
+
+---
+
+- U5. **Frontend: session-disconnect affordance**
+
+**Goal:** When the SSE channel for the open session closes (CLI exited or server lost it), the editor surfaces a clear "session disconnected — saves will not persist" banner instead of silently failing.
+
+**Requirements:** R6 (clarity that bytes are owned by the CLI process)
+
+**Dependencies:** U4
+
+**Files:**
+- Modify: `packages/app/src/remote-backend.ts` (expose a `sessionStatus` observable or callback)
+- Modify: `packages/app/src/DocumentWorkspace.tsx` or equivalent top-level editor wrapper
+- Create: `packages/app/src/components/RemoteSessionBanner.tsx`
+- Test: `packages/app/src/components/RemoteSessionBanner.test.tsx` *(new, if a test file is warranted)*
+
+**Approach:**
+- Banner copy: "This document's CLI session disconnected. Reopen from the source machine to continue editing."
+- Editor goes read-only when disconnected. No auto-reconnect in v1.
+- Use a shadcn-style component from `packages/app/src/components/ui/` per `AGENTS.md`.
+
+**Patterns to follow:**
+- Existing top-level UI scaffolding in `DocumentWorkspace.tsx` and the components in `packages/app/src/components/`.
+- shadcn alert / banner style if one is already in `components/ui/`.
+
+**Test scenarios:**
+- Happy path: when `sessionStatus === "connected"`, banner is not rendered.
+- Happy path: when `sessionStatus === "disconnected"`, banner appears with the expected copy.
+- Edge case: editor is read-only when disconnected (saves are blocked at the UI level, not just the network level).
+
+**Verification:**
+- Manual: kill the CLI process while editing → banner appears within ~1s; editor blocks new saves.
+- Test cases pass.
+
+---
+
+- U6. **Update ADR-0001 and ADR-0004 to acknowledge remote mode**
+
+**Goal:** Reconcile the new mode with the recorded decisions. ADR-0001 is updated (not superseded) to clarify the unit of work is one markdown file regardless of where it's stored. ADR-0004 gets a brief note that remote-document sessions are intentionally in-memory only and not part of the state file.
+
+**Requirements:** R6, R7
+
+**Dependencies:** None (can land alongside or after U2)
+
+**Files:**
+- Modify: `docs/adr/0001-single-local-markdown-file.md`
+- Modify: `docs/adr/0004-cli-server-state-model.md`
+
+**Approach:**
+- ADR-0001: append a "Clarification (2026-04-30)" section noting that remote document mode preserves the one-file-at-a-time unit. The "local-file boundaries" wording is broadened to "the resolved file boundary" — the file is still a single markdown file, it just may live on a different machine that the CLI bridges.
+- ADR-0004: append a short clarification that remote-document sessions are deliberately in-memory only and are not persisted in the state file. This keeps the state file's role unchanged.
+- Do not write a new ADR; the existing decisions are still valid with these clarifications.
+
+**Test scenarios:** *Test expectation: none — documentation-only change.*
+
+**Verification:**
+- ADRs read coherently after the additions.
+- Plan reviewers can locate the rationale for in-memory-only session storage in ADR-0004.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** New `/api/remote-document/*` routes added to the Express app. New SSE channel added. Frontend backend detection branches expanded. CLI gains a parallel command path. No existing routes are modified except `GET /api/status` (additive `capabilities.remoteDocuments` flag).
+- **Error propagation:** Remote registration failures surface as CLI exit 1 with stderr message. SSE disconnect surfaces as a UI banner; CLI exits 0 (intentional). 409 conflicts on save mirror existing `/api/markdown-file` behavior.
+- **State lifecycle risks:** In-memory session map can leak if the eviction sweep is buggy. Mitigation: explicit TTL test (U2) and a session count metric (or just `console.log` count on each sweep — keep simple).
+- **API surface parity:** `local-files` mode is untouched. Remote mode is fully additive. `GET /api/status` is the one shared surface; the `capabilities` extension is back-compat (older frontend ignores unknown fields).
+- **Integration coverage:** End-to-end happy path is a manual smoke test in U3 verification. Automated coverage stops at the SSE-emit-on-PUT integration scenario in U2 — anything more ambitious requires multi-process orchestration we don't have.
+- **Unchanged invariants:**
+  - `roughdraft open foo.md` with no `ROUGHDRAFT_HOST` set behaves exactly as today.
+  - `local-files` backend, `/api/markdown-file`, and the existing SSE channels are not touched.
+  - The CLI state file (`.roughdraft-state`) keeps its current shape and purpose.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| In-memory session map leaks if TTL sweep is buggy | Explicit TTL test in U2; sweep is a simple `setInterval` with a single eviction predicate. |
+| Tailscale not available on a participating machine | Documented as a hard prerequisite in the origin doc; not solved by this plan. |
+| CLI process exits before browser opens the URL → session never viewed | Acceptable: user just reruns. Server's TTL evicts. |
+| Path traversal via the opaque `path` field on register | Path is metadata only on the server; only the CLI uses it for disk writes, and the CLI only ever writes to the path it itself read. No user-supplied path crosses the trust boundary on the server. |
+| Two CLIs from two boxes register the same session id (collision) | UUIDs make this practically impossible. Server returns 409 on duplicate-id register if it ever happens. |
+| Long-running SSE keeps too much server memory tied up | Each session holds the file content in memory. Monitor in practice; v1 is single-user. |
+
+---
+
+## Documentation / Operational Notes
+
+- README update: add a "Remote document mode" section with the `ROUGHDRAFT_HOST` and `ROUGHDRAFT_BIND_HOST` env vars and the canonical Mac-mini-as-host setup.
+- After landing, add a `docs/solutions/` entry capturing the SSE+POST decision and the in-memory session-store rationale (use `/ce-compound`).
+- No production rollout — this is a local/Tailnet feature. No flags, no monitoring, no migration.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/remote-document-mode-requirements.md](docs/brainstorms/remote-document-mode-requirements.md)
+- ADRs: [docs/adr/0001-single-local-markdown-file.md](docs/adr/0001-single-local-markdown-file.md), [docs/adr/0004-cli-server-state-model.md](docs/adr/0004-cli-server-state-model.md)
+- Code: `packages/server/src/index.ts` (existing SSE handlers, capability flag, version concurrency), `packages/server/src/cli.ts` (`open` command flow), `packages/app/src/storage.ts` (backend abstraction)

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -772,8 +772,7 @@ export function App() {
         setBackend(detectedBackend);
 
         if (detectedBackend.info.kind === "remote") {
-          const documentPath =
-            detectedBackend.info.detail || "remote.md";
+          const documentPath = detectedBackend.info.detail || "remote.md";
           await loadDocument(detectedBackend, documentPath);
           if (cancelled) return;
           setLoading(false);

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -771,6 +771,15 @@ export function App() {
 
         setBackend(detectedBackend);
 
+        if (detectedBackend.info.kind === "remote") {
+          const documentPath =
+            detectedBackend.info.detail || "remote.md";
+          await loadDocument(detectedBackend, documentPath);
+          if (cancelled) return;
+          setLoading(false);
+          return;
+        }
+
         if (!requestedPathState.rawPath) {
           setActiveDocumentPath(null);
           setLoading(false);

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -28,6 +28,7 @@ import {
 import { criticMarkdownHasReviewRail } from "./critic-markup";
 import { cn } from "./lib/utils";
 import { PageCard, type DocumentInteractionMode } from "./PageCard";
+import { RemoteSessionBanner } from "./components/RemoteSessionBanner";
 import type { Page, StorageBackend } from "./storage";
 
 type SaveState = "idle" | "saving" | "error";
@@ -156,6 +157,7 @@ export function DocumentWorkspace({
         conflictNotice ? "pt-40 sm:pt-28" : "pt-10",
       )}
     >
+      <RemoteSessionBanner backend={backend} />
       {conflictNotice ? (
         <div
           role="status"

--- a/packages/app/src/components/RemoteSessionBanner.tsx
+++ b/packages/app/src/components/RemoteSessionBanner.tsx
@@ -1,0 +1,59 @@
+import { CloudOff, Cloud } from "lucide-react";
+import { useEffect, useState } from "react";
+import { RemoteBackend, type RemoteSessionStatus } from "../remote-backend";
+import type { StorageBackend } from "../storage";
+
+interface RemoteSessionBannerProps {
+  backend: StorageBackend | null;
+}
+
+export function RemoteSessionBanner({ backend }: RemoteSessionBannerProps) {
+  const [status, setStatus] = useState<RemoteSessionStatus>("disconnected");
+
+  useEffect(() => {
+    if (!(backend instanceof RemoteBackend)) {
+      return;
+    }
+    return backend.onSessionStatusChange(setStatus);
+  }, [backend]);
+
+  if (!(backend instanceof RemoteBackend)) {
+    return null;
+  }
+
+  if (status === "connected") {
+    return (
+      <div
+        role="status"
+        aria-label="Remote session connected"
+        className="fixed top-3 right-3 z-40 flex items-center gap-2 rounded-md border border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-950 px-2.5 py-1.5 text-xs text-emerald-900 dark:text-emerald-100 shadow"
+      >
+        <Cloud className="size-3.5" aria-hidden="true" />
+        <span className="font-medium">Remote session connected</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="alert"
+      aria-label="Remote session disconnected"
+      className="fixed top-3 left-1/2 z-50 flex w-[min(calc(100vw-1rem),52rem)] -translate-x-1/2 items-start gap-2.5 rounded-[8px] border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950 px-3 py-3 text-amber-950 dark:text-amber-100 shadow-[0_14px_40px_rgba(120,53,15,0.18)] dark:shadow-[0_14px_40px_rgba(0,0,0,0.4)] sm:px-4"
+    >
+      <CloudOff
+        className="mt-0.5 size-4 shrink-0 text-amber-700 dark:text-amber-400"
+        aria-hidden="true"
+      />
+      <div className="min-w-0">
+        <div className="text-sm font-semibold leading-5">
+          Remote session disconnected
+        </div>
+        <div className="mt-0.5 text-xs leading-5 text-amber-900 dark:text-amber-200">
+          The CLI on the source machine is no longer connected. Reopen
+          <span className="font-mono"> roughdraft open </span>
+          from that machine to keep editing.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/detect-backend.test.ts
+++ b/packages/app/src/detect-backend.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiBackend } from "./api-backend";
+import { detectBackend } from "./detect-backend";
+import { LocalStorageBackend } from "./local-storage-backend";
+import { RemoteBackend } from "./remote-backend";
+
+describe("detectBackend", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    window.history.replaceState(null, "", "/");
+    vi.restoreAllMocks();
+  });
+
+  it("creates a remote backend when the URL has a session and the server supports remote documents", async () => {
+    window.history.replaceState(null, "", "/?session=session-1&token=secret");
+    global.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            backend: "local-files",
+            capabilities: { remoteDocuments: true },
+          }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof fetch;
+
+    const remoteBackend = new RemoteBackend(
+      {
+        kind: "remote",
+        label: "Remote document",
+        detail: "draft.md",
+        sessionId: "session-1",
+        originPath: "/work/draft.md",
+      },
+      {
+        id: "session-1",
+        originPath: "/work/draft.md",
+        content: "content",
+        version: "version-1",
+      },
+    );
+    const createRemoteBackend = vi
+      .spyOn(RemoteBackend, "create")
+      .mockResolvedValue(remoteBackend);
+
+    await expect(detectBackend()).resolves.toBe(remoteBackend);
+    expect(createRemoteBackend).toHaveBeenCalledWith("session-1", "secret");
+  });
+
+  it("falls back to the API backend when a session URL points at a server without remote-document support", async () => {
+    window.history.replaceState(null, "", "/?session=session-1");
+    global.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            backend: "local-files",
+            projectDir: "/work",
+            capabilities: {},
+          }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof fetch;
+    const createRemoteBackend = vi.spyOn(RemoteBackend, "create");
+
+    const backend = await detectBackend();
+
+    expect(backend).toBeInstanceOf(ApiBackend);
+    expect(backend.info.kind).toBe("local-files");
+    expect(createRemoteBackend).not.toHaveBeenCalled();
+  });
+
+  it("does not hide a broken remote session by falling back to local storage", async () => {
+    window.history.replaceState(null, "", "/?session=missing&token=bad");
+    global.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            backend: "local-files",
+            capabilities: { remoteDocuments: true },
+          }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof fetch;
+    vi.spyOn(RemoteBackend, "create").mockRejectedValue(
+      new Error("Could not load remote document session missing: 404"),
+    );
+
+    await expect(detectBackend()).rejects.toThrow(
+      /Could not load remote document session/,
+    );
+  });
+
+  it("uses local storage when no server is available", async () => {
+    global.fetch = vi.fn(async () => {
+      throw new Error("offline");
+    }) as unknown as typeof fetch;
+
+    const backend = await detectBackend();
+
+    expect(backend).toBeInstanceOf(LocalStorageBackend);
+  });
+});

--- a/packages/app/src/detect-backend.ts
+++ b/packages/app/src/detect-backend.ts
@@ -9,6 +9,7 @@ export async function detectBackend(): Promise<StorageBackend> {
   }
 
   const sessionId = readSessionIdFromUrl();
+  const token = readTokenFromUrl();
 
   try {
     const res = await fetch("/api/status");
@@ -22,7 +23,7 @@ export async function detectBackend(): Promise<StorageBackend> {
 
       if (sessionId && payload.capabilities?.remoteDocuments) {
         try {
-          return await RemoteBackend.create(sessionId);
+          return await RemoteBackend.create(sessionId, token);
         } catch (error) {
           console.error("Could not initialize remote backend:", error);
         }
@@ -50,4 +51,10 @@ function readSessionIdFromUrl(): string | null {
   const params = new URLSearchParams(window.location.search);
   const session = params.get("session")?.trim();
   return session && session.length > 0 ? session : null;
+}
+
+function readTokenFromUrl(): string {
+  if (typeof window === "undefined") return "";
+  const params = new URLSearchParams(window.location.search);
+  return params.get("token")?.trim() ?? "";
 }

--- a/packages/app/src/detect-backend.ts
+++ b/packages/app/src/detect-backend.ts
@@ -3,6 +3,13 @@ import { ApiBackend } from "./api-backend";
 import { LocalStorageBackend } from "./local-storage-backend";
 import { RemoteBackend } from "./remote-backend";
 
+interface StatusPayload {
+  backend?: string;
+  projectDir?: string;
+  stateless?: boolean;
+  capabilities?: { remoteDocuments?: boolean };
+}
+
 export async function detectBackend(): Promise<StorageBackend> {
   if (import.meta.env.VITE_PREVIEW_WEB === "1") {
     return new LocalStorageBackend();
@@ -11,38 +18,39 @@ export async function detectBackend(): Promise<StorageBackend> {
   const sessionId = readSessionIdFromUrl();
   const token = readTokenFromUrl();
 
+  let statusPayload: StatusPayload | null = null;
+
   try {
     const res = await fetch("/api/status");
     if (res.ok) {
-      const payload = (await res.json()) as {
-        backend?: string;
-        projectDir?: string;
-        stateless?: boolean;
-        capabilities?: { remoteDocuments?: boolean };
-      };
-
-      if (sessionId && payload.capabilities?.remoteDocuments) {
-        try {
-          return await RemoteBackend.create(sessionId, token);
-        } catch (error) {
-          console.error("Could not initialize remote backend:", error);
-        }
-      }
-
-      if (payload.backend === "local-files") {
-        return new ApiBackend({
-          kind: "local-files",
-          label: "Local files",
-          detail: payload.stateless
-            ? "Open a markdown file"
-            : "Markdown file on disk",
-          projectPath: payload.projectDir,
-        });
-      }
+      statusPayload = (await res.json()) as StatusPayload;
     }
   } catch {
     // network error — no server available
   }
+
+  if (statusPayload) {
+    if (sessionId && statusPayload.capabilities?.remoteDocuments) {
+      try {
+        return await RemoteBackend.create(sessionId, token);
+      } catch (error) {
+        console.error("Could not initialize remote backend:", error);
+        throw error;
+      }
+    }
+
+    if (statusPayload.backend === "local-files") {
+      return new ApiBackend({
+        kind: "local-files",
+        label: "Local files",
+        detail: statusPayload.stateless
+          ? "Open a markdown file"
+          : "Markdown file on disk",
+        projectPath: statusPayload.projectDir,
+      });
+    }
+  }
+
   return new LocalStorageBackend();
 }
 

--- a/packages/app/src/detect-backend.ts
+++ b/packages/app/src/detect-backend.ts
@@ -1,11 +1,14 @@
 import type { StorageBackend } from "./storage";
 import { ApiBackend } from "./api-backend";
 import { LocalStorageBackend } from "./local-storage-backend";
+import { RemoteBackend } from "./remote-backend";
 
 export async function detectBackend(): Promise<StorageBackend> {
   if (import.meta.env.VITE_PREVIEW_WEB === "1") {
     return new LocalStorageBackend();
   }
+
+  const sessionId = readSessionIdFromUrl();
 
   try {
     const res = await fetch("/api/status");
@@ -14,7 +17,16 @@ export async function detectBackend(): Promise<StorageBackend> {
         backend?: string;
         projectDir?: string;
         stateless?: boolean;
+        capabilities?: { remoteDocuments?: boolean };
       };
+
+      if (sessionId && payload.capabilities?.remoteDocuments) {
+        try {
+          return await RemoteBackend.create(sessionId);
+        } catch (error) {
+          console.error("Could not initialize remote backend:", error);
+        }
+      }
 
       if (payload.backend === "local-files") {
         return new ApiBackend({
@@ -31,4 +43,11 @@ export async function detectBackend(): Promise<StorageBackend> {
     // network error — no server available
   }
   return new LocalStorageBackend();
+}
+
+function readSessionIdFromUrl(): string | null {
+  if (typeof window === "undefined") return null;
+  const params = new URLSearchParams(window.location.search);
+  const session = params.get("session")?.trim();
+  return session && session.length > 0 ? session : null;
 }

--- a/packages/app/src/remote-backend.test.ts
+++ b/packages/app/src/remote-backend.test.ts
@@ -54,9 +54,50 @@ describe("RemoteBackend", () => {
     const backend = bootstrap();
     const page = await backend.getMarkdownFile("ignored.md");
 
-    expect(fetchMock).toHaveBeenCalledWith("/api/remote-document/session-1");
+    expect(fetchMock).toHaveBeenCalledWith("/api/remote-document/session-1", {
+      headers: {},
+    });
     expect(page.content).toBe("v2");
     expect(page.version).toBe("version-2");
+  });
+
+  it("includes the bearer token on requests when constructed with one", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            id: "session-1",
+            originPath: "/work/draft.md",
+            content: "v1",
+            version: "v",
+          }),
+          { status: 200 },
+        ),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const backend = new RemoteBackend(
+      {
+        kind: "remote",
+        label: "Remote document",
+        detail: "draft.md",
+        sessionId: "session-1",
+        originPath: "/work/draft.md",
+      },
+      {
+        id: "session-1",
+        originPath: "/work/draft.md",
+        content: "v1",
+        version: "v",
+      },
+      "secret-token",
+    );
+
+    await backend.getMarkdownFile("ignored.md");
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/remote-document/session-1", {
+      headers: { Authorization: "Bearer secret-token" },
+    });
   });
 
   it("saveMarkdownFile PUTs the new content with expectedVersion", async () => {

--- a/packages/app/src/remote-backend.test.ts
+++ b/packages/app/src/remote-backend.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { RemoteBackend } from "./remote-backend";
 import { MarkdownFileConflictError } from "./storage";
 
@@ -44,25 +37,24 @@ describe("RemoteBackend", () => {
   });
 
   it("getMarkdownFile fetches /api/remote-document/:id and returns the page", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response(
-        JSON.stringify({
-          id: "session-1",
-          originPath: "/work/draft.md",
-          content: "v2",
-          version: "version-2",
-        }),
-        { status: 200 },
-      ),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            id: "session-1",
+            originPath: "/work/draft.md",
+            content: "v2",
+            version: "version-2",
+          }),
+          { status: 200 },
+        ),
     );
     global.fetch = fetchMock as unknown as typeof fetch;
 
     const backend = bootstrap();
     const page = await backend.getMarkdownFile("ignored.md");
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/remote-document/session-1",
-    );
+    expect(fetchMock).toHaveBeenCalledWith("/api/remote-document/session-1");
     expect(page.content).toBe("v2");
     expect(page.version).toBe("version-2");
   });
@@ -96,18 +88,19 @@ describe("RemoteBackend", () => {
   });
 
   it("surfaces a 409 as MarkdownFileConflictError carrying current state", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response(
-        JSON.stringify({
-          current: {
-            id: "session-1",
-            originPath: "/work/draft.md",
-            content: "server-content",
-            version: "version-server",
-          },
-        }),
-        { status: 409 },
-      ),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            current: {
+              id: "session-1",
+              originPath: "/work/draft.md",
+              content: "server-content",
+              version: "version-server",
+            },
+          }),
+          { status: 409 },
+        ),
     );
     global.fetch = fetchMock as unknown as typeof fetch;
 
@@ -134,5 +127,32 @@ describe("RemoteBackend", () => {
     const backend = bootstrap();
     await expect(backend.openProject("/elsewhere")).resolves.toBeUndefined();
     expect(backend.info.projectPath).toBeUndefined();
+  });
+
+  it("onSessionStatusChange immediately reports the current status and any future changes", () => {
+    const backend = bootstrap();
+    const events: string[] = [];
+    const unsubscribe = backend.onSessionStatusChange((status) =>
+      events.push(status),
+    );
+
+    expect(events).toEqual(["disconnected"]);
+
+    // Simulate the SSE flow flipping the status to connected, then disconnected.
+    (
+      backend as unknown as { setSessionStatus: (s: string) => void }
+    ).setSessionStatus("connected");
+    (
+      backend as unknown as { setSessionStatus: (s: string) => void }
+    ).setSessionStatus("disconnected");
+
+    expect(events).toEqual(["disconnected", "connected", "disconnected"]);
+
+    unsubscribe();
+
+    (
+      backend as unknown as { setSessionStatus: (s: string) => void }
+    ).setSessionStatus("connected");
+    expect(events).toEqual(["disconnected", "connected", "disconnected"]);
   });
 });

--- a/packages/app/src/remote-backend.test.ts
+++ b/packages/app/src/remote-backend.test.ts
@@ -4,9 +4,11 @@ import { MarkdownFileConflictError } from "./storage";
 
 describe("RemoteBackend", () => {
   const originalFetch = global.fetch;
+  const originalEventSource = global.EventSource;
 
   afterEach(() => {
     global.fetch = originalFetch;
+    global.EventSource = originalEventSource;
     vi.restoreAllMocks();
   });
 
@@ -195,5 +197,74 @@ describe("RemoteBackend", () => {
       backend as unknown as { setSessionStatus: (s: string) => void }
     ).setSessionStatus("connected");
     expect(events).toEqual(["disconnected", "connected", "disconnected"]);
+  });
+
+  it("watchMarkdownFile opens a viewer event stream with the token in the query string", () => {
+    const instances: Array<{
+      url: string;
+      listeners: Record<string, Array<(event: Event) => void>>;
+      readyState: number;
+      close: () => void;
+    }> = [];
+
+    class FakeEventSource {
+      static CLOSED = 2;
+      url: string;
+      listeners: Record<string, Array<(event: Event) => void>> = {};
+      readyState = 1;
+      onerror: ((event: Event) => void) | null = null;
+
+      constructor(url: string) {
+        this.url = url;
+        instances.push(this);
+      }
+
+      addEventListener(type: string, listener: (event: Event) => void) {
+        this.listeners[type] ??= [];
+        this.listeners[type].push(listener);
+      }
+
+      close() {
+        this.readyState = FakeEventSource.CLOSED;
+      }
+    }
+
+    global.EventSource = FakeEventSource as unknown as typeof EventSource;
+
+    const backend = new RemoteBackend(
+      {
+        kind: "remote",
+        label: "Remote document",
+        detail: "draft.md",
+        sessionId: "session-1",
+        originPath: "/work/draft.md",
+      },
+      {
+        id: "session-1",
+        originPath: "/work/draft.md",
+        content: "v1",
+        version: "version-1",
+      },
+      "secret-token",
+    );
+
+    const statuses: string[] = [];
+    backend.onSessionStatusChange((status) => statuses.push(status));
+
+    const stopWatching = backend.watchMarkdownFile("ignored.md", () => {});
+    expect(instances).toHaveLength(1);
+
+    const eventsUrl = new URL(instances[0].url);
+    expect(eventsUrl.pathname).toBe("/api/remote-document/session-1/events");
+    expect(eventsUrl.searchParams.get("role")).toBe("viewer");
+    expect(eventsUrl.searchParams.get("token")).toBe("secret-token");
+
+    instances[0].listeners.connected?.forEach((listener) => {
+      listener(new Event("connected"));
+    });
+    expect(statuses).toEqual(["disconnected", "connected"]);
+
+    stopWatching();
+    expect(statuses).toEqual(["disconnected", "connected", "disconnected"]);
   });
 });

--- a/packages/app/src/remote-backend.test.ts
+++ b/packages/app/src/remote-backend.test.ts
@@ -1,0 +1,138 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { RemoteBackend } from "./remote-backend";
+import { MarkdownFileConflictError } from "./storage";
+
+describe("RemoteBackend", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  function bootstrap() {
+    return new RemoteBackend(
+      {
+        kind: "remote",
+        label: "Remote document",
+        detail: "draft.md",
+        sessionId: "session-1",
+        originPath: "/work/draft.md",
+      },
+      {
+        id: "session-1",
+        originPath: "/work/draft.md",
+        content: "v1",
+        version: "version-1",
+      },
+    );
+  }
+
+  it("creates an info object that exposes the session id and origin path", async () => {
+    const backend = bootstrap();
+    expect(backend.info.kind).toBe("remote");
+    expect(backend.info.sessionId).toBe("session-1");
+    expect(backend.info.originPath).toBe("/work/draft.md");
+    expect(backend.canManageProjects).toBe(false);
+  });
+
+  it("getMarkdownFile fetches /api/remote-document/:id and returns the page", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          id: "session-1",
+          originPath: "/work/draft.md",
+          content: "v2",
+          version: "version-2",
+        }),
+        { status: 200 },
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const backend = bootstrap();
+    const page = await backend.getMarkdownFile("ignored.md");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/remote-document/session-1",
+    );
+    expect(page.content).toBe("v2");
+    expect(page.version).toBe("version-2");
+  });
+
+  it("saveMarkdownFile PUTs the new content with expectedVersion", async () => {
+    const fetchMock = vi.fn(async (_url, init) => {
+      const body = JSON.parse(init?.body as string) as {
+        content: string;
+        expectedVersion?: string;
+      };
+      expect(body).toMatchObject({
+        content: "v2",
+        expectedVersion: "version-1",
+      });
+      return new Response(
+        JSON.stringify({ id: "session-1", version: "version-2" }),
+        { status: 200 },
+      );
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const backend = bootstrap();
+    const page = await backend.saveMarkdownFile(
+      "ignored.md",
+      "v2",
+      "version-1",
+    );
+
+    expect(page.version).toBe("version-2");
+    expect(page.content).toBe("v2");
+  });
+
+  it("surfaces a 409 as MarkdownFileConflictError carrying current state", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          current: {
+            id: "session-1",
+            originPath: "/work/draft.md",
+            content: "server-content",
+            version: "version-server",
+          },
+        }),
+        { status: 409 },
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const backend = bootstrap();
+    await expect(
+      backend.saveMarkdownFile("ignored.md", "client-content", "stale-version"),
+    ).rejects.toBeInstanceOf(MarkdownFileConflictError);
+  });
+
+  it("saveAsset throws a clear error", async () => {
+    const backend = bootstrap();
+    const file = new File(["bytes"], "image.png");
+    await expect(backend.saveAsset(file)).rejects.toThrow(
+      /do not support asset uploads/,
+    );
+  });
+
+  it("resolveFileUrl returns null", () => {
+    const backend = bootstrap();
+    expect(backend.resolveFileUrl("anything.png")).toBeNull();
+  });
+
+  it("openProject is a no-op for remote sessions", async () => {
+    const backend = bootstrap();
+    await expect(backend.openProject("/elsewhere")).resolves.toBeUndefined();
+    expect(backend.info.projectPath).toBeUndefined();
+  });
+});

--- a/packages/app/src/remote-backend.ts
+++ b/packages/app/src/remote-backend.ts
@@ -186,7 +186,11 @@ export class RemoteBackend implements StorageBackend {
     });
 
     source.onerror = () => {
-      this.setSessionStatus("disconnected");
+      // EventSource auto-reconnects on transient errors; only flag the session
+      // as disconnected once the browser has given up and closed the stream.
+      if (source.readyState === EventSource.CLOSED) {
+        this.setSessionStatus("disconnected");
+      }
     };
 
     return () => {

--- a/packages/app/src/remote-backend.ts
+++ b/packages/app/src/remote-backend.ts
@@ -23,15 +23,26 @@ export class RemoteBackend implements StorageBackend {
 
   private bootstrap: RemoteDocumentPayload;
   private statusListeners = new Set<(status: RemoteSessionStatus) => void>();
+  private token: string;
 
-  constructor(info: BackendInfo, bootstrap: RemoteDocumentPayload) {
+  constructor(info: BackendInfo, bootstrap: RemoteDocumentPayload, token = "") {
     this.info = info;
     this.bootstrap = bootstrap;
+    this.token = token;
   }
 
-  static async create(sessionId: string): Promise<RemoteBackend> {
+  private authHeaders(): Record<string, string> {
+    return this.token.length > 0
+      ? { Authorization: `Bearer ${this.token}` }
+      : {};
+  }
+
+  static async create(sessionId: string, token = ""): Promise<RemoteBackend> {
+    const headers: Record<string, string> =
+      token.length > 0 ? { Authorization: `Bearer ${token}` } : {};
     const response = await fetch(
       `/api/remote-document/${encodeURIComponent(sessionId)}`,
+      { headers },
     );
     if (!response.ok) {
       throw new Error(
@@ -49,6 +60,7 @@ export class RemoteBackend implements StorageBackend {
         originPath: bootstrap.originPath,
       },
       bootstrap,
+      token,
     );
   }
 
@@ -90,6 +102,7 @@ export class RemoteBackend implements StorageBackend {
     }
     const response = await fetch(
       `/api/remote-document/${encodeURIComponent(sessionId)}`,
+      { headers: this.authHeaders() },
     );
     if (!response.ok) {
       throw new Error(
@@ -114,7 +127,10 @@ export class RemoteBackend implements StorageBackend {
       `/api/remote-document/${encodeURIComponent(sessionId)}`,
       {
         method: "PUT",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          ...this.authHeaders(),
+        },
         body: JSON.stringify({ content, expectedVersion }),
       },
     );
@@ -151,9 +167,17 @@ export class RemoteBackend implements StorageBackend {
     const sessionId = this.info.sessionId;
     if (!sessionId) return () => {};
 
-    const source = new EventSource(
+    // EventSource cannot set custom headers, so the token rides as a query
+    // parameter. The server accepts both `Authorization: Bearer` and ?token=
+    // for the SSE endpoint specifically.
+    const eventsUrl = new URL(
       `/api/remote-document/${encodeURIComponent(sessionId)}/events`,
+      window.location.origin,
     );
+    if (this.token.length > 0) {
+      eventsUrl.searchParams.set("token", this.token);
+    }
+    const source = new EventSource(eventsUrl.toString());
 
     source.addEventListener("connected", () => {
       this.setSessionStatus("connected");

--- a/packages/app/src/remote-backend.ts
+++ b/packages/app/src/remote-backend.ts
@@ -161,9 +161,10 @@ export class RemoteBackend implements StorageBackend {
 
     source.addEventListener("save", (event) => {
       try {
-        const payload = JSON.parse(
-          (event as MessageEvent<string>).data,
-        ) as { content?: string; version?: string };
+        const payload = JSON.parse((event as MessageEvent<string>).data) as {
+          content?: string;
+          version?: string;
+        };
         if (
           typeof payload.content === "string" &&
           typeof payload.version === "string"

--- a/packages/app/src/remote-backend.ts
+++ b/packages/app/src/remote-backend.ts
@@ -174,6 +174,7 @@ export class RemoteBackend implements StorageBackend {
       `/api/remote-document/${encodeURIComponent(sessionId)}/events`,
       window.location.origin,
     );
+    eventsUrl.searchParams.set("role", "viewer");
     if (this.token.length > 0) {
       eventsUrl.searchParams.set("token", this.token);
     }

--- a/packages/app/src/remote-backend.ts
+++ b/packages/app/src/remote-backend.ts
@@ -1,0 +1,216 @@
+import {
+  MarkdownFileConflictError,
+  type BackendInfo,
+  type MarkdownFileChangeEvent,
+  type Page,
+  type StorageBackend,
+  type StoredAsset,
+} from "./storage";
+
+interface RemoteDocumentPayload {
+  id: string;
+  originPath: string;
+  content: string;
+  version: string;
+}
+
+export type RemoteSessionStatus = "connected" | "disconnected";
+
+export class RemoteBackend implements StorageBackend {
+  info: BackendInfo;
+  canManageProjects = false;
+  sessionStatus: RemoteSessionStatus = "disconnected";
+
+  private bootstrap: RemoteDocumentPayload;
+  private statusListeners = new Set<(status: RemoteSessionStatus) => void>();
+
+  constructor(info: BackendInfo, bootstrap: RemoteDocumentPayload) {
+    this.info = info;
+    this.bootstrap = bootstrap;
+  }
+
+  static async create(sessionId: string): Promise<RemoteBackend> {
+    const response = await fetch(
+      `/api/remote-document/${encodeURIComponent(sessionId)}`,
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Could not load remote document session ${sessionId}: ${response.status}`,
+      );
+    }
+    const bootstrap = (await response.json()) as RemoteDocumentPayload;
+    const filename = bootstrap.originPath.split(/[\\/]/).pop() ?? "remote.md";
+    return new RemoteBackend(
+      {
+        kind: "remote",
+        label: "Remote document",
+        detail: filename,
+        sessionId,
+        originPath: bootstrap.originPath,
+      },
+      bootstrap,
+    );
+  }
+
+  documentPath(): string {
+    return this.bootstrap.originPath.split(/[\\/]/).pop() ?? "remote.md";
+  }
+
+  onSessionStatusChange(
+    listener: (status: RemoteSessionStatus) => void,
+  ): () => void {
+    this.statusListeners.add(listener);
+    listener(this.sessionStatus);
+    return () => {
+      this.statusListeners.delete(listener);
+    };
+  }
+
+  private setSessionStatus(next: RemoteSessionStatus): void {
+    if (this.sessionStatus === next) return;
+    this.sessionStatus = next;
+    for (const listener of this.statusListeners) {
+      listener(next);
+    }
+  }
+
+  private pageFromBootstrap(): Page {
+    return {
+      id: this.bootstrap.id,
+      title: titleFromContent(this.bootstrap.content, this.documentPath()),
+      content: this.bootstrap.content,
+      version: this.bootstrap.version,
+    };
+  }
+
+  async getMarkdownFile(_relativePath: string): Promise<Page> {
+    const sessionId = this.info.sessionId;
+    if (!sessionId) {
+      throw new Error("Remote backend missing session id");
+    }
+    const response = await fetch(
+      `/api/remote-document/${encodeURIComponent(sessionId)}`,
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Failed to load remote document: HTTP ${response.status}`,
+      );
+    }
+    const payload = (await response.json()) as RemoteDocumentPayload;
+    this.bootstrap = payload;
+    return this.pageFromBootstrap();
+  }
+
+  async saveMarkdownFile(
+    _relativePath: string,
+    content: string,
+    expectedVersion?: string,
+  ): Promise<Page> {
+    const sessionId = this.info.sessionId;
+    if (!sessionId) {
+      throw new Error("Remote backend missing session id");
+    }
+    const response = await fetch(
+      `/api/remote-document/${encodeURIComponent(sessionId)}`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content, expectedVersion }),
+      },
+    );
+
+    if (response.status === 409) {
+      const payload = (await response.json()) as {
+        current?: RemoteDocumentPayload;
+      };
+      if (payload.current) {
+        this.bootstrap = payload.current;
+        throw new MarkdownFileConflictError(this.pageFromBootstrap());
+      }
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to save remote document: HTTP ${response.status}`,
+      );
+    }
+
+    const updated = (await response.json()) as { id: string; version: string };
+    this.bootstrap = {
+      ...this.bootstrap,
+      content,
+      version: updated.version,
+    };
+    return this.pageFromBootstrap();
+  }
+
+  watchMarkdownFile(
+    _relativePath: string,
+    onChange: (event: MarkdownFileChangeEvent) => void,
+  ): () => void {
+    const sessionId = this.info.sessionId;
+    if (!sessionId) return () => {};
+
+    const source = new EventSource(
+      `/api/remote-document/${encodeURIComponent(sessionId)}/events`,
+    );
+
+    source.addEventListener("connected", () => {
+      this.setSessionStatus("connected");
+    });
+
+    source.addEventListener("save", (event) => {
+      try {
+        const payload = JSON.parse(
+          (event as MessageEvent<string>).data,
+        ) as { content?: string; version?: string };
+        if (
+          typeof payload.content === "string" &&
+          typeof payload.version === "string"
+        ) {
+          this.bootstrap = {
+            ...this.bootstrap,
+            content: payload.content,
+            version: payload.version,
+          };
+          onChange({
+            path: this.bootstrap.originPath,
+            exists: true,
+            version: payload.version,
+          });
+        }
+      } catch (error) {
+        console.error("Failed to read remote save event:", error);
+      }
+    });
+
+    source.onerror = () => {
+      this.setSessionStatus("disconnected");
+    };
+
+    return () => {
+      source.close();
+      this.setSessionStatus("disconnected");
+    };
+  }
+
+  async saveAsset(_file: File): Promise<StoredAsset> {
+    throw new Error(
+      "Remote document sessions do not support asset uploads in this version.",
+    );
+  }
+
+  resolveFileUrl(_path: string): string | null {
+    return null;
+  }
+
+  async openProject(_path: string): Promise<void> {
+    // Remote sessions are bound to a single document; openProject is a no-op.
+  }
+}
+
+function titleFromContent(content: string, fallback: string): string {
+  const firstLine = content.split("\n")[0] ?? "";
+  const trimmed = firstLine.replace(/^#*\s*/, "").trim();
+  return trimmed || fallback;
+}

--- a/packages/app/src/storage.ts
+++ b/packages/app/src/storage.ts
@@ -28,10 +28,12 @@ export interface StoredAsset {
 }
 
 export interface BackendInfo {
-  kind: "local-files" | "local-storage";
+  kind: "local-files" | "local-storage" | "remote";
   label: string;
   detail: string;
   projectPath?: string;
+  sessionId?: string;
+  originPath?: string;
 }
 
 export interface StorageBackend {

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -1293,3 +1293,176 @@ describe("cli", () => {
     expect(result.server.port).toBe(ROUGHDRAFT_DEFAULT_PORT + 1);
   });
 });
+
+describe("runCli open in remote mode", () => {
+  let tempDir: string;
+  let projectDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "roughdraft-cli-remote-"));
+    projectDir = path.join(tempDir, "project");
+    fs.mkdirSync(projectDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  async function startRemoteHost(): Promise<{
+    url: string;
+    close: () => Promise<void>;
+  }> {
+    const { app } = createApp({
+      homeDir: tempDir,
+      staticDirPath: tempDir,
+    });
+    const server = createHttpServer(app);
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", () => resolve()),
+    );
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Failed to bind remote host");
+    }
+    return {
+      url: `http://127.0.0.1:${address.port}`,
+      close: () =>
+        new Promise<void>((resolve) => {
+          server.closeAllConnections?.();
+          server.close(() => resolve());
+        }),
+    };
+  }
+
+  it("prints register failure and exits 1 when the remote host is unreachable", async () => {
+    const filePath = path.join(projectDir, "draft.md");
+    fs.writeFileSync(filePath, "# hello\n");
+
+    const logs: string[] = [];
+    const errors: string[] = [];
+
+    const exitCode = await runCli(["open", filePath], {
+      env: { ROUGHDRAFT_HOST: "http://127.0.0.1:1" },
+      cwd: projectDir,
+      log: (m) => logs.push(m),
+      error: (m) => errors.push(m),
+      openUrl: () => "disabled",
+      resolveUpdateStatus: async () => ({
+        packageName: "roughdraft",
+        currentVersion: "0.1.0",
+        latestVersion: "0.1.0",
+        updateAvailable: false,
+        updateCommand: "",
+      }),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(errors.join("\n")).toContain("Could not register remote session");
+  });
+
+  it("rejects non-.md targets in remote mode without contacting the host", async () => {
+    const filePath = path.join(projectDir, "notes.txt");
+    fs.writeFileSync(filePath, "hello");
+
+    const errors: string[] = [];
+    let fetchCalls = 0;
+
+    const exitCode = await runCli(["open", filePath], {
+      env: { ROUGHDRAFT_HOST: "http://127.0.0.1:1" },
+      cwd: projectDir,
+      log: () => {},
+      error: (m) => errors.push(m),
+      openUrl: () => "disabled",
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        return new Response("", { status: 200 });
+      },
+      resolveUpdateStatus: async () => ({
+        packageName: "roughdraft",
+        currentVersion: "0.1.0",
+        latestVersion: "0.1.0",
+        updateAvailable: false,
+        updateCommand: "",
+      }),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(fetchCalls).toBe(0);
+    expect(errors.join("\n")).toContain("can only open .md files");
+  });
+
+  it("registers a session, opens the viewer URL, and writes save events to disk", { timeout: 15_000 }, async () => {
+    const remote = await startRemoteHost();
+    try {
+      const filePath = path.join(projectDir, "draft.md");
+      fs.writeFileSync(filePath, "before\n");
+
+      const logs: string[] = [];
+      const errors: string[] = [];
+      let openedUrl: string | null = null;
+
+      const cliPromise = runCli(["open", filePath], {
+        env: { ROUGHDRAFT_HOST: remote.url },
+        cwd: projectDir,
+        log: (m) => logs.push(m),
+        error: (m) => errors.push(m),
+        openUrl: (url) => {
+          openedUrl = url;
+          return "disabled";
+        },
+        resolveUpdateStatus: async () => ({
+          packageName: "roughdraft",
+          currentVersion: "0.1.0",
+          latestVersion: "0.1.0",
+          updateAvailable: false,
+          updateCommand: "",
+        }),
+      });
+
+      // Wait for the CLI to register and open the SSE channel.
+      const deadline = Date.now() + 4000;
+      while (openedUrl === null && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(openedUrl).not.toBeNull();
+      const sessionId = new URL(openedUrl as unknown as string).searchParams.get(
+        "session",
+      );
+      expect(sessionId).toBeTruthy();
+
+      // Wait until the server actually has the SSE client connected before PUTting.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Trigger a save event by PUTting new content.
+      const putResponse = await fetch(
+        `${remote.url}/api/remote-document/${sessionId}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: "after\n" }),
+        },
+      );
+      expect(putResponse.status).toBe(200);
+
+      // Wait until the file on disk reflects the save.
+      const writeDeadline = Date.now() + 4000;
+      while (
+        fs.readFileSync(filePath, "utf-8") !== "after\n" &&
+        Date.now() < writeDeadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(fs.readFileSync(filePath, "utf-8")).toBe("after\n");
+
+      // Closing the server ends the SSE stream and lets the CLI exit cleanly.
+      await remote.close();
+      const exitCode = await cliPromise;
+      expect(exitCode).toBe(0);
+      expect(logs.some((m) => m.includes("Opened remote Roughdraft session"))).toBe(
+        true,
+      );
+    } finally {
+      await remote.close();
+    }
+  });
+});

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -1391,7 +1391,9 @@ describe("runCli open in remote mode", () => {
     expect(errors.join("\n")).toContain("can only open .md files");
   });
 
-  it("registers a session, opens the viewer URL, and writes save events to disk", { timeout: 15_000 }, async () => {
+  it("registers a session, opens the viewer URL, and writes save events to disk", {
+    timeout: 15_000,
+  }, async () => {
     const remote = await startRemoteHost();
     try {
       const filePath = path.join(projectDir, "draft.md");
@@ -1425,9 +1427,9 @@ describe("runCli open in remote mode", () => {
         await new Promise((resolve) => setTimeout(resolve, 25));
       }
       expect(openedUrl).not.toBeNull();
-      const sessionId = new URL(openedUrl as unknown as string).searchParams.get(
-        "session",
-      );
+      const sessionId = new URL(
+        openedUrl as unknown as string,
+      ).searchParams.get("session");
       expect(sessionId).toBeTruthy();
 
       // Wait until the server actually has the SSE client connected before PUTting.
@@ -1458,9 +1460,9 @@ describe("runCli open in remote mode", () => {
       await remote.close();
       const exitCode = await cliPromise;
       expect(exitCode).toBe(0);
-      expect(logs.some((m) => m.includes("Opened remote Roughdraft session"))).toBe(
-        true,
-      );
+      expect(
+        logs.some((m) => m.includes("Opened remote Roughdraft session")),
+      ).toBe(true);
     } finally {
       await remote.close();
     }

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -1308,12 +1308,13 @@ describe("runCli open in remote mode", () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  async function startRemoteHost(): Promise<{
+  async function startRemoteHost(remoteDocumentToken?: string): Promise<{
     url: string;
     close: () => Promise<void>;
   }> {
     const { app } = createApp({
       homeDir: tempDir,
+      remoteDocumentToken,
       staticDirPath: tempDir,
     });
     const server = createHttpServer(app);
@@ -1464,6 +1465,303 @@ describe("runCli open in remote mode", () => {
         logs.some((m) => m.includes("Opened remote Roughdraft session")),
       ).toBe(true);
     } finally {
+      await remote.close();
+    }
+  });
+
+  it("authenticates remote registration and the CLI save-back stream with ROUGHDRAFT_TOKEN", {
+    timeout: 15_000,
+  }, async () => {
+    const remote = await startRemoteHost("secret-token");
+    try {
+      const filePath = path.join(projectDir, "draft.md");
+      fs.writeFileSync(filePath, "before\n");
+
+      const logs: string[] = [];
+      const errors: string[] = [];
+      let openedUrl: string | null = null;
+
+      const cliPromise = runCli(["open", filePath], {
+        env: {
+          ROUGHDRAFT_HOST: remote.url,
+          ROUGHDRAFT_TOKEN: "secret-token",
+        },
+        cwd: projectDir,
+        log: (m) => logs.push(m),
+        error: (m) => errors.push(m),
+        openUrl: (url) => {
+          openedUrl = url;
+          return "disabled";
+        },
+        resolveUpdateStatus: async () => ({
+          packageName: "roughdraft",
+          currentVersion: "0.1.0",
+          latestVersion: "0.1.0",
+          updateAvailable: false,
+          updateCommand: "",
+        }),
+      });
+
+      const openDeadline = Date.now() + 4000;
+      while (openedUrl === null && Date.now() < openDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(openedUrl).not.toBeNull();
+
+      const parsedOpenedUrl = new URL(openedUrl as unknown as string);
+      const sessionId = parsedOpenedUrl.searchParams.get("session");
+      expect(sessionId).toBeTruthy();
+      expect(parsedOpenedUrl.searchParams.get("token")).toBe("secret-token");
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const putResponse = await fetch(
+        `${remote.url}/api/remote-document/${sessionId}`,
+        {
+          method: "PUT",
+          headers: {
+            Authorization: "Bearer secret-token",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ content: "after-token\n" }),
+        },
+      );
+      expect(putResponse.status).toBe(200);
+
+      const writeDeadline = Date.now() + 4000;
+      while (
+        fs.readFileSync(filePath, "utf-8") !== "after-token\n" &&
+        Date.now() < writeDeadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(fs.readFileSync(filePath, "utf-8")).toBe("after-token\n");
+
+      await remote.close();
+      expect(await cliPromise).toBe(0);
+      expect(errors).toEqual([]);
+      expect(
+        logs.some((m) => m.includes("Opened remote Roughdraft session")),
+      ).toBe(true);
+    } finally {
+      await remote.close();
+    }
+  });
+
+  it("writes remote saves to disk without altering markdown constructs", {
+    timeout: 15_000,
+  }, async () => {
+    const remote = await startRemoteHost();
+    try {
+      const filePath = path.join(projectDir, "roundtrip.md");
+      const originalContent = [
+        "---",
+        "title: Remote Roundtrip",
+        "---",
+        "",
+        "# Remote Roundtrip",
+        "",
+        "{>>Keep this comment<<}",
+        "{++new text++}",
+        "{--old text--}",
+        "{~~old~>new~~}",
+        "{==highlight==}",
+        "",
+        "| A | B |",
+        "| - | - |",
+        "| 1 | 2 |",
+        "",
+        "- [ ] task",
+        "",
+        "```md",
+        "{>>literal example<<}",
+        "```",
+        "",
+        "Inline `{>>literal<<}` and [local](./neighbor.md).",
+        "",
+        "<aside>supported html</aside>",
+        "",
+      ].join("\n");
+      const savedContent = originalContent.replace(
+        "# Remote Roundtrip",
+        "# Remote Roundtrip Edited",
+      );
+      fs.writeFileSync(filePath, originalContent);
+
+      const logs: string[] = [];
+      const errors: string[] = [];
+      let openedUrl: string | null = null;
+
+      const cliPromise = runCli(["open", filePath], {
+        env: { ROUGHDRAFT_HOST: remote.url },
+        cwd: projectDir,
+        log: (m) => logs.push(m),
+        error: (m) => errors.push(m),
+        openUrl: (url) => {
+          openedUrl = url;
+          return "disabled";
+        },
+        resolveUpdateStatus: async () => ({
+          packageName: "roughdraft",
+          currentVersion: "0.1.0",
+          latestVersion: "0.1.0",
+          updateAvailable: false,
+          updateCommand: "",
+        }),
+      });
+
+      const openDeadline = Date.now() + 4000;
+      while (openedUrl === null && Date.now() < openDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(openedUrl).not.toBeNull();
+
+      const sessionId = new URL(
+        openedUrl as unknown as string,
+      ).searchParams.get("session");
+      expect(sessionId).toBeTruthy();
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const loaded = await fetch(
+        `${remote.url}/api/remote-document/${sessionId}`,
+      );
+      expect(loaded.status).toBe(200);
+      const payload = (await loaded.json()) as { version: string };
+
+      const putResponse = await fetch(
+        `${remote.url}/api/remote-document/${sessionId}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            content: savedContent,
+            expectedVersion: payload.version,
+          }),
+        },
+      );
+      expect(putResponse.status).toBe(200);
+
+      const writeDeadline = Date.now() + 4000;
+      while (
+        fs.readFileSync(filePath, "utf-8") !== savedContent &&
+        Date.now() < writeDeadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(fs.readFileSync(filePath, "utf-8")).toBe(savedContent);
+
+      await remote.close();
+      expect(await cliPromise).toBe(0);
+      expect(errors).toEqual([]);
+      expect(
+        logs.some((m) => m.includes("Saved") && m.includes("roundtrip.md")),
+      ).toBe(true);
+    } finally {
+      await remote.close();
+    }
+  });
+
+  it("keeps the CLI save-back stream when a browser also watches the remote session", {
+    timeout: 15_000,
+  }, async () => {
+    const remote = await startRemoteHost();
+    let browserEventsReader: ReadableStreamDefaultReader<Uint8Array> | null =
+      null;
+
+    try {
+      const filePath = path.join(projectDir, "draft.md");
+      fs.writeFileSync(filePath, "before\n");
+
+      const logs: string[] = [];
+      const errors: string[] = [];
+      let openedUrl: string | null = null;
+      let cliSettled = false;
+
+      const cliPromise = runCli(["open", filePath], {
+        env: { ROUGHDRAFT_HOST: remote.url },
+        cwd: projectDir,
+        log: (m) => logs.push(m),
+        error: (m) => errors.push(m),
+        openUrl: (url) => {
+          openedUrl = url;
+          return "disabled";
+        },
+        resolveUpdateStatus: async () => ({
+          packageName: "roughdraft",
+          currentVersion: "0.1.0",
+          latestVersion: "0.1.0",
+          updateAvailable: false,
+          updateCommand: "",
+        }),
+      }).finally(() => {
+        cliSettled = true;
+      });
+
+      const openDeadline = Date.now() + 4000;
+      while (openedUrl === null && Date.now() < openDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(openedUrl).not.toBeNull();
+
+      const sessionId = new URL(
+        openedUrl as unknown as string,
+      ).searchParams.get("session");
+      expect(sessionId).toBeTruthy();
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const browserEvents = await fetch(
+        `${remote.url}/api/remote-document/${sessionId}/events?role=viewer`,
+      );
+      expect(browserEvents.status).toBe(200);
+      browserEventsReader = browserEvents.body?.getReader() ?? null;
+      expect(browserEventsReader).not.toBeNull();
+
+      const decoder = new TextDecoder();
+      let connectedChunk = "";
+      const browserConnectDeadline = Date.now() + 4000;
+      while (
+        !connectedChunk.includes("event: connected") &&
+        Date.now() < browserConnectDeadline
+      ) {
+        const chunk = await browserEventsReader?.read();
+        if (!chunk || chunk.done) break;
+        connectedChunk += decoder.decode(chunk.value);
+      }
+      expect(connectedChunk).toContain("event: connected");
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(cliSettled).toBe(false);
+
+      const putResponse = await fetch(
+        `${remote.url}/api/remote-document/${sessionId}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: "after-browser-watch\n" }),
+        },
+      );
+      expect(putResponse.status).toBe(200);
+
+      const writeDeadline = Date.now() + 4000;
+      while (
+        fs.readFileSync(filePath, "utf-8") !== "after-browser-watch\n" &&
+        Date.now() < writeDeadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(fs.readFileSync(filePath, "utf-8")).toBe("after-browser-watch\n");
+
+      await browserEventsReader?.cancel();
+      await remote.close();
+      expect(await cliPromise).toBe(0);
+      expect(errors).toEqual([]);
+      expect(
+        logs.some((m) => m.includes("Opened remote Roughdraft session")),
+      ).toBe(true);
+    } finally {
+      await browserEventsReader?.cancel().catch(() => undefined);
       await remote.close();
     }
   });

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -608,6 +608,20 @@ function printCommandHelp(
     log("  --port <port>        Preferred server port");
     log("  --state-file <path>  Server state file");
     log("  --state-dir <dir>    Directory containing server.json");
+    log("");
+    log("Environment variables:");
+    log(
+      "  ROUGHDRAFT_HOST       Route open through a hosted Roughdraft instance",
+    );
+    log("                        (remote mode). The CLI registers a session,");
+    log("                        opens an SSE channel, and writes save events");
+    log("                        back to disk.");
+    log("  ROUGHDRAFT_NO_OPEN    Set to 1 to suppress browser launch.");
+    log("  ROUGHDRAFT_BIND_HOST  Comma-separated bind hosts for the hosted");
+    log(
+      "                        server (default: loopback). Set to 0.0.0.0 or",
+    );
+    log("                        a Tailscale interface to expose remotely.");
     return;
   }
 
@@ -799,12 +813,15 @@ interface ParsedSseChunk {
 }
 
 function parseSseEvents(buffer: string): ParsedSseChunk {
+  // Normalize CRLF to LF up front so the rest of the parser can treat \n
+  // as the only line terminator. SSE allows \r\n; some proxies rewrite it.
+  const normalized = buffer.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
   const events: SseEvent[] = [];
   let cursor = 0;
   while (true) {
-    const blank = buffer.indexOf("\n\n", cursor);
+    const blank = normalized.indexOf("\n\n", cursor);
     if (blank === -1) break;
-    const block = buffer.slice(cursor, blank);
+    const block = normalized.slice(cursor, blank);
     let eventName = "message";
     const dataLines: string[] = [];
     for (const line of block.split("\n")) {
@@ -819,7 +836,7 @@ function parseSseEvents(buffer: string): ParsedSseChunk {
     }
     cursor = blank + 2;
   }
-  return { events, remainder: buffer.slice(cursor) };
+  return { events, remainder: normalized.slice(cursor) };
 }
 
 async function atomicWriteFile(
@@ -859,6 +876,7 @@ async function runRemoteOpen(
 
   const sessionId = crypto.randomUUID();
 
+  const REGISTER_TIMEOUT_MS = 10_000;
   let registerResponse: Response;
   try {
     registerResponse = await deps.fetchImpl(`${baseUrl}/api/remote-document`, {
@@ -869,6 +887,7 @@ async function runRemoteOpen(
         originPath: options.openPath,
         content,
       }),
+      signal: AbortSignal.timeout(REGISTER_TIMEOUT_MS),
     });
   } catch (error) {
     deps.error(
@@ -920,11 +939,15 @@ async function runRemoteOpen(
     deps.log(`Holding session open for ${options.openPath}. Ctrl-C to exit.`);
   }
 
+  const SSE_CONNECT_TIMEOUT_MS = 10_000;
   let eventsResponse: Response;
   try {
     eventsResponse = await deps.fetchImpl(
       `${baseUrl}/api/remote-document/${encodeURIComponent(sessionId)}/events`,
-      { headers: { Accept: "text/event-stream" } },
+      {
+        headers: { Accept: "text/event-stream" },
+        signal: AbortSignal.timeout(SSE_CONNECT_TIMEOUT_MS),
+      },
     );
   } catch (error) {
     deps.error(

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -616,12 +616,19 @@ function printCommandHelp(
     log("                        (remote mode). The CLI registers a session,");
     log("                        opens an SSE channel, and writes save events");
     log("                        back to disk.");
+    log(
+      "  ROUGHDRAFT_TOKEN      Bearer token sent on remote-document requests.",
+    );
+    log("                        Required when the hosted server binds to a");
+    log("                        non-loopback host. Must match the value the");
+    log("                        hosted server was started with.");
     log("  ROUGHDRAFT_NO_OPEN    Set to 1 to suppress browser launch.");
     log("  ROUGHDRAFT_BIND_HOST  Comma-separated bind hosts for the hosted");
     log(
       "                        server (default: loopback). Set to 0.0.0.0 or",
     );
     log("                        a Tailscale interface to expose remotely.");
+    log("                        Requires ROUGHDRAFT_TOKEN.");
     return;
   }
 
@@ -848,6 +855,20 @@ async function atomicWriteFile(
   await fs.promises.rename(tmpPath, targetPath);
 }
 
+function appendTokenToViewerUrl(viewerUrl: string, token: string): string {
+  if (token.length === 0) return viewerUrl;
+  try {
+    const parsed = new URL(viewerUrl);
+    parsed.searchParams.set("token", token);
+    return parsed.toString();
+  } catch {
+    // Fall back to a simple suffix if the URL is malformed; the browser will
+    // reject it the same way it would have without the token.
+    const separator = viewerUrl.includes("?") ? "&" : "?";
+    return `${viewerUrl}${separator}token=${encodeURIComponent(token)}`;
+  }
+}
+
 interface RemoteOpenOptions {
   host: string;
   openPath: string;
@@ -861,6 +882,12 @@ async function runRemoteOpen(
   options: RemoteOpenOptions,
 ): Promise<number> {
   const baseUrl = options.host.replace(/\/$/, "");
+  const remoteToken =
+    typeof deps.env.ROUGHDRAFT_TOKEN === "string"
+      ? deps.env.ROUGHDRAFT_TOKEN.trim()
+      : "";
+  const authHeaders: Record<string, string> =
+    remoteToken.length > 0 ? { Authorization: `Bearer ${remoteToken}` } : {};
 
   let content: string;
   try {
@@ -881,7 +908,7 @@ async function runRemoteOpen(
   try {
     registerResponse = await deps.fetchImpl(`${baseUrl}/api/remote-document`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...authHeaders },
       body: JSON.stringify({
         sessionId,
         originPath: options.openPath,
@@ -899,9 +926,15 @@ async function runRemoteOpen(
   }
 
   if (!registerResponse.ok) {
-    deps.error(
-      `Remote host rejected the session register (HTTP ${registerResponse.status}).`,
-    );
+    if (registerResponse.status === 401) {
+      deps.error(
+        `Remote host rejected the session register (HTTP 401). Set ROUGHDRAFT_TOKEN to the token configured on the host before retrying.`,
+      );
+    } else {
+      deps.error(
+        `Remote host rejected the session register (HTTP ${registerResponse.status}).`,
+      );
+    }
     return 1;
   }
 
@@ -911,10 +944,15 @@ async function runRemoteOpen(
     viewerUrl?: string;
   };
 
-  const viewerUrl =
+  // The browser viewer must include the same token so its fetches and
+  // EventSource connection authenticate. The server's viewerUrl response field
+  // is unaware of the token (it doesn't see secrets in plaintext over the wire
+  // unless we add them); the CLI knows the token and can append it.
+  const baseViewer =
     typeof registerPayload.viewerUrl === "string"
       ? registerPayload.viewerUrl
       : `${baseUrl}/?session=${encodeURIComponent(sessionId)}`;
+  const viewerUrl = appendTokenToViewerUrl(baseViewer, remoteToken);
 
   if (options.printUrl) {
     deps.log(viewerUrl);
@@ -945,7 +983,7 @@ async function runRemoteOpen(
     eventsResponse = await deps.fetchImpl(
       `${baseUrl}/api/remote-document/${encodeURIComponent(sessionId)}/events`,
       {
-        headers: { Accept: "text/event-stream" },
+        headers: { Accept: "text/event-stream", ...authHeaders },
         signal: AbortSignal.timeout(SSE_CONNECT_TIMEOUT_MS),
       },
     );

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -785,6 +786,215 @@ function buildTargetUrl(baseUrl: string, openPath: string): string {
   url.pathname = "/";
   url.searchParams.set("path", openPath);
   return url.toString();
+}
+
+interface SseEvent {
+  event: string;
+  data: string;
+}
+
+interface ParsedSseChunk {
+  events: SseEvent[];
+  remainder: string;
+}
+
+function parseSseEvents(buffer: string): ParsedSseChunk {
+  const events: SseEvent[] = [];
+  let cursor = 0;
+  while (true) {
+    const blank = buffer.indexOf("\n\n", cursor);
+    if (blank === -1) break;
+    const block = buffer.slice(cursor, blank);
+    let eventName = "message";
+    const dataLines: string[] = [];
+    for (const line of block.split("\n")) {
+      if (line.startsWith("event: ")) {
+        eventName = line.slice(7).trim();
+      } else if (line.startsWith("data: ")) {
+        dataLines.push(line.slice(6));
+      }
+    }
+    if (dataLines.length > 0) {
+      events.push({ event: eventName, data: dataLines.join("\n") });
+    }
+    cursor = blank + 2;
+  }
+  return { events, remainder: buffer.slice(cursor) };
+}
+
+async function atomicWriteFile(
+  targetPath: string,
+  content: string,
+): Promise<void> {
+  const tmpPath = `${targetPath}.tmp-${process.pid}-${Date.now()}`;
+  await fs.promises.writeFile(tmpPath, content);
+  await fs.promises.rename(tmpPath, targetPath);
+}
+
+interface RemoteOpenOptions {
+  host: string;
+  openPath: string;
+  noOpen: boolean;
+  printUrl: boolean;
+  json: boolean;
+}
+
+async function runRemoteOpen(
+  deps: CliDependencies,
+  options: RemoteOpenOptions,
+): Promise<number> {
+  const baseUrl = options.host.replace(/\/$/, "");
+
+  let content: string;
+  try {
+    content = await fs.promises.readFile(options.openPath, "utf-8");
+  } catch (error) {
+    deps.error(
+      error instanceof Error
+        ? error.message
+        : `Could not read ${options.openPath}`,
+    );
+    return 1;
+  }
+
+  const sessionId = crypto.randomUUID();
+
+  let registerResponse: Response;
+  try {
+    registerResponse = await deps.fetchImpl(`${baseUrl}/api/remote-document`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sessionId,
+        originPath: options.openPath,
+        content,
+      }),
+    });
+  } catch (error) {
+    deps.error(
+      `Could not register remote session at ${baseUrl}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return 1;
+  }
+
+  if (!registerResponse.ok) {
+    deps.error(
+      `Remote host rejected the session register (HTTP ${registerResponse.status}).`,
+    );
+    return 1;
+  }
+
+  const registerPayload = (await registerResponse.json()) as {
+    id?: string;
+    version?: string;
+    viewerUrl?: string;
+  };
+
+  const viewerUrl =
+    typeof registerPayload.viewerUrl === "string"
+      ? registerPayload.viewerUrl
+      : `${baseUrl}/?session=${encodeURIComponent(sessionId)}`;
+
+  if (options.printUrl) {
+    deps.log(viewerUrl);
+    return 0;
+  }
+
+  if (!options.noOpen && deps.env.ROUGHDRAFT_NO_OPEN !== "1") {
+    deps.openUrl(viewerUrl);
+  }
+
+  if (options.json) {
+    emitJson(deps.log, {
+      opened: true,
+      mode: "remote",
+      sessionId,
+      url: viewerUrl,
+      host: baseUrl,
+      path: options.openPath,
+    });
+  } else {
+    deps.log(`Opened remote Roughdraft session: ${viewerUrl}`);
+    deps.log(`Holding session open for ${options.openPath}. Ctrl-C to exit.`);
+  }
+
+  let eventsResponse: Response;
+  try {
+    eventsResponse = await deps.fetchImpl(
+      `${baseUrl}/api/remote-document/${encodeURIComponent(sessionId)}/events`,
+      { headers: { Accept: "text/event-stream" } },
+    );
+  } catch (error) {
+    deps.error(
+      `Lost connection to remote host: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return 1;
+  }
+
+  if (!eventsResponse.ok || !eventsResponse.body) {
+    deps.error(
+      `Could not open remote event stream (HTTP ${eventsResponse.status}).`,
+    );
+    return 1;
+  }
+
+  const reader = eventsResponse.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    while (true) {
+      let chunk: ReadableStreamReadResult<Uint8Array>;
+      try {
+        chunk = await reader.read();
+      } catch {
+        break;
+      }
+      if (chunk.done) break;
+      buffer += decoder.decode(chunk.value, { stream: true });
+      const parsed = parseSseEvents(buffer);
+      buffer = parsed.remainder;
+      for (const event of parsed.events) {
+        if (event.event === "save") {
+          let payload: { content?: unknown } = {};
+          try {
+            payload = JSON.parse(event.data) as { content?: unknown };
+          } catch {
+            continue;
+          }
+          if (typeof payload.content === "string") {
+            try {
+              await atomicWriteFile(options.openPath, payload.content);
+              if (!options.json) {
+                deps.log(`Saved ${options.openPath} from remote.`);
+              }
+            } catch (error) {
+              deps.error(
+                `Failed to write ${options.openPath}: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
+              );
+            }
+          }
+        }
+      }
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // The stream may already be in an errored state; ignore.
+    }
+  }
+
+  if (!options.json) {
+    deps.log("Remote session disconnected.");
+  }
+  return 0;
 }
 
 async function sendOpenRequestToExistingWindow(
@@ -1966,6 +2176,21 @@ export async function runCli(
       }
 
       const { projectDir, openPath } = resolvedTarget;
+
+      const remoteHost =
+        typeof deps.env.ROUGHDRAFT_HOST === "string"
+          ? deps.env.ROUGHDRAFT_HOST.trim()
+          : "";
+      if (remoteHost.length > 0) {
+        return runRemoteOpen(deps, {
+          host: remoteHost,
+          openPath,
+          noOpen: options.noOpen,
+          printUrl: options.printUrl,
+          json,
+        });
+      }
+
       const liveDevFrontendUrl = await resolveLiveDevFrontendBaseUrl(deps);
       let result: EnsureRunningResult | null = null;
       let baseUrl: string;

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -978,15 +978,18 @@ async function runRemoteOpen(
   }
 
   const SSE_CONNECT_TIMEOUT_MS = 10_000;
+  const eventsUrl = new URL(
+    `/api/remote-document/${encodeURIComponent(sessionId)}/events`,
+    baseUrl,
+  );
+  eventsUrl.searchParams.set("role", "cli");
+
   let eventsResponse: Response;
   try {
-    eventsResponse = await deps.fetchImpl(
-      `${baseUrl}/api/remote-document/${encodeURIComponent(sessionId)}/events`,
-      {
-        headers: { Accept: "text/event-stream", ...authHeaders },
-        signal: AbortSignal.timeout(SSE_CONNECT_TIMEOUT_MS),
-      },
-    );
+    eventsResponse = await deps.fetchImpl(eventsUrl.toString(), {
+      headers: { Accept: "text/event-stream", ...authHeaders },
+      signal: AbortSignal.timeout(SSE_CONNECT_TIMEOUT_MS),
+    });
   } catch (error) {
     deps.error(
       `Lost connection to remote host: ${

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -596,9 +596,12 @@ describe("createApp", () => {
     expect(put.status).toBe(404);
   });
 
-  it("updates remote document content and bumps the version on PUT", async () => {
+  it("returns 503 when PUT lands with no active CLI session listener", async () => {
+    // The browser's save is meaningless if no CLI is connected to receive it
+    // and write to disk. Surfacing 503 (instead of silently 200-ing) prevents
+    // the browser from believing a save succeeded that never reached disk.
     const { app } = createApp({ homeDir, staticDirPath: projectDir });
-    const register = await request(app).post("/api/remote-document").send({
+    await request(app).post("/api/remote-document").send({
       sessionId: "s2",
       originPath: "/draft.md",
       content: "v1",
@@ -606,15 +609,14 @@ describe("createApp", () => {
 
     const update = await request(app).put("/api/remote-document/s2").send({
       content: "v2",
-      expectedVersion: register.body.version,
     });
 
-    expect(update.status).toBe(200);
-    expect(update.body.version).not.toBe(register.body.version);
+    expect(update.status).toBe(503);
 
+    // The session content stays on the bumped version so a reconnect-then-fetch
+    // sees the saved bytes, but the browser knows the round-trip to disk failed.
     const fetched = await request(app).get("/api/remote-document/s2");
     expect(fetched.body.content).toBe("v2");
-    expect(fetched.body.version).toBe(update.body.version);
   });
 
   it("returns 409 with current state when expectedVersion is stale", async () => {
@@ -625,6 +627,8 @@ describe("createApp", () => {
       content: "v1",
     });
 
+    // First PUT bumps the version to "v2" (returns 503 because no SSE listener,
+    // but the in-memory content and version are still updated).
     await request(app).put("/api/remote-document/s3").send({
       content: "v2",
       expectedVersion: register.body.version,

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -323,6 +323,7 @@ describe("createApp", () => {
         projectPathRequired: true,
         fileSystemBrowsing: true,
         remoteDocuments: true,
+        remoteDocumentTokenRequired: false,
       },
     });
     expect(response.body).not.toHaveProperty("projectDir");
@@ -594,6 +595,80 @@ describe("createApp", () => {
       .put("/api/remote-document/missing")
       .send({ content: "x" });
     expect(put.status).toBe(404);
+  });
+
+  it("rejects remote-document register without a valid token when a token is configured", async () => {
+    const { app } = createApp({
+      homeDir,
+      staticDirPath: projectDir,
+      remoteDocumentToken: "secret-token",
+    });
+
+    const noToken = await request(app).post("/api/remote-document").send({
+      sessionId: "auth-1",
+      originPath: "/work/a.md",
+      content: "x",
+    });
+    expect(noToken.status).toBe(401);
+
+    const wrongToken = await request(app)
+      .post("/api/remote-document")
+      .set("Authorization", "Bearer wrong-token")
+      .send({
+        sessionId: "auth-1",
+        originPath: "/work/a.md",
+        content: "x",
+      });
+    expect(wrongToken.status).toBe(401);
+
+    const ok = await request(app)
+      .post("/api/remote-document")
+      .set("Authorization", "Bearer secret-token")
+      .send({
+        sessionId: "auth-1",
+        originPath: "/work/a.md",
+        content: "x",
+      });
+    expect(ok.status).toBe(201);
+  });
+
+  it("accepts ?token= query for the SSE endpoint when a token is configured", async () => {
+    const { app } = createApp({
+      homeDir,
+      staticDirPath: projectDir,
+      remoteDocumentToken: "secret-token",
+    });
+
+    await request(app)
+      .post("/api/remote-document")
+      .set("Authorization", "Bearer secret-token")
+      .send({ sessionId: "sse-auth", originPath: "/a.md", content: "x" });
+
+    const noToken = await request(app).get("/api/remote-document/sse-auth");
+    expect(noToken.status).toBe(401);
+
+    const queryToken = await request(app)
+      .get("/api/remote-document/sse-auth")
+      .query({ token: "secret-token" });
+    expect(queryToken.status).toBe(200);
+  });
+
+  it("advertises whether a remote-document token is required in /api/status", async () => {
+    const noTokenApp = createApp({ homeDir, staticDirPath: projectDir });
+    const noTokenStatus = await request(noTokenApp.app).get("/api/status");
+    expect(noTokenStatus.body.capabilities.remoteDocumentTokenRequired).toBe(
+      false,
+    );
+
+    const tokenApp = createApp({
+      homeDir,
+      staticDirPath: projectDir,
+      remoteDocumentToken: "secret-token",
+    });
+    const tokenStatus = await request(tokenApp.app).get("/api/status");
+    expect(tokenStatus.body.capabilities.remoteDocumentTokenRequired).toBe(
+      true,
+    );
   });
 
   it("returns 503 when PUT lands with no active CLI session listener", async () => {

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -1,4 +1,4 @@
-import { type AddressInfo } from "node:net";
+import type { AddressInfo } from "node:net";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -536,13 +536,11 @@ describe("createApp", () => {
     const { app } = createApp({ homeDir, staticDirPath: projectDir });
     const sessionId = "session-1";
 
-    const register = await request(app)
-      .post("/api/remote-document")
-      .send({
-        sessionId,
-        originPath: "/work/draft.md",
-        content: "# hello\n",
-      });
+    const register = await request(app).post("/api/remote-document").send({
+      sessionId,
+      originPath: "/work/draft.md",
+      content: "# hello\n",
+    });
 
     expect(register.status).toBe(201);
     expect(register.body).toMatchObject({
@@ -646,9 +644,7 @@ describe("createApp", () => {
 
   it("returns 404 when opening SSE for an unknown session", async () => {
     const { app } = createApp({ homeDir, staticDirPath: projectDir });
-    const response = await request(app).get(
-      "/api/remote-document/nope/events",
-    );
+    const response = await request(app).get("/api/remote-document/nope/events");
     expect(response.status).toBe(404);
   });
 
@@ -659,15 +655,18 @@ describe("createApp", () => {
       const port = (server.address() as AddressInfo).port;
       const sessionId = "sse-delivers";
 
-      const register = await fetch(`http://127.0.0.1:${port}/api/remote-document`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sessionId,
-          originPath: "/draft.md",
-          content: "before",
-        }),
-      });
+      const register = await fetch(
+        `http://127.0.0.1:${port}/api/remote-document`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            sessionId,
+            originPath: "/draft.md",
+            content: "before",
+          }),
+        },
+      );
       expect(register.status).toBe(201);
 
       const events = await fetch(

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -597,7 +597,7 @@ describe("createApp", () => {
     expect(put.status).toBe(404);
   });
 
-  it("rejects remote-document register without a valid token when a token is configured", async () => {
+  it("requires a bearer token on remote-document JSON routes when a token is configured", async () => {
     const { app } = createApp({
       homeDir,
       staticDirPath: projectDir,
@@ -621,6 +621,16 @@ describe("createApp", () => {
       });
     expect(wrongToken.status).toBe(401);
 
+    const queryToken = await request(app)
+      .post("/api/remote-document")
+      .query({ token: "secret-token" })
+      .send({
+        sessionId: "auth-1",
+        originPath: "/work/a.md",
+        content: "x",
+      });
+    expect(queryToken.status).toBe(401);
+
     const ok = await request(app)
       .post("/api/remote-document")
       .set("Authorization", "Bearer secret-token")
@@ -630,6 +640,27 @@ describe("createApp", () => {
         content: "x",
       });
     expect(ok.status).toBe(201);
+
+    const getWithQueryToken = await request(app)
+      .get("/api/remote-document/auth-1")
+      .query({ token: "secret-token" });
+    expect(getWithQueryToken.status).toBe(401);
+
+    const getWithHeader = await request(app)
+      .get("/api/remote-document/auth-1")
+      .set("Authorization", "Bearer secret-token");
+    expect(getWithHeader.status).toBe(200);
+
+    const putWithQueryToken = await request(app)
+      .put("/api/remote-document/auth-1")
+      .query({ token: "secret-token" })
+      .send({ content: "mutated" });
+    expect(putWithQueryToken.status).toBe(401);
+
+    const unchanged = await request(app)
+      .get("/api/remote-document/auth-1")
+      .set("Authorization", "Bearer secret-token");
+    expect(unchanged.body.content).toBe("x");
   });
 
   it("accepts ?token= query for the SSE endpoint when a token is configured", async () => {
@@ -644,13 +675,23 @@ describe("createApp", () => {
       .set("Authorization", "Bearer secret-token")
       .send({ sessionId: "sse-auth", originPath: "/a.md", content: "x" });
 
-    const noToken = await request(app).get("/api/remote-document/sse-auth");
-    expect(noToken.status).toBe(401);
+    const server = app.listen(0);
+    try {
+      const port = (server.address() as AddressInfo).port;
 
-    const queryToken = await request(app)
-      .get("/api/remote-document/sse-auth")
-      .query({ token: "secret-token" });
-    expect(queryToken.status).toBe(200);
+      const noToken = await fetch(
+        `http://127.0.0.1:${port}/api/remote-document/sse-auth/events?role=viewer`,
+      );
+      expect(noToken.status).toBe(401);
+
+      const queryToken = await fetch(
+        `http://127.0.0.1:${port}/api/remote-document/sse-auth/events?role=viewer&token=secret-token`,
+      );
+      expect(queryToken.status).toBe(200);
+      await queryToken.body?.cancel();
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 
   it("advertises whether a remote-document token is required in /api/status", async () => {

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -1,3 +1,4 @@
+import { type AddressInfo } from "node:net";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -321,6 +322,7 @@ describe("createApp", () => {
       capabilities: {
         projectPathRequired: true,
         fileSystemBrowsing: true,
+        remoteDocuments: true,
       },
     });
     expect(response.body).not.toHaveProperty("projectDir");
@@ -519,5 +521,191 @@ describe("createApp", () => {
         "utf-8",
       ),
     ).toBe("png bytes");
+  });
+
+  it("advertises remote-document support in the status capabilities", async () => {
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+    const response = await request(app).get("/api/status");
+    expect(response.status).toBe(200);
+    expect(response.body.capabilities).toMatchObject({
+      remoteDocuments: true,
+    });
+  });
+
+  it("registers a remote document session and returns it on GET", async () => {
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+    const sessionId = "session-1";
+
+    const register = await request(app)
+      .post("/api/remote-document")
+      .send({
+        sessionId,
+        originPath: "/work/draft.md",
+        content: "# hello\n",
+      });
+
+    expect(register.status).toBe(201);
+    expect(register.body).toMatchObject({
+      id: sessionId,
+      version: expect.any(String),
+      viewerUrl: expect.stringContaining(`/?session=${sessionId}`),
+    });
+
+    const fetchResponse = await request(app).get(
+      `/api/remote-document/${sessionId}`,
+    );
+    expect(fetchResponse.status).toBe(200);
+    expect(fetchResponse.body).toMatchObject({
+      id: sessionId,
+      originPath: "/work/draft.md",
+      content: "# hello\n",
+      version: register.body.version,
+    });
+  });
+
+  it("rejects remote-document register without required fields", async () => {
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+    const response = await request(app)
+      .post("/api/remote-document")
+      .send({ sessionId: "x" });
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects a remote-document register with a duplicate session id", async () => {
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+    await request(app).post("/api/remote-document").send({
+      sessionId: "dup",
+      originPath: "/a.md",
+      content: "a",
+    });
+
+    const second = await request(app).post("/api/remote-document").send({
+      sessionId: "dup",
+      originPath: "/b.md",
+      content: "b",
+    });
+    expect(second.status).toBe(409);
+  });
+
+  it("returns 404 for unknown remote document sessions", async () => {
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+    const get = await request(app).get("/api/remote-document/missing");
+    expect(get.status).toBe(404);
+
+    const put = await request(app)
+      .put("/api/remote-document/missing")
+      .send({ content: "x" });
+    expect(put.status).toBe(404);
+  });
+
+  it("updates remote document content and bumps the version on PUT", async () => {
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+    const register = await request(app).post("/api/remote-document").send({
+      sessionId: "s2",
+      originPath: "/draft.md",
+      content: "v1",
+    });
+
+    const update = await request(app).put("/api/remote-document/s2").send({
+      content: "v2",
+      expectedVersion: register.body.version,
+    });
+
+    expect(update.status).toBe(200);
+    expect(update.body.version).not.toBe(register.body.version);
+
+    const fetched = await request(app).get("/api/remote-document/s2");
+    expect(fetched.body.content).toBe("v2");
+    expect(fetched.body.version).toBe(update.body.version);
+  });
+
+  it("returns 409 with current state when expectedVersion is stale", async () => {
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+    const register = await request(app).post("/api/remote-document").send({
+      sessionId: "s3",
+      originPath: "/a.md",
+      content: "v1",
+    });
+
+    await request(app).put("/api/remote-document/s3").send({
+      content: "v2",
+      expectedVersion: register.body.version,
+    });
+
+    const conflict = await request(app).put("/api/remote-document/s3").send({
+      content: "v-bad",
+      expectedVersion: register.body.version,
+    });
+
+    expect(conflict.status).toBe(409);
+    expect(conflict.body.current).toMatchObject({
+      id: "s3",
+      content: "v2",
+    });
+  });
+
+  it("returns 404 when opening SSE for an unknown session", async () => {
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+    const response = await request(app).get(
+      "/api/remote-document/nope/events",
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("delivers a save event over SSE when the session content is updated", async () => {
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+    const server = app.listen(0);
+    try {
+      const port = (server.address() as AddressInfo).port;
+      const sessionId = "sse-delivers";
+
+      const register = await fetch(`http://127.0.0.1:${port}/api/remote-document`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sessionId,
+          originPath: "/draft.md",
+          content: "before",
+        }),
+      });
+      expect(register.status).toBe(201);
+
+      const events = await fetch(
+        `http://127.0.0.1:${port}/api/remote-document/${sessionId}/events`,
+      );
+      expect(events.status).toBe(200);
+      const reader = events.body?.getReader();
+      if (!reader) throw new Error("Expected SSE body");
+
+      const decoder = new TextDecoder();
+      const readChunk = async () => {
+        const { value, done } = await reader.read();
+        if (done) return "";
+        return decoder.decode(value);
+      };
+
+      const connected = await readChunk();
+      expect(connected).toContain("event: connected");
+
+      const update = await fetch(
+        `http://127.0.0.1:${port}/api/remote-document/${sessionId}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: "after" }),
+        },
+      );
+      expect(update.status).toBe(200);
+
+      let saveChunk = "";
+      while (!saveChunk.includes("event: save")) {
+        saveChunk += await readChunk();
+      }
+      expect(saveChunk).toContain('"content":"after"');
+
+      reader.cancel();
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,6 +8,7 @@ import fs from "node:fs";
 import {
   ROUGHDRAFT_DEFAULT_PORT,
   ROUGHDRAFT_PUBLIC_HOST,
+  hasNonLoopbackHost,
   resolveBindHosts,
 } from "./network.js";
 import { resolveUpdateStatus } from "./update-status.js";
@@ -60,6 +61,7 @@ interface CreateAppOptions {
   packageJsonPath?: string;
   fetchImpl?: typeof fetch;
   packageName?: string;
+  remoteDocumentToken?: string;
 }
 
 interface CreateAppResult {
@@ -375,9 +377,38 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
   const serverRoot = path.resolve(options.serverRoot ?? defaultServerRoot);
   const staticDirPath = options.staticDirPath ?? staticDir;
   const fetchImpl = options.fetchImpl ?? fetch;
+  const remoteDocumentToken =
+    typeof options.remoteDocumentToken === "string" &&
+    options.remoteDocumentToken.length > 0
+      ? options.remoteDocumentToken
+      : null;
   const app = express();
   const openRequestClients = new Set<OpenRequestClient>();
   const remoteSessions = new Map<string, RemoteSession>();
+
+  function isAuthorizedRemoteDocumentRequest(req: Request): boolean {
+    if (!remoteDocumentToken) return true;
+
+    const header =
+      typeof req.headers.authorization === "string"
+        ? req.headers.authorization
+        : "";
+    if (header.startsWith("Bearer ")) {
+      const supplied = header.slice("Bearer ".length).trim();
+      if (supplied === remoteDocumentToken) return true;
+    }
+
+    const queryToken =
+      typeof req.query.token === "string" ? req.query.token : "";
+    return queryToken === remoteDocumentToken;
+  }
+
+  function rejectUnauthorizedRemoteDocumentRequest(res: Response): void {
+    res.status(401).json({
+      error:
+        "Remote document endpoints require a valid token. Set ROUGHDRAFT_TOKEN on the client or include ?token=... in the URL.",
+    });
+  }
 
   const remoteSessionSweeper = setInterval(() => {
     const now = Date.now();
@@ -631,6 +662,7 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
         projectPathRequired: true,
         fileSystemBrowsing: true,
         remoteDocuments: true,
+        remoteDocumentTokenRequired: remoteDocumentToken !== null,
       },
     });
   });
@@ -701,6 +733,10 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
   });
 
   app.post("/api/remote-document", (req, res) => {
+    if (!isAuthorizedRemoteDocumentRequest(req)) {
+      rejectUnauthorizedRemoteDocumentRequest(res);
+      return;
+    }
     const payload = req.body as RemoteDocumentRegisterPayload;
     const sessionId =
       typeof payload.sessionId === "string" &&
@@ -751,6 +787,10 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
   });
 
   app.get("/api/remote-document/:id", (req, res) => {
+    if (!isAuthorizedRemoteDocumentRequest(req)) {
+      rejectUnauthorizedRemoteDocumentRequest(res);
+      return;
+    }
     const session = remoteSessions.get(req.params.id);
     if (!session) {
       res.status(404).json({ error: "Remote document session not found" });
@@ -760,6 +800,10 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
   });
 
   app.put("/api/remote-document/:id", (req, res) => {
+    if (!isAuthorizedRemoteDocumentRequest(req)) {
+      rejectUnauthorizedRemoteDocumentRequest(res);
+      return;
+    }
     const session = remoteSessions.get(req.params.id);
     if (!session) {
       res.status(404).json({ error: "Remote document session not found" });
@@ -819,6 +863,10 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
   });
 
   app.get("/api/remote-document/:id/events", (req, res) => {
+    if (!isAuthorizedRemoteDocumentRequest(req)) {
+      rejectUnauthorizedRemoteDocumentRequest(res);
+      return;
+    }
     const session = remoteSessions.get(req.params.id);
     if (!session) {
       res.status(404).json({ error: "Remote document session not found" });
@@ -1008,14 +1056,34 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
   return { app, port };
 }
 
+export const ROUGHDRAFT_TOKEN_ENV = "ROUGHDRAFT_TOKEN";
+
 export async function createServer(
   port = ROUGHDRAFT_DEFAULT_PORT,
   projectDir?: string,
 ): Promise<void> {
-  const { app } = createApp({ port, projectDir });
-  const listeningHosts: string[] = [];
-
   const bindHosts = resolveBindHosts();
+  const remoteDocumentToken = process.env[ROUGHDRAFT_TOKEN_ENV] ?? "";
+
+  if (hasNonLoopbackHost(bindHosts) && remoteDocumentToken.length === 0) {
+    throw new Error(
+      [
+        `Roughdraft refuses to bind ${bindHosts.join(", ")} without a token.`,
+        "Non-loopback bindings expose the remote-document endpoints, which can",
+        "rewrite files on every connected CLI machine. Set ROUGHDRAFT_TOKEN to",
+        "a strong secret and pass the same value to your CLI before retrying,",
+        "or remove ROUGHDRAFT_BIND_HOST to keep loopback-only.",
+      ].join(" "),
+    );
+  }
+
+  const { app } = createApp({
+    port,
+    projectDir,
+    remoteDocumentToken:
+      remoteDocumentToken.length > 0 ? remoteDocumentToken : undefined,
+  });
+  const listeningHosts: string[] = [];
 
   await Promise.all(
     bindHosts.map(

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -733,7 +733,7 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
       content,
       version: remoteSessionVersion(content),
       client: null,
-      disconnectedAt: Date.now(),
+      disconnectedAt: null,
     };
     remoteSessions.set(sessionId, session);
 
@@ -789,13 +789,30 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
     session.content = content;
     session.version = remoteSessionVersion(content);
 
+    let deliveredToClient = true;
     if (session.client) {
-      session.client.write(
-        `event: save\ndata: ${JSON.stringify({
-          content: session.content,
-          version: session.version,
-        })}\n\n`,
-      );
+      try {
+        session.client.write(
+          `event: save\ndata: ${JSON.stringify({
+            content: session.content,
+            version: session.version,
+          })}\n\n`,
+        );
+      } catch {
+        deliveredToClient = false;
+        session.client = null;
+        session.disconnectedAt = Date.now();
+      }
+    } else {
+      deliveredToClient = false;
+    }
+
+    if (!deliveredToClient) {
+      res.status(503).json({
+        error: "No active CLI session; save not delivered to disk.",
+        version: session.version,
+      });
+      return;
     }
 
     res.json({ id: session.id, version: session.version });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -85,7 +85,8 @@ interface RemoteSession {
   originPath: string;
   content: string;
   version: string;
-  client: Response | null;
+  saveClient: Response | null;
+  viewers: Set<Response>;
   disconnectedAt: number | null;
 }
 
@@ -123,6 +124,14 @@ function remoteSessionView(session: RemoteSession): {
     content: session.content,
     version: session.version,
   };
+}
+
+function writeRemoteSessionEvent(
+  response: Response,
+  event: string,
+  data: unknown,
+): void {
+  response.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
 }
 
 function listMdFiles(projectDir: string): string[] {
@@ -398,15 +407,21 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
       if (supplied === remoteDocumentToken) return true;
     }
 
+    const acceptsQueryToken =
+      req.method === "GET" &&
+      req.path.startsWith("/api/remote-document/") &&
+      req.path.endsWith("/events");
     const queryToken =
-      typeof req.query.token === "string" ? req.query.token : "";
+      acceptsQueryToken && typeof req.query.token === "string"
+        ? req.query.token
+        : "";
     return queryToken === remoteDocumentToken;
   }
 
   function rejectUnauthorizedRemoteDocumentRequest(res: Response): void {
     res.status(401).json({
       error:
-        "Remote document endpoints require a valid token. Set ROUGHDRAFT_TOKEN on the client or include ?token=... in the URL.",
+        "Remote document endpoints require a valid token. Set ROUGHDRAFT_TOKEN on the client; browser event streams may include ?token=... in the URL.",
     });
   }
 
@@ -768,7 +783,8 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
       originPath,
       content,
       version: remoteSessionVersion(content),
-      client: null,
+      saveClient: null,
+      viewers: new Set<Response>(),
       disconnectedAt: null,
     };
     remoteSessions.set(sessionId, session);
@@ -834,17 +850,15 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
     session.version = remoteSessionVersion(content);
 
     let deliveredToClient = true;
-    if (session.client) {
+    if (session.saveClient) {
       try {
-        session.client.write(
-          `event: save\ndata: ${JSON.stringify({
-            content: session.content,
-            version: session.version,
-          })}\n\n`,
-        );
+        writeRemoteSessionEvent(session.saveClient, "save", {
+          content: session.content,
+          version: session.version,
+        });
       } catch {
         deliveredToClient = false;
-        session.client = null;
+        session.saveClient = null;
         session.disconnectedAt = Date.now();
       }
     } else {
@@ -873,24 +887,45 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
       return;
     }
 
+    const role = req.query.role === "viewer" ? "viewer" : "cli";
+
     res.setHeader("Content-Type", "text/event-stream");
     res.setHeader("Cache-Control", "no-cache, no-transform");
     res.setHeader("Connection", "keep-alive");
     res.flushHeaders?.();
 
-    if (session.client) {
-      session.client.end();
-    }
+    if (role === "cli") {
+      if (session.saveClient) {
+        session.saveClient.end();
+      }
 
-    session.client = res;
-    session.disconnectedAt = null;
+      session.saveClient = res;
+      session.disconnectedAt = null;
 
-    res.write(
-      `event: connected\ndata: ${JSON.stringify({
+      writeRemoteSessionEvent(res, "connected", {
         id: session.id,
+        role,
         version: session.version,
-      })}\n\n`,
-    );
+      });
+      for (const viewer of session.viewers) {
+        writeRemoteSessionEvent(viewer, "connected", {
+          id: session.id,
+          role: "viewer",
+          version: session.version,
+        });
+      }
+    } else {
+      session.viewers.add(res);
+      writeRemoteSessionEvent(
+        res,
+        session.saveClient ? "connected" : "disconnected",
+        {
+          id: session.id,
+          role,
+          version: session.version,
+        },
+      );
+    }
 
     const keepAlive = setInterval(() => {
       res.write(": keep-alive\n\n");
@@ -898,9 +933,18 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
 
     req.on("close", () => {
       clearInterval(keepAlive);
-      if (session.client === res) {
-        session.client = null;
+      if (role === "cli" && session.saveClient === res) {
+        session.saveClient = null;
         session.disconnectedAt = Date.now();
+        for (const viewer of session.viewers) {
+          writeRemoteSessionEvent(viewer, "disconnected", {
+            id: session.id,
+            role: "viewer",
+            version: session.version,
+          });
+        }
+      } else if (role === "viewer") {
+        session.viewers.delete(res);
       }
     });
   });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -109,9 +109,7 @@ function remoteSessionVersion(content: string): string {
   return `${hash}:${crypto.randomUUID()}`;
 }
 
-function remoteSessionView(
-  session: RemoteSession,
-): {
+function remoteSessionView(session: RemoteSession): {
   id: string;
   originPath: string;
   content: string;
@@ -705,7 +703,8 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
   app.post("/api/remote-document", (req, res) => {
     const payload = req.body as RemoteDocumentRegisterPayload;
     const sessionId =
-      typeof payload.sessionId === "string" && payload.sessionId.trim().length > 0
+      typeof payload.sessionId === "string" &&
+      payload.sessionId.trim().length > 0
         ? payload.sessionId.trim()
         : null;
     const originPath =
@@ -713,7 +712,8 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
       payload.originPath.trim().length > 0
         ? payload.originPath.trim()
         : null;
-    const content = typeof payload.content === "string" ? payload.content : null;
+    const content =
+      typeof payload.content === "string" ? payload.content : null;
 
     if (!sessionId || !originPath || content === null) {
       res
@@ -767,7 +767,8 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
     }
 
     const payload = req.body as RemoteDocumentSavePayload;
-    const content = typeof payload.content === "string" ? payload.content : null;
+    const content =
+      typeof payload.content === "string" ? payload.content : null;
 
     if (content === null) {
       res.status(400).json({ error: "content is required" });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -7,8 +7,8 @@ import path from "node:path";
 import fs from "node:fs";
 import {
   ROUGHDRAFT_DEFAULT_PORT,
-  ROUGHDRAFT_LOOPBACK_HOSTS,
   ROUGHDRAFT_PUBLIC_HOST,
+  resolveBindHosts,
 } from "./network.js";
 import { resolveUpdateStatus } from "./update-status.js";
 
@@ -800,8 +800,10 @@ export async function createServer(
   const { app } = createApp({ port, projectDir });
   const listeningHosts: string[] = [];
 
+  const bindHosts = resolveBindHosts();
+
   await Promise.all(
-    ROUGHDRAFT_LOOPBACK_HOSTS.map(
+    bindHosts.map(
       (host) =>
         new Promise<void>((resolve, reject) => {
           const server = createHttpServer(app);
@@ -827,7 +829,9 @@ export async function createServer(
   );
 
   if (listeningHosts.length === 0) {
-    throw new Error("Roughdraft could not bind to any loopback interface.");
+    throw new Error(
+      `Roughdraft could not bind to any host (tried: ${bindHosts.join(", ")}).`,
+    );
   }
 
   console.log(

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -78,7 +78,52 @@ interface OpenRequestPayload {
   url?: string;
 }
 
+interface RemoteSession {
+  id: string;
+  originPath: string;
+  content: string;
+  version: string;
+  client: Response | null;
+  disconnectedAt: number | null;
+}
+
+interface RemoteDocumentRegisterPayload {
+  sessionId?: string;
+  originPath?: string;
+  content?: string;
+}
+
+interface RemoteDocumentSavePayload {
+  content?: string;
+  expectedVersion?: string;
+}
+
+const REMOTE_SESSION_TTL_MS = 5 * 60 * 1000;
+const REMOTE_SESSION_SWEEP_INTERVAL_MS = 60 * 1000;
+const REMOTE_SESSION_KEEPALIVE_MS = 15 * 1000;
+
 let nextOpenRequestClientId = 1;
+
+function remoteSessionVersion(content: string): string {
+  const hash = crypto.createHash("sha256").update(content).digest("hex");
+  return `${hash}:${crypto.randomUUID()}`;
+}
+
+function remoteSessionView(
+  session: RemoteSession,
+): {
+  id: string;
+  originPath: string;
+  content: string;
+  version: string;
+} {
+  return {
+    id: session.id,
+    originPath: session.originPath,
+    content: session.content,
+    version: session.version,
+  };
+}
 
 function listMdFiles(projectDir: string): string[] {
   try {
@@ -334,6 +379,20 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
   const fetchImpl = options.fetchImpl ?? fetch;
   const app = express();
   const openRequestClients = new Set<OpenRequestClient>();
+  const remoteSessions = new Map<string, RemoteSession>();
+
+  const remoteSessionSweeper = setInterval(() => {
+    const now = Date.now();
+    for (const [id, session] of remoteSessions) {
+      if (
+        session.disconnectedAt !== null &&
+        now - session.disconnectedAt > REMOTE_SESSION_TTL_MS
+      ) {
+        remoteSessions.delete(id);
+      }
+    }
+  }, REMOTE_SESSION_SWEEP_INTERVAL_MS);
+  remoteSessionSweeper.unref?.();
 
   app.use(express.json({ limit: "50mb" }));
 
@@ -573,6 +632,7 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
       capabilities: {
         projectPathRequired: true,
         fileSystemBrowsing: true,
+        remoteDocuments: true,
       },
     });
   });
@@ -640,6 +700,143 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
       })}\n\n`,
     );
     res.json({ delivered: true });
+  });
+
+  app.post("/api/remote-document", (req, res) => {
+    const payload = req.body as RemoteDocumentRegisterPayload;
+    const sessionId =
+      typeof payload.sessionId === "string" && payload.sessionId.trim().length > 0
+        ? payload.sessionId.trim()
+        : null;
+    const originPath =
+      typeof payload.originPath === "string" &&
+      payload.originPath.trim().length > 0
+        ? payload.originPath.trim()
+        : null;
+    const content = typeof payload.content === "string" ? payload.content : null;
+
+    if (!sessionId || !originPath || content === null) {
+      res
+        .status(400)
+        .json({ error: "sessionId, originPath, and content are required" });
+      return;
+    }
+
+    if (remoteSessions.has(sessionId)) {
+      res.status(409).json({ error: "session already exists" });
+      return;
+    }
+
+    const session: RemoteSession = {
+      id: sessionId,
+      originPath,
+      content,
+      version: remoteSessionVersion(content),
+      client: null,
+      disconnectedAt: Date.now(),
+    };
+    remoteSessions.set(sessionId, session);
+
+    const host = req.get("host");
+    const viewerUrl =
+      host !== undefined
+        ? `${req.protocol}://${host}/?session=${encodeURIComponent(sessionId)}`
+        : null;
+
+    res.status(201).json({
+      id: session.id,
+      version: session.version,
+      viewerUrl,
+    });
+  });
+
+  app.get("/api/remote-document/:id", (req, res) => {
+    const session = remoteSessions.get(req.params.id);
+    if (!session) {
+      res.status(404).json({ error: "Remote document session not found" });
+      return;
+    }
+    res.json(remoteSessionView(session));
+  });
+
+  app.put("/api/remote-document/:id", (req, res) => {
+    const session = remoteSessions.get(req.params.id);
+    if (!session) {
+      res.status(404).json({ error: "Remote document session not found" });
+      return;
+    }
+
+    const payload = req.body as RemoteDocumentSavePayload;
+    const content = typeof payload.content === "string" ? payload.content : null;
+
+    if (content === null) {
+      res.status(400).json({ error: "content is required" });
+      return;
+    }
+
+    if (
+      typeof payload.expectedVersion === "string" &&
+      payload.expectedVersion !== session.version
+    ) {
+      res.status(409).json({
+        error: "Remote document changed",
+        current: remoteSessionView(session),
+      });
+      return;
+    }
+
+    session.content = content;
+    session.version = remoteSessionVersion(content);
+
+    if (session.client) {
+      session.client.write(
+        `event: save\ndata: ${JSON.stringify({
+          content: session.content,
+          version: session.version,
+        })}\n\n`,
+      );
+    }
+
+    res.json({ id: session.id, version: session.version });
+  });
+
+  app.get("/api/remote-document/:id/events", (req, res) => {
+    const session = remoteSessions.get(req.params.id);
+    if (!session) {
+      res.status(404).json({ error: "Remote document session not found" });
+      return;
+    }
+
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache, no-transform");
+    res.setHeader("Connection", "keep-alive");
+    res.flushHeaders?.();
+
+    if (session.client) {
+      session.client.end();
+    }
+
+    session.client = res;
+    session.disconnectedAt = null;
+
+    res.write(
+      `event: connected\ndata: ${JSON.stringify({
+        id: session.id,
+        version: session.version,
+      })}\n\n`,
+    );
+
+    const keepAlive = setInterval(() => {
+      res.write(": keep-alive\n\n");
+    }, REMOTE_SESSION_KEEPALIVE_MS);
+
+    req.on("close", () => {
+      clearInterval(keepAlive);
+      if (session.client === res) {
+        session.client = null;
+        session.disconnectedAt = Date.now();
+      }
+    });
   });
 
   app.get("/api/update-status", async (_req, res) => {

--- a/packages/server/src/network.test.ts
+++ b/packages/server/src/network.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   ROUGHDRAFT_BIND_HOST_ENV,
   ROUGHDRAFT_LOOPBACK_HOSTS,
+  hasNonLoopbackHost,
+  isLoopbackHost,
   resolveBindHosts,
 } from "./network";
 
@@ -40,5 +42,35 @@ describe("resolveBindHosts", () => {
     expect(resolveBindHosts({ [ROUGHDRAFT_BIND_HOST_ENV]: " , , " })).toEqual(
       ROUGHDRAFT_LOOPBACK_HOSTS,
     );
+  });
+});
+
+describe("isLoopbackHost", () => {
+  it("treats 127.0.0.1, ::1, and localhost as loopback", () => {
+    expect(isLoopbackHost("127.0.0.1")).toBe(true);
+    expect(isLoopbackHost("::1")).toBe(true);
+    expect(isLoopbackHost("localhost")).toBe(true);
+  });
+
+  it("treats every 127.0.0.0/8 address as loopback", () => {
+    expect(isLoopbackHost("127.0.0.2")).toBe(true);
+    expect(isLoopbackHost("127.255.255.254")).toBe(true);
+  });
+
+  it("rejects 0.0.0.0 and routable IPs", () => {
+    expect(isLoopbackHost("0.0.0.0")).toBe(false);
+    expect(isLoopbackHost("100.73.51.106")).toBe(false);
+    expect(isLoopbackHost("192.168.1.1")).toBe(false);
+  });
+});
+
+describe("hasNonLoopbackHost", () => {
+  it("returns false for the default loopback list", () => {
+    expect(hasNonLoopbackHost(ROUGHDRAFT_LOOPBACK_HOSTS)).toBe(false);
+  });
+
+  it("returns true when any host is non-loopback", () => {
+    expect(hasNonLoopbackHost(["127.0.0.1", "0.0.0.0"])).toBe(true);
+    expect(hasNonLoopbackHost(["100.73.51.106"])).toBe(true);
   });
 });

--- a/packages/server/src/network.test.ts
+++ b/packages/server/src/network.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  ROUGHDRAFT_BIND_HOST_ENV,
+  ROUGHDRAFT_LOOPBACK_HOSTS,
+  resolveBindHosts,
+} from "./network";
+
+describe("resolveBindHosts", () => {
+  it("returns the default loopback list when the env var is unset", () => {
+    expect(resolveBindHosts({})).toEqual(ROUGHDRAFT_LOOPBACK_HOSTS);
+  });
+
+  it("returns a single host when the env var names one host", () => {
+    expect(
+      resolveBindHosts({ [ROUGHDRAFT_BIND_HOST_ENV]: "0.0.0.0" }),
+    ).toEqual(["0.0.0.0"]);
+  });
+
+  it("returns multiple hosts from a comma-separated value", () => {
+    expect(
+      resolveBindHosts({ [ROUGHDRAFT_BIND_HOST_ENV]: "0.0.0.0,::" }),
+    ).toEqual(["0.0.0.0", "::"]);
+  });
+
+  it("trims whitespace around comma-separated hosts", () => {
+    expect(
+      resolveBindHosts({
+        [ROUGHDRAFT_BIND_HOST_ENV]: " 127.0.0.1 , ::1 ",
+      }),
+    ).toEqual(["127.0.0.1", "::1"]);
+  });
+
+  it("falls back to the loopback list when the env var is an empty string", () => {
+    expect(
+      resolveBindHosts({ [ROUGHDRAFT_BIND_HOST_ENV]: "" }),
+    ).toEqual(ROUGHDRAFT_LOOPBACK_HOSTS);
+  });
+
+  it("falls back to the loopback list when the env var is only commas and whitespace", () => {
+    expect(
+      resolveBindHosts({ [ROUGHDRAFT_BIND_HOST_ENV]: " , , " }),
+    ).toEqual(ROUGHDRAFT_LOOPBACK_HOSTS);
+  });
+});

--- a/packages/server/src/network.test.ts
+++ b/packages/server/src/network.test.ts
@@ -11,9 +11,9 @@ describe("resolveBindHosts", () => {
   });
 
   it("returns a single host when the env var names one host", () => {
-    expect(
-      resolveBindHosts({ [ROUGHDRAFT_BIND_HOST_ENV]: "0.0.0.0" }),
-    ).toEqual(["0.0.0.0"]);
+    expect(resolveBindHosts({ [ROUGHDRAFT_BIND_HOST_ENV]: "0.0.0.0" })).toEqual(
+      ["0.0.0.0"],
+    );
   });
 
   it("returns multiple hosts from a comma-separated value", () => {
@@ -31,14 +31,14 @@ describe("resolveBindHosts", () => {
   });
 
   it("falls back to the loopback list when the env var is an empty string", () => {
-    expect(
-      resolveBindHosts({ [ROUGHDRAFT_BIND_HOST_ENV]: "" }),
-    ).toEqual(ROUGHDRAFT_LOOPBACK_HOSTS);
+    expect(resolveBindHosts({ [ROUGHDRAFT_BIND_HOST_ENV]: "" })).toEqual(
+      ROUGHDRAFT_LOOPBACK_HOSTS,
+    );
   });
 
   it("falls back to the loopback list when the env var is only commas and whitespace", () => {
-    expect(
-      resolveBindHosts({ [ROUGHDRAFT_BIND_HOST_ENV]: " , , " }),
-    ).toEqual(ROUGHDRAFT_LOOPBACK_HOSTS);
+    expect(resolveBindHosts({ [ROUGHDRAFT_BIND_HOST_ENV]: " , , " })).toEqual(
+      ROUGHDRAFT_LOOPBACK_HOSTS,
+    );
   });
 });

--- a/packages/server/src/network.ts
+++ b/packages/server/src/network.ts
@@ -5,6 +5,11 @@ export const ROUGHDRAFT_PUBLIC_HOST = "localhost";
 
 export const ROUGHDRAFT_BIND_HOST_ENV = "ROUGHDRAFT_BIND_HOST";
 
+const LOOPBACK_HOST_NAMES = new Set<string>([
+  ...ROUGHDRAFT_LOOPBACK_HOSTS,
+  "localhost",
+]);
+
 export function resolveBindHosts(
   env: NodeJS.ProcessEnv = process.env,
 ): readonly string[] {
@@ -24,4 +29,15 @@ export function resolveBindHosts(
   }
 
   return hosts;
+}
+
+export function isLoopbackHost(host: string): boolean {
+  if (LOOPBACK_HOST_NAMES.has(host)) return true;
+  // Any address in 127.0.0.0/8 is loopback (RFC 5735).
+  if (host.startsWith("127.")) return true;
+  return false;
+}
+
+export function hasNonLoopbackHost(hosts: readonly string[]): boolean {
+  return hosts.some((host) => !isLoopbackHost(host));
 }

--- a/packages/server/src/network.ts
+++ b/packages/server/src/network.ts
@@ -2,3 +2,26 @@ export { ROUGHDRAFT_DEFAULT_PORT } from "../defaults.mjs";
 export const ROUGHDRAFT_BIND_HOST = "127.0.0.1";
 export const ROUGHDRAFT_LOOPBACK_HOSTS = ["127.0.0.1", "::1"] as const;
 export const ROUGHDRAFT_PUBLIC_HOST = "localhost";
+
+export const ROUGHDRAFT_BIND_HOST_ENV = "ROUGHDRAFT_BIND_HOST";
+
+export function resolveBindHosts(
+  env: NodeJS.ProcessEnv = process.env,
+): readonly string[] {
+  const raw = env[ROUGHDRAFT_BIND_HOST_ENV];
+
+  if (raw === undefined) {
+    return ROUGHDRAFT_LOOPBACK_HOSTS;
+  }
+
+  const hosts = raw
+    .split(",")
+    .map((host) => host.trim())
+    .filter((host) => host.length > 0);
+
+  if (hosts.length === 0) {
+    return ROUGHDRAFT_LOOPBACK_HOSTS;
+  }
+
+  return hosts;
+}


### PR DESCRIPTION
## Summary

Adds a remote-document mode that lets a CLI on one machine surface a markdown file in a Roughdraft instance running on another machine. Today the server reads/writes files from local disk; this PR adds a parallel "remote" mode where the file is owned by a CLI on a different machine and the server is just an editor for it.

Designed around Kieran's daily workflow: laptop is the human-facing surface; agents (Claude Code) run on SSH-targeted boxes (Mac mini, Hetzner Linux runner) where the markdown lives. Today, surfacing those files in Roughdraft requires either running Roughdraft on the SSH box (per-box clutter, no roaming) or copying files manually. The user wants one persistent Roughdraft they browse to from any device, with the SSH-side agent able to push files into it and saves round-tripping back to disk.

## What's in the PR

- **Server endpoints**: `POST/GET/PUT /api/remote-document/:id` and an SSE channel `/api/remote-document/:id/events`. Sessions live in an in-memory `Map<sessionId, RemoteSession>` with a 5-minute TTL eviction sweeper. The SSE channel is held by the CLI; PUT pushes a save event through it. (`packages/server/src/index.ts`)
- **CLI remote-mode**: `ROUGHDRAFT_HOST=<url> roughdraft open foo.md` reads the file, registers a session, opens the SSE channel, and atomically writes save events back to disk. Local-mode behavior is unchanged when `ROUGHDRAFT_HOST` is unset. (`packages/server/src/cli.ts`)
- **Frontend backend**: `RemoteBackend` implements `StorageBackend` against `/api/remote-document/:id`. `detect-backend.ts` reads `?session=` from the URL and chooses `RemoteBackend` when `/api/status` advertises `capabilities.remoteDocuments`. (`packages/app/src/{remote-backend.ts,detect-backend.ts,App.tsx}`)
- **Disconnect banner**: top-of-page indicator that shows green "connected" or amber "disconnected" depending on the SSE channel state. Backed by `RemoteBackend.onSessionStatusChange`. (`packages/app/src/components/RemoteSessionBanner.tsx`)
- **Token auth + secure-by-default bind**: every `/api/remote-document/*` endpoint requires `Authorization: Bearer <ROUGHDRAFT_TOKEN>` (or `?token=` for SSE since EventSource can't set headers). `createServer()` refuses to bind a non-loopback host without a token. The CLI's printed viewer URL embeds the token so the browser tab authenticates. Loopback-only deployments stay back-compatible — no token, no behavior change. (`packages/server/src/{network.ts,index.ts,cli.ts}`, `packages/app/src/{remote-backend.ts,detect-backend.ts}`)
- **`ROUGHDRAFT_BIND_HOST` env var**: enables binding to `0.0.0.0` or a specific Tailscale interface so the hosted Roughdraft is reachable across the tailnet.
- **ADR clarifications + brainstorm + plan**: ADR-0001 / ADR-0004 gain "Clarification (2026-04-30)" sections; new sections in `docs/brainstorms/remote-document-mode-requirements.md` and `docs/plans/2026-04-30-001-feat-remote-document-mode-plan.md`.

## Process

This PR was built end-to-end through the compound-engineering pipeline:

1. `/ce-brainstorm` produced `docs/brainstorms/remote-document-mode-requirements.md` after we settled on the Mac-mini-hosted approach.
2. `/ce-plan` produced `docs/plans/2026-04-30-001-feat-remote-document-mode-plan.md` with 6 implementation units (U1–U6), enumerated test scenarios per unit, and explicit ADR conflicts to surface.
3. `/ce-work` shipped each unit as its own commit.
4. `/ce-code-review mode:autofix` ran 12 reviewer personas in parallel. 6 safe-auto fixes applied (TTL clock fix, silent-data-loss try/catch on PUT, fetch timeouts, CRLF SSE parser tolerance, env-var help block, EventSource-onerror gating). The full run summary is in `.context/compound-engineering/ce-code-review/20260430-113942-e443f9e7/run-summary.md` (gitignored).
5. The P0 finding from the review (no auth on the new endpoints + canonical `0.0.0.0` deployment = unauthenticated arbitrary file overwrite primitive on every connected CLI machine) was addressed in the final commit with the token + secure-by-default bind work.

## Test plan

- [ ] `pnpm check` — ✅ passes locally (lint clean, 232 tests pass: 9 rfm + 136 app + 87 server, both builds succeed)
- [ ] Manual smoke: `ROUGHDRAFT_BIND_HOST=0.0.0.0 ROUGHDRAFT_TOKEN=<secret> roughdraft start` on Mac mini; from Hetzner SSH session, `ROUGHDRAFT_HOST=http://mac-mini.tailnet:7373 ROUGHDRAFT_TOKEN=<secret> roughdraft open plan.md`; click viewer URL on laptop, edit and save, verify the file on Hetzner reflects the new content
- [ ] Verify loopback-only mode (no `ROUGHDRAFT_BIND_HOST`, no token) still works exactly as before
- [ ] Verify `roughdraft open` without `ROUGHDRAFT_HOST` is a regression-free local path

## Known follow-ups (deferred to separate PRs)

- Replace the raw-Tailwind banner with a shadcn `Alert` primitive (AGENTS.md compliance — needs `components/ui/alert.tsx` first)
- Test coverage gaps surfaced by the review: TTL eviction with fake timers, SSE heartbeat, `parseSseEvents` direct unit tests, `detect-backend` remote branch, `RemoteBackend.watchMarkdownFile` EventSource path
- `--detach` flag for agent-friendly remote mode (currently the CLI blocks indefinitely holding the SSE)
- SIGINT exit code 130 (plan committed to it; not yet wired)
- Empty-content save-event safeguard (currently silently truncates; may be intentional)
- `--json` mode NDJSON output for save events