### PR TITLE
Add Test Desiderata agent guidance

### DIFF
--- a/.codex/skills/test-desiderata/SKILL.md
+++ b/.codex/skills/test-desiderata/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: test-desiderata
+description: Apply Kent Beck's Test Desiderata to plan, add, rewrite, or review tests. Use when Codex is designing a test strategy, adding or changing unit/integration/e2e tests, reproducing a bug with a failing test, reviewing test quality, deciding what level of test to write, or explaining test tradeoffs.
+---
+
+# Test Desiderata
+
+Use the desiderata as design lenses, not a rigid checklist. The goal is to optimize the value of the tests by making explicit tradeoffs among valuable properties. Source: https://testdesiderata.com/
+
+## Workflow
+
+1. State the behavior or risk the test must protect in one sentence before choosing the test level.
+2. Choose the fastest test level that remains predictive of production behavior. Escalate from pure unit tests to integration or e2e tests only when the boundary itself is the behavior under test.
+3. Prefer tests that fail for user-visible behavior changes over tests that fail because a private implementation detail was refactored.
+4. Make the failure diagnostic: the test name, fixture, and assertion should point to the broken behavior without requiring a long investigation.
+5. Keep setup local to the test or an explicit helper that preserves isolation and determinism.
+6. Run the narrow relevant command first, then the broader package or repo command when the change is broad enough to justify it.
+7. In the final response, name the command run and any meaningful test tradeoff made.
+
+## Desiderata
+
+- Isolated: test results should not depend on execution order or shared mutable state.
+- Composable: independently valuable tests should combine without hidden coupling or cascading setup requirements.
+- Deterministic: unchanged code and inputs should produce the same result every run.
+- Fast: tests should be quick enough that agents and humans will run them while working.
+- Writable: tests should be cheap to create relative to the behavior protected.
+- Readable: tests should make their motivation and expected behavior clear to the next maintainer.
+- Behavioral: tests should change result when the behavior under test changes.
+- Structure-insensitive: tests should survive internal refactors that preserve behavior.
+- Automated: tests should run without manual intervention.
+- Specific: failures should make the likely cause obvious.
+- Predictive: passing tests should give justified confidence that production behavior is acceptable.
+- Inspiring: the suite should increase confidence, not create noise, flakes, or avoidance.
+
+## Repo Defaults
+
+- For bug fixes, create the smallest failing behavioral test before implementation, following the repo's `AGENTS.md` bug-fix workflow.
+- Use `slog` before or during test work when runtime behavior is uncertain and static reading is not enough.
+- For Markdown and CriticMarkup behavior, prefer fixture or round-trip coverage that protects the file-format contract.
+- For UI behavior, prefer component tests for local interaction logic and Playwright only when browser, file, server, or cross-view behavior is the product risk.
+- Avoid snapshot-heavy or DOM-structure-heavy assertions unless the rendered structure itself is the public contract.
+
+## Tradeoff Notes
+
+When a test intentionally sacrifices one desideratum for another, make that explicit in a short comment or final summary. Common acceptable tradeoffs:
+
+- Slower e2e coverage for a critical file-system or browser integration path.
+- A slightly larger fixture when readability and production similarity matter more than minimal setup.
+- Multiple focused tests instead of one broad test when specificity and determinism matter more than brevity.

--- a/.codex/skills/test-desiderata/agents/openai.yaml
+++ b/.codex/skills/test-desiderata/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Test Desiderata"
+  short_description: "Review tests against Kent Beck's desiderata"
+  default_prompt: "Use $test-desiderata to review this test plan or test change against Kent Beck's desiderata."

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@ test-results
 .DS_Store
 *.tsbuildinfo
 sandbox
-.codex/
+.codex/*
+!.codex/skills/
+!.codex/skills/**
 .conductor/
 .claude/
 .agents/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,23 +1,29 @@
 # Roughdraft Agent Instructions
 
+## Testing Principles
+
+Use the repo-local `test-desiderata` skill when planning, adding, changing, or reviewing tests. Keep the core bar visible even when the skill is not loaded: tests should optimize for Kent Beck's Test Desiderata (https://testdesiderata.com/) as context-specific tradeoffs, not as a mechanical checklist.
+
+Before finalizing test work, check that the tests are:
+
+- Isolated: results do not depend on execution order or shared mutable state.
+- Composable: tests combine without hidden coupling.
+- Deterministic: unchanged code and inputs produce the same result every run.
+- Fast: tests are quick enough to run during normal development.
+- Writable: tests are cheap to create relative to the behavior protected.
+- Readable: tests make their motivation and expected behavior clear.
+- Behavioral: tests fail when the behavior under test changes.
+- Structure-insensitive: tests survive internal refactors that preserve behavior.
+- Automated: tests run without manual intervention.
+- Specific: failures point clearly at the broken behavior.
+- Predictive: passing tests justify confidence in production behavior.
+- Inspiring: the suite increases confidence instead of creating noise or avoidance.
+
+Prefer the fastest test that remains predictive. Escalate to integration or e2e coverage when the boundary itself is the behavior under test, and make any meaningful tradeoff explicit in the final summary.
+
 ## Bug Fix Workflow
 
 When the user asks you to fix something, first have a subagent reproduce the bug with a failing test case before implementing the fix. The subagent should focus on the smallest behavioral test that demonstrates the problem, and should report the failing command, changed test files, and why the failure captures the requested bug.
-
-Tests should follow Kent Beck's desiderata:
-
-- Isolated: tests should return the same results regardless of the order in which they are run.
-- Composable: if tests are isolated, then 1, 10, 100, or 1,000,000 tests can run and get the same results.
-- Fast: tests should run quickly.
-- Inspiring: passing tests should inspire confidence.
-- Writable: tests should be cheap to write relative to the cost of the code being tested.
-- Readable: tests should be comprehensible for the reader, invoking the motivation for writing this particular test.
-- Behavioral: tests should be sensitive to changes in the behavior of the code under test. If the behavior changes, the test result should change.
-- Structure-insensitive: tests should not change their result if the structure of the code changes.
-- Automated: tests should run without human intervention.
-- Specific: if a test fails, the cause of the failure should be obvious.
-- Deterministic: if nothing changes, the test result should not change.
-- Predictive: if the tests all pass, then the code under test should be suitable for production.
 
 ## Slog Default
 


### PR DESCRIPTION
Summary:
- Add always-on testing principles in AGENTS.md based on Kent Beck's Test Desiderata.
- Add a repo-local test-desiderata Codex skill for planning, writing, and reviewing tests.
- Allow repo-vendored .codex/skills files through .gitignore.

Tests:
- pnpm check
- python3 /Users/nbaschez/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/test-desiderata