### PR TITLE
fix: keep editor focused inside links

### DIFF
--- a/packages/app/src/EditorContextMenu.tsx
+++ b/packages/app/src/EditorContextMenu.tsx
@@ -51,6 +51,7 @@ interface LinkPopoverState {
   rawHref: string;
   left: number;
   top: number;
+  existingLink: boolean;
 }
 
 function getNavigatorPlatform() {
@@ -291,40 +292,47 @@ export function EditorContextMenu({
   }, [editor, onSuggestInsertion]);
 
   const updateLinkPopover = useCallback(() => {
-    if (!editor || !containerRef.current || !editor.isActive("link")) {
-      setLinkPopoverState(null);
-      return;
-    }
+    setLinkPopoverState((current) => {
+      if (!current?.existingLink) return current;
+      if (!editor || !containerRef.current || !editor.isActive("link")) {
+        return null;
+      }
 
-    const anchor = findActiveLinkAnchor(editor, containerRef.current);
+      const anchor = findActiveLinkAnchor(editor, containerRef.current);
 
-    if (!anchor) {
-      setLinkPopoverState(null);
-      return;
-    }
+      if (!anchor) {
+        return null;
+      }
 
-    const rect = anchor.getBoundingClientRect();
-    if (rect.width === 0 && rect.height === 0) {
-      setLinkPopoverState(null);
-      return;
-    }
+      const rect = anchor.getBoundingClientRect();
+      if (rect.width === 0 && rect.height === 0) {
+        return null;
+      }
 
-    const rawHref =
-      (editor.getAttributes("link").dataMarkdownSrc as string | null) ||
-      anchor.getAttribute("data-markdown-src") ||
-      anchor.getAttribute("href") ||
-      "";
-    const href = resolveEditableLinkTarget(
-      rawHref,
-      backend,
-      (editor.getAttributes("link").href as string | null) || anchor.href,
-    );
+      const rawHref =
+        (editor.getAttributes("link").dataMarkdownSrc as string | null) ||
+        anchor.getAttribute("data-markdown-src") ||
+        anchor.getAttribute("href") ||
+        "";
+      const href = resolveEditableLinkTarget(
+        rawHref,
+        backend,
+        (editor.getAttributes("link").href as string | null) || anchor.href,
+      );
+      const next = {
+        ...current,
+        href,
+        rawHref,
+        left: rect.left + rect.width / 2,
+        top: rect.top - 12,
+      };
 
-    setLinkPopoverState({
-      href,
-      rawHref,
-      left: rect.left + rect.width / 2,
-      top: rect.top - 12,
+      return next.href === current.href &&
+        next.rawHref === current.rawHref &&
+        next.left === current.left &&
+        next.top === current.top
+        ? current
+        : next;
     });
   }, [backend, editor]);
 
@@ -351,6 +359,7 @@ export function EditorContextMenu({
         rawHref,
         left: rect.left + rect.width / 2,
         top: rect.top - 12,
+        existingLink: true,
       });
       return;
     }
@@ -369,6 +378,7 @@ export function EditorContextMenu({
       rawHref,
       left: rect.left + rect.width / 2,
       top: rect.top - 12,
+      existingLink: false,
     });
   }, [backend, editor]);
 

--- a/packages/app/src/EditorContextMenu.tsx
+++ b/packages/app/src/EditorContextMenu.tsx
@@ -52,6 +52,7 @@ interface LinkPopoverState {
   left: number;
   top: number;
   existingLink: boolean;
+  focusInput: boolean;
 }
 
 function getNavigatorPlatform() {
@@ -336,22 +337,37 @@ export function EditorContextMenu({
     });
   }, [backend, editor]);
 
-  const openLinkPopover = useCallback(() => {
-    if (!editor || !containerRef.current) return;
+  const openExistingLinkPopover = useCallback(
+    (anchor: HTMLAnchorElement) => {
+      if (!editor) return;
 
-    const anchor = findActiveLinkAnchor(editor, containerRef.current);
+      const firstChild = anchor.firstChild;
+      if (firstChild) {
+        try {
+          const position = editor.view.posAtDOM(firstChild, 0);
+          editor.commands.setTextSelection(
+            anchor.textContent ? position + 1 : position,
+          );
+        } catch {
+          // Fall back to the current editor selection if the DOM mapping changed.
+        }
+      }
 
-    if (anchor) {
       const rect = anchor.getBoundingClientRect();
+      if (rect.width === 0 && rect.height === 0) return;
+
+      const linkAttrs = editor.isActive("link")
+        ? editor.getAttributes("link")
+        : {};
       const rawHref =
-        (editor.getAttributes("link").dataMarkdownSrc as string | null) ||
+        (linkAttrs.dataMarkdownSrc as string | null) ||
         anchor.getAttribute("data-markdown-src") ||
         anchor.getAttribute("href") ||
         "";
       const href = resolveEditableLinkTarget(
         rawHref,
         backend,
-        (editor.getAttributes("link").href as string | null) || anchor.href,
+        (linkAttrs.href as string | null) || anchor.href,
       );
 
       setLinkPopoverState({
@@ -360,7 +376,19 @@ export function EditorContextMenu({
         left: rect.left + rect.width / 2,
         top: rect.top - 12,
         existingLink: true,
+        focusInput: false,
       });
+    },
+    [backend, editor],
+  );
+
+  const openLinkPopover = useCallback(() => {
+    if (!editor || !containerRef.current) return;
+
+    const anchor = findActiveLinkAnchor(editor, containerRef.current);
+
+    if (anchor) {
+      openExistingLinkPopover(anchor);
       return;
     }
 
@@ -379,8 +407,9 @@ export function EditorContextMenu({
       left: rect.left + rect.width / 2,
       top: rect.top - 12,
       existingLink: false,
+      focusInput: true,
     });
-  }, [backend, editor]);
+  }, [backend, editor, openExistingLinkPopover]);
 
   const applyLink = useCallback(
     (nextValue: string) => {
@@ -512,7 +541,9 @@ export function EditorContextMenu({
   }, [linkPopoverState]);
 
   useEffect(() => {
-    if (!linkPopoverState || !linkInputRef.current) return;
+    if (!linkPopoverState?.focusInput || !linkInputRef.current) {
+      return;
+    }
 
     requestAnimationFrame(() => {
       linkInputRef.current?.focus();
@@ -558,6 +589,23 @@ export function EditorContextMenu({
     <div
       ref={containerRef}
       className="relative"
+      onMouseDownCapture={(event) => {
+        if (!editor || !containerRef.current) return;
+
+        const target = event.target as Node;
+        const candidate = getElementFromDomNode(target);
+        const anchor = candidate?.closest("a[href]");
+
+        if (
+          !(anchor instanceof HTMLAnchorElement) ||
+          !containerRef.current.contains(anchor)
+        ) {
+          return;
+        }
+
+        event.preventDefault();
+        openExistingLinkPopover(anchor);
+      }}
       onContextMenu={(event) => {
         event.preventDefault();
         event.stopPropagation();

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -611,6 +611,32 @@ describe("PageCard editor integration", () => {
     ).toBe("false");
   });
 
+  it("keeps focus in the editor when placing the cursor inside a link", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-link-cursor-focus-1",
+        title: "Doc Link Cursor Focus 1",
+        content: "[linked](https://example.com)",
+      },
+      interactionMode: "editing",
+      selected: true,
+    });
+    const editor = rendered.getEditor();
+
+    await act(async () => {
+      const range = findTextRange(editor, "linked");
+      expect(range).not.toBeNull();
+      editor.commands.focus();
+      editor.commands.setTextSelection((range?.from ?? 1) + 2);
+    });
+    await flushAnimationFrame();
+
+    expect(document.activeElement).toBe(getEditable(rendered.container));
+    expect(
+      rendered.container.querySelector('input[aria-label="Link URL"]'),
+    ).toBeNull();
+  });
+
   it("suggesting mode turns typed text into insertion markup", async () => {
     const rendered = await renderPageCard({
       page: {

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -637,6 +637,38 @@ describe("PageCard editor integration", () => {
     ).toBeNull();
   });
 
+  it("opens the link edit popover without focusing the URL input when clicking link text", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-link-click-popover-1",
+        title: "Doc Link Click Popover 1",
+        content: "[linked](https://example.com)",
+      },
+      interactionMode: "editing",
+      selected: true,
+    });
+
+    const link = rendered.container.querySelector(
+      'a[href="https://example.com"]',
+    );
+    expect(link).not.toBeNull();
+
+    await act(async () => {
+      link?.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+      );
+    });
+    await flushAnimationFrame();
+
+    const input = rendered.container.querySelector<HTMLInputElement>(
+      'input[aria-label="Link URL"]',
+    );
+
+    expect(input).not.toBeNull();
+    expect(input?.value).toBe("https://example.com");
+    expect(document.activeElement).not.toBe(input);
+  });
+
   it("suggesting mode turns typed text into insertion markup", async () => {
     const rendered = await renderPageCard({
       page: {


### PR DESCRIPTION
Editing a linked word no longer opens the link URL popover and steals focus from the editor. The link popover still updates position after it has been opened explicitly, while ordinary caret movement inside links stays editable. Covered by a PageCard regression test that verifies focus remains on the editor and no URL input appears.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
