### PR TITLE
Polish homepage format preview

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -231,7 +231,7 @@ export function Homepage({
               />
               <DialogContent>
                 <DialogHeader>
-                  <DialogTitle>Copy this into your coding agent</DialogTitle>
+                  <DialogTitle>Give this to your coding agent</DialogTitle>
                   <DialogDescription>
                     This prompt tells the agent how to install Roughdraft and
                     set up the review workflow.

--- a/packages/app/src/RoughdraftFormatDemo.tsx
+++ b/packages/app/src/RoughdraftFormatDemo.tsx
@@ -100,7 +100,7 @@ export function RoughdraftFormatDemo() {
       aria-labelledby="roughdraft-markdown-heading"
       className="rfm-format-demo mx-auto mt-20 w-full max-w-none border-t border-slate-200 pt-10 text-left dark:border-slate-700 sm:mt-24"
     >
-      <div className="mx-auto w-full">
+      <div className="rfm-format-demo-intro mx-auto w-full px-4">
         <div className="max-w-3xl">
           <p className="text-xs font-medium tracking-[0.16em] text-stone-500 uppercase dark:text-stone-400">
             Roughdraft flavored Markdown
@@ -135,7 +135,7 @@ export function RoughdraftFormatDemo() {
       </div>
 
       <div
-        className="mx-auto mt-5 flex w-full flex-wrap gap-2"
+        className="rfm-format-demo-examples mx-auto mt-5 flex w-full flex-wrap gap-2 px-4"
         role="group"
         aria-label="Format examples"
       >
@@ -153,22 +153,24 @@ export function RoughdraftFormatDemo() {
       </div>
 
       <div className="mx-auto mt-5 grid w-full gap-3 lg:grid-cols-[minmax(20rem,0.72fr)_2.5rem_minmax(0,1.28fr)] lg:items-stretch">
-        <div className="rfm-demo-pane">
+        <div className="rfm-demo-pane rfm-source-pane">
           <div className="rfm-demo-pane-header">
             <span>Source</span>
           </div>
-          <MarkdownCodeEditor
-            className="rfm-source-editor"
-            value={source}
-            onChange={handleSourceChange}
-          />
+          <div className="rfm-source-page">
+            <MarkdownCodeEditor
+              className="rfm-source-editor"
+              value={source}
+              onChange={handleSourceChange}
+            />
+          </div>
         </div>
 
         <div className="hidden items-start justify-center pt-3 text-slate-400 dark:text-slate-500 lg:flex">
           <ArrowRight className="size-5" aria-hidden="true" />
         </div>
 
-        <div className="rfm-demo-pane">
+        <div className="rfm-demo-pane rfm-result-pane">
           <div className="rfm-demo-pane-header">
             <span>Result</span>
           </div>

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -570,12 +570,50 @@
     @apply flex h-10 items-center border-b border-slate-200 px-4 text-xs font-semibold tracking-[0.14em] text-slate-500 uppercase dark:border-slate-700 dark:text-slate-400;
   }
 
+  .rfm-source-pane,
+  .rfm-result-pane {
+    border: 0;
+    background-color: transparent;
+    box-shadow: none;
+    overflow: visible;
+  }
+
+  .rfm-source-pane {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .rfm-source-pane .rfm-demo-pane-header,
+  .rfm-result-pane .rfm-demo-pane-header {
+    border-bottom-color: transparent;
+  }
+
+  .rfm-source-pane .rfm-demo-pane-header {
+    justify-content: flex-end;
+  }
+
+  .rfm-source-page {
+    overflow: hidden;
+    margin: 1rem;
+    min-height: calc(70vh + 7rem);
+    border: 1px solid #e9e9e8;
+    border-radius: 0.75rem;
+    background-color: #fff;
+    box-shadow: 0 18px 44px rgb(57 47 38 / 8%);
+  }
+
+  .dark .rfm-source-page {
+    border-color: rgb(51 65 85);
+    background-color: var(--card);
+    box-shadow: 0 18px 44px rgb(0 0 0 / 35%);
+  }
+
   .rfm-source-editor {
     color: rgb(15 23 42);
   }
 
   .rfm-source-editor .cm-editor {
-    min-height: 19rem;
+    min-height: calc(70vh + 7rem);
   }
 
   .rfm-source-editor .cm-scroller {
@@ -609,13 +647,6 @@
 
   .rfm-result-editor .document-page-main > .pb-24 {
     padding-bottom: 0;
-  }
-
-  .rfm-result-editor .document-page-main > .pb-24 > div {
-    border: 0;
-    border-radius: 0;
-    box-shadow: none;
-    padding: 1.25rem;
   }
 
   .rfm-result-editor .document-comment-fallback {

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -160,14 +160,40 @@ describe("Homepage", () => {
     expect(container.querySelector(".rfm-format-demo")?.className).toContain(
       "max-w-none",
     );
+    expect(
+      container.querySelector(".rfm-format-demo-intro")?.className,
+    ).toContain("px-4");
+    expect(
+      container.querySelector(".rfm-format-demo-examples")?.className,
+    ).toContain("px-4");
     const formatDemoGrid = container.querySelector(
       ".rfm-format-demo > div:nth-of-type(3)",
     );
     const formatDemoArrow = formatDemoGrid?.children.item(1);
     expect(formatDemoArrow?.className).toContain("items-start");
+    expect(container.querySelector(".rfm-source-pane")?.textContent).toContain(
+      "Source",
+    );
+    expect(container.querySelector(".rfm-result-pane")?.textContent).toContain(
+      "Result",
+    );
     expect(APP_STYLES).toMatch(
       /\.rfm-result-editor \.document-page-shell \{[^}]*grid-template-columns:\s*minmax\(0,\s*min\(100%,\s*42rem\)\)\s+minmax\(13rem,\s*16rem\);[^}]*justify-content:\s*start;/s,
     );
+    expect(APP_STYLES).toMatch(
+      /\.rfm-source-pane,\s*\.rfm-result-pane \{[^}]*border:\s*0;[^}]*background-color:\s*transparent;[^}]*box-shadow:\s*none;[^}]*overflow:\s*visible;/s,
+    );
+    expect(APP_STYLES).toMatch(
+      /\.rfm-source-pane \.rfm-demo-pane-header \{[^}]*justify-content:\s*flex-end;/s,
+    );
+    expect(APP_STYLES).toMatch(
+      /\.rfm-source-page \{[^}]*margin:\s*1rem;[^}]*min-height:\s*calc\(70vh \+ 7rem\);[^}]*border:\s*1px solid #e9e9e8;[^}]*border-radius:\s*0\.75rem;[^}]*background-color:\s*#fff;[^}]*box-shadow:\s*0 18px 44px rgb\(57 47 38 \/ 8%\);/s,
+    );
+    const resultDocumentCard = container.querySelector(
+      ".rfm-result-editor .document-page-main > .pb-24 > div",
+    );
+    expect(resultDocumentCard?.className).toContain("bg-white");
+    expect(resultDocumentCard?.className).toContain("shadow-");
     expect(APP_STYLES).not.toContain("rfm-token-");
     expect(container.querySelector('[class*="rfm-token-"]')).toBeNull();
     expect(
@@ -236,7 +262,7 @@ describe("Homepage", () => {
     await click(cta);
 
     expect(document.body.textContent).toContain(
-      "Copy this into your coding agent",
+      "Give this to your coding agent",
     );
     expect(document.body.textContent).toContain(AGENT_SETUP_PROMPT);
 


### PR DESCRIPTION
Polishes the homepage format preview so the source and result panes read as unboxed document surfaces instead of matching cards. The intro copy and example controls now align with the source page, the Source label sits closer to the arrow, and the install dialog uses “Give this to your coding agent.” The homepage test now covers the updated layout classes and prompt copy, and `pnpm check` passes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
