### PR TITLE
feat: show document save state and flush cmd+s saves

### DIFF
--- a/docs/plans/2026-05-07-save-indicator-command-s-test-plan.md
+++ b/docs/plans/2026-05-07-save-indicator-command-s-test-plan.md
@@ -1,0 +1,240 @@
+# Save Indicator Command-S Test Plan
+
+## Strategy reconciliation
+
+The implementation plan matches the agreed strategy: autosave remains the primary persistence path, `Cmd-S` / `Ctrl-S` becomes a manual flush instead of browser Save Page, save truth originates in `PageCard`, document-level UX and keyboard handling live in `DocumentWorkspace`, and backend writes stay centralized through `App`.
+
+No strategy changes require user approval. The planned harnesses are already present in this repo: Vitest/jsdom component tests for `PageCard`, `DocumentWorkspace`, and pure App risk logic, plus Playwright browser tests against real markdown files. No paid APIs, remote infrastructure, or manual visual review are required.
+
+## Harness requirements
+
+1. **Playwright markdown-file workflow harness**
+   - **Does:** Opens a real temporary Markdown file through Roughdraft, simulates user input in rich-text or code mode, presses keyboard shortcuts, observes DOM state, and reads the file from disk.
+   - **Exposes:** `openMarkdownFile`, `appendInCodeEditor`, `readProjectFile`, `writeProjectFile`, role/label queries, keyboard input, `expect.poll` against disk.
+   - **Estimated complexity:** Low. Existing helpers in `packages/app/e2e/helpers.ts` cover most needs; add only test-specific steps.
+   - **Dependent tests:** 1, 2, 3, 4, 5, 6.
+
+2. **PageCard save-controller component harness**
+   - **Does:** Renders `PageCard` in Vitest/jsdom, captures editor instance, save callback, save-state callback, and the new `DocumentSaveController`.
+   - **Exposes:** Programmatic rich-text edits, fake timers for debounce, `flushSave()`, mocked save success/failure, `saveBlocked` rerenders.
+   - **Estimated complexity:** Low to medium. Existing `renderPageCard()` needs controller capture and `saveBlocked` support.
+   - **Dependent tests:** 7, 8, 9, 10, 11.
+
+3. **DocumentWorkspace component harness**
+   - **Does:** Renders document workspace with an in-memory backend, configurable disk-change state, review watcher count, and mocked save callback.
+   - **Exposes:** DOM status assertions, handoff button state, capture-phase keyboard event simulation, conflict banner assertions.
+   - **Estimated complexity:** Low. Existing `view-toggle-bugs.test.tsx` has the renderer and backend stub; expand it.
+   - **Dependent tests:** 12, 13, 14, 15, 16, 17, 18.
+
+4. **App beforeunload risk helper harness**
+   - **Does:** Tests the pure decision for whether closing/reloading should warn.
+   - **Exposes:** `shouldWarnBeforeUnload({ activeDocumentPath, isDirty, saveState, diskChangeState })`.
+   - **Estimated complexity:** Low. Extract the helper from `App.tsx`.
+   - **Dependent tests:** 19, 20.
+
+5. **App storage-boundary harness**
+   - **Does:** Exercises the document save boundary with a mocked `StorageBackend` so tests can assert `expectedVersion` and conflict propagation without relying on private component state.
+   - **Exposes:** A minimal helper around the same inputs used by `App.handleSaveDocument`: active path, current page id/version, markdown content, backend save result/error, and resulting disk-change state.
+   - **Estimated complexity:** Medium if extracted from `App.tsx`; low if implemented by rendering `App` behind an injectable backend in tests. Keep the helper behavior identical to `handleSaveDocument` and avoid duplicating save policy in the test.
+   - **Dependent tests:** 21.
+
+## Test plan
+
+1. **Manual save shortcut flushes code-mode edits to disk**
+   - **Type:** scenario
+   - **Harness:** Playwright markdown-file workflow harness
+   - **Preconditions:** A temporary file `manual-save.md` contains `# Manual Save\n\nInitial body.\n`; Roughdraft opens it in code mode.
+   - **Actions:** Append `Saved by shortcut.` in the code editor. Press `Meta+S` on macOS or `Control+S` elsewhere.
+   - **Expected outcome:** The file on disk contains `Saved by shortcut.` without waiting for the normal autosave debounce, and the DOM has a visible status with accessible name `Saved`. Source of truth: user request for an easy save shortcut without Save As; implementation plan End-State Behavior for manual flush and persistent `Saved`; ADR 0001 single markdown file.
+   - **Interactions:** CodeMirror input, `DocumentWorkspace` shortcut handler, `PageCard` save controller, `App.handleSaveDocument`, server filesystem write.
+
+2. **Save shortcut never opens browser Save Page while a document is open**
+   - **Type:** scenario
+   - **Harness:** Playwright markdown-file workflow harness
+   - **Preconditions:** A temporary markdown file is open in Roughdraft, first in rich-text mode and then in code mode.
+   - **Actions:** Install a capture-phase test listener on `window` that records save-key events after app handlers run. For each mode, press `Meta+S` and `Control+S`.
+   - **Expected outcome:** The recorded events for both shortcuts have `defaultPrevented=true`, the page stays on the same URL, and the document editor remains focused/usable. Source of truth: user report that browser web-file save is confusing; implementation plan End-State Behavior says both shortcuts prevent the browser dialog with a document open.
+   - **Interactions:** Browser keyboard default handling, capture-phase workspace listener, TipTap or CodeMirror key handling.
+
+3. **Manual save shortcut flushes rich-text edits to disk**
+   - **Type:** scenario
+   - **Harness:** Playwright markdown-file workflow harness
+   - **Preconditions:** A temporary file contains `# Rich Save\n\nInitial body.\n`; Roughdraft opens it in rich-text mode.
+   - **Actions:** Type `Saved by shortcut.` into the rich-text editor and press platform save shortcut.
+   - **Expected outcome:** The disk file contains the typed text, and the visible save status becomes `Saved`. Existing supported Markdown around the edit remains parseable as Markdown. Source of truth: user wants saved screen edits to be what gets pushed; implementation plan says manual save writes current rich-text markdown; ADR 0003 round-trip contract.
+   - **Interactions:** TipTap editing, Markdown serialization, save controller, backend persistence.
+
+4. **Initial open shows persistent saved confidence**
+   - **Type:** scenario
+   - **Harness:** Playwright markdown-file workflow harness
+   - **Preconditions:** A clean temporary markdown file is opened with no edits.
+   - **Actions:** Wait for the document editor to render.
+   - **Expected outcome:** A visible status with accessible name `Saved` is present. Source of truth: implementation plan End-State Behavior says initial opened document shows `Saved`; user requested peace of mind about save state.
+   - **Interactions:** Document load, `PageCard` initial save state, `DocumentWorkspace` status rendering.
+
+5. **Autosave still saves normal code-mode edits without manual shortcut**
+   - **Type:** scenario
+   - **Harness:** Playwright markdown-file workflow harness
+   - **Preconditions:** A temporary file is open in code mode.
+   - **Actions:** Append text and do not press a save shortcut.
+   - **Expected outcome:** The file on disk eventually contains the appended text, and existing fenced CriticMarkup examples remain literal. Source of truth: implementation plan says keep autosave primary; ADR 0003 requires round-trip preservation.
+   - **Interactions:** CodeMirror update listener, `PageCard` debounce, `App.handleSaveDocument`, filesystem write.
+
+6. **Disk conflict blocks persistence while preserving local draft UI**
+   - **Type:** scenario
+   - **Harness:** Playwright markdown-file workflow harness
+   - **Preconditions:** A temporary file is open in code mode; server file events are disabled or controlled so an external disk write creates a stale expected-version conflict.
+   - **Actions:** Modify the file externally, type local draft text, press platform save shortcut, then choose `Keep editing with autosave paused`.
+   - **Expected outcome:** The browser save dialog is prevented, disk content remains the external version, visible UI includes `Save conflict` before pausing and `Autosave paused` after choosing keep-editing, and local draft text remains visible in the editor. Source of truth: implementation plan blocked/conflict behavior; ADR 0004 stale-write/versioned server model.
+   - **Interactions:** File watcher/stale write path, shortcut handling, conflict banner, persistent save status, CodeMirror local state.
+
+7. **Manual rich-text save cancels pending autosave and writes once**
+   - **Type:** integration
+   - **Harness:** PageCard save-controller component harness
+   - **Preconditions:** `PageCard` is rendered with content `Start`, selected, rich-text mode, fake timers enabled, and `onSave` mocked as successful.
+   - **Actions:** Insert ` now` at the end of the editor, then call `flushSave()` before advancing the 500 ms debounce.
+   - **Expected outcome:** `onSave` is called exactly once with the page id and markdown containing `Start now`; advancing the debounce afterward does not call `onSave` again; final save state is `saved`. Source of truth: implementation plan End-State Behavior says manual save cancels pending debounce and writes current markdown immediately.
+   - **Interactions:** TipTap edit serialization, save debounce timer, save controller, save-state callback.
+
+8. **Autosave still debounces rich-text edits**
+   - **Type:** regression
+   - **Harness:** PageCard save-controller component harness
+   - **Preconditions:** `PageCard` is rendered with content `Start` in rich-text mode and fake timers enabled.
+   - **Actions:** Insert text and advance timers by less than 500 ms, then to 500 ms.
+   - **Expected outcome:** No save occurs before 500 ms; one save occurs at/after the debounce with the edited markdown; final state becomes `saved`. Source of truth: implementation plan preserves autosave as primary and existing PageCard autosave behavior.
+   - **Interactions:** TipTap editing, debounce scheduling, save-state callback.
+
+9. **Manual save of already-saved content is harmless**
+   - **Type:** boundary
+   - **Harness:** PageCard save-controller component harness
+   - **Preconditions:** `PageCard` is rendered with unchanged content; no save timer or in-flight save exists.
+   - **Actions:** Call `flushSave()`.
+   - **Expected outcome:** Result is `{ status: "saved" }`, no backend save callback is invoked, and save state is `saved`. Source of truth: implementation plan End-State Behavior says pressing the shortcut when already saved is harmless and keeps/refocuses saved confirmation.
+   - **Interactions:** Save controller state machine only.
+
+10. **Manual save failure reports failure without marking dirty content saved**
+    - **Type:** integration
+    - **Harness:** PageCard save-controller component harness
+    - **Preconditions:** `PageCard` is rendered with content `Start`; `onSave` rejects once with a non-conflict error.
+    - **Actions:** Edit the document and call `flushSave()`.
+    - **Expected outcome:** Result has status `error`, final save state is `error`, and dirty content is not accepted as saved. Source of truth: implementation plan End-State Behavior says non-conflict save failures show `Save failed`; user wants confidence that unsaved edits are not falsely considered saved.
+    - **Interactions:** Save controller, failed backend promise, dirty-state reporting.
+
+11. **Manual save is blocked without backend write when disk state blocks saves**
+    - **Type:** integration
+    - **Harness:** PageCard save-controller component harness
+    - **Preconditions:** `PageCard` is rendered with content `Start`; user edits content; component is rerendered with `saveBlocked=true`.
+    - **Actions:** Call `flushSave()`.
+    - **Expected outcome:** Result is `{ status: "blocked" }`, `onSave` is not called, and final save state is `unsaved`. Source of truth: implementation plan says conflict-blocked shortcut prevents browser dialog and leaves conflict UI visible; top-right status must not imply saved.
+    - **Interactions:** Dirty refs, blocked save path, DocumentWorkspace-provided `saveBlocked` prop.
+
+12. **Status indicator exposes every clean save state accessibly**
+    - **Type:** integration
+    - **Harness:** DocumentWorkspace component harness
+    - **Preconditions:** Render `DocumentSaveStatusIndicator` with disk state `clean`.
+    - **Actions:** Render states `saved`, `saving`, `unsaved`, and `error`.
+    - **Expected outcome:** Each render has `role="status"` with accessible names and visible labels `Saved`, `Saving`, `Unsaved changes`, and `Save failed` respectively. Source of truth: implementation plan End-State Behavior and status view model labels.
+    - **Interactions:** Save status view model, icon/ARIA rendering.
+
+13. **Disk-blocked states override clean save labels**
+    - **Type:** integration
+    - **Harness:** DocumentWorkspace component harness
+    - **Preconditions:** Render `DocumentSaveStatusIndicator` with arbitrary save state.
+    - **Actions:** Render disk states `changed`, `conflict`, and `paused`.
+    - **Expected outcome:** Accessible status names are `File changed on disk`, `Save conflict`, and `Autosave paused`; no `Saved` implication is shown for blocked disk states. Source of truth: implementation plan says blocked/conflict messaging must not imply the draft was saved.
+    - **Interactions:** Disk state mapping and visual status rendering.
+
+14. **Save status appears in the top-right stack under handoff**
+    - **Type:** integration
+    - **Harness:** DocumentWorkspace component harness
+    - **Preconditions:** Render `DocumentWorkspace` with a document open and backend watcher count `1` so `I'm done` is visible.
+    - **Actions:** Inspect `[data-document-status-stack="true"]`.
+    - **Expected outcome:** The stack contains both `I'm done` and `Saved`, with the save indicator in the same top-right stack. Source of truth: user Roughdraft review comment incorporated in the implementation plan; implementation plan Task 4 placement.
+    - **Interactions:** Review watcher status, handoff affordance, save status layout.
+
+15. **Workspace prevents browser save for Meta+S and Control+S**
+    - **Type:** integration
+    - **Harness:** DocumentWorkspace component harness
+    - **Preconditions:** Render `DocumentWorkspace` with a document open and clean disk state.
+    - **Actions:** Dispatch cancelable `keydown` events for `Meta+S` and `Control+S` on `window`.
+    - **Expected outcome:** `preventDefault()` is called for each event. Source of truth: implementation plan End-State Behavior says both shortcuts are prevented whenever a document is open.
+    - **Interactions:** Capture-phase window listener, document-open guard.
+
+16. **Workspace prevents browser save but does not write during conflict**
+    - **Type:** integration
+    - **Harness:** DocumentWorkspace component harness
+    - **Preconditions:** Render `DocumentWorkspace` with disk state `conflict` and mocked `onSaveDocument`.
+    - **Actions:** Dispatch cancelable `Meta+S`.
+    - **Expected outcome:** `preventDefault()` is called, `onSaveDocument` is not called, and the DOM contains `Save conflict`. Source of truth: implementation plan End-State Behavior for conflict-blocked shortcut.
+    - **Interactions:** Shortcut handler, disk conflict state, save controller guard, conflict banner/status.
+
+17. **Conflict status does not replace the existing conflict banner**
+    - **Type:** regression
+    - **Harness:** DocumentWorkspace component harness
+    - **Preconditions:** Render `DocumentWorkspace` with disk state `conflict`.
+    - **Actions:** Inspect DOM text and status elements.
+    - **Expected outcome:** Persistent status has accessible name `Save conflict`, and the existing banner still contains the explanatory copy `This file changed on disk while you have unsaved edits`. Source of truth: implementation plan says existing amber banner remains the prominent explanation.
+    - **Interactions:** Banner rendering, persistent status rendering.
+
+18. **Handoff is disabled unless document is saved and conflict-free**
+    - **Type:** invariant
+    - **Harness:** DocumentWorkspace component harness
+    - **Preconditions:** Render `DocumentWorkspace` with watcher count `1`.
+    - **Actions:** Drive/render save states `saving`, `unsaved`, `error`, and disk state `conflict`, then inspect the `I'm done` button.
+    - **Expected outcome:** `I'm done` is disabled for each risky state and enabled only for `saved` with disk state `clean` and idle handoff state. Source of truth: implementation plan Review Checklist and Task 4 disabled guard.
+    - **Interactions:** Save status, disk state, review handoff action boundary.
+
+19. **Beforeunload warns for every local save risk**
+    - **Type:** unit
+    - **Harness:** App beforeunload risk helper harness
+    - **Preconditions:** `activeDocumentPath` is `doc.md`.
+    - **Actions:** Call `shouldWarnBeforeUnload` for dirty content, save states `saving`, `unsaved`, `error`, and disk states `changed`, `conflict`, `paused`.
+    - **Expected outcome:** The helper returns `true` for each risky input. Source of truth: implementation plan says closing/reloading warns only for dirty, saving, failed, or disk-change blocked states.
+    - **Interactions:** App-level refs/effect decision once wired into `beforeunload`.
+
+20. **Beforeunload does not warn for clean saved or no-document states**
+    - **Type:** boundary
+    - **Harness:** App beforeunload risk helper harness
+    - **Preconditions:** None.
+    - **Actions:** Call `shouldWarnBeforeUnload` with active document, `isDirty=false`, `saveState="saved"`, `diskChangeState="clean"`; call again with `activeDocumentPath=null` and otherwise risky inputs.
+    - **Expected outcome:** The helper returns `false` in both cases. Source of truth: implementation plan says no warning for a clean saved document and only with a document open.
+    - **Interactions:** App route/document-open boundary.
+
+21. **Manual save preserves backend stale-write expectedVersion semantics**
+    - **Type:** integration
+    - **Harness:** App storage-boundary harness
+    - **Preconditions:** A document has version `v1`; the save backend can assert the expected version it receives.
+    - **Actions:** Trigger manual save through the document save path.
+    - **Expected outcome:** The backend save receives the current document version as `expectedVersion`; if the backend throws `MarkdownFileConflictError`, disk state becomes `conflict` and the error is not swallowed as saved. Source of truth: implementation plan architecture says `App` remains the single backend persistence boundary preserving stale-write `expectedVersion`; ADR 0004.
+    - **Interactions:** Save controller, `DocumentWorkspace`, `App.handleSaveDocument`, storage backend versioning.
+
+22. **Save status layout is present and non-overlapping on desktop and mobile snapshots**
+    - **Type:** invariant
+    - **Harness:** Playwright markdown-file workflow harness
+    - **Preconditions:** A document is open with watcher count or mocked backend status that makes `I'm done` visible; run at desktop and mobile viewport widths.
+    - **Actions:** Capture DOM bounding boxes or screenshots for `[data-document-status-stack="true"]`, the save status, the handoff button, and the conflict banner when present.
+    - **Expected outcome:** Stack elements have non-zero bounding boxes within the viewport; status and handoff bounding boxes do not intersect except through intended vertical stacking; conflict banner and top-right stack both remain visible. Source of truth: implementation plan placement requirement and frontend design constraints for non-overlap.
+    - **Interactions:** CSS layout, fixed positioning, responsive viewport constraints.
+
+## Coverage summary
+
+Covered action space:
+
+- Opening a single Markdown file and seeing persistent initial `Saved` confidence.
+- Editing in rich-text and code modes.
+- Autosave debounce behavior and manual save shortcut behavior.
+- `Meta+S` and `Control+S` browser-default prevention.
+- Immediate manual save flushing, duplicate-save prevention, already-saved no-op behavior, save failure behavior, and blocked save behavior.
+- Persistent status labels for clean, saving, unsaved, failed, changed, conflict, and paused states.
+- Top-right status placement with `I'm done`.
+- Handoff disabling when save confidence is not clean.
+- App-level unload warnings for local-risk states.
+- Stale-write/version conflict semantics through the backend save boundary.
+- Round-trip preservation where save tests touch Markdown serialization.
+
+Explicitly excluded:
+
+- A `Save As` workflow, file picker, document database, git action, vault model, or multi-file workspace. These are excluded by the user request, ADR 0001, and the implementation plan strategy gate. Risk: users who expect a separate save-location flow will not get one, but adding it would materially change scope and product direction.
+- Exhaustive CodeMirror internals tests in jsdom. Browser scenarios cover code-mode user behavior more predictively. Risk: a low-level CodeMirror integration regression might be found later than a unit failure, but the scenario test covers the user-visible contract.
+- Full visual snapshot approval by a human. Layout checks are expressed as reproducible DOM/screenshot/bounding-box assertions. Risk: some aesthetic regressions may pass if they do not violate measurable visibility or overlap rules.
+- Remote document mode-specific manual save coverage. The same `StorageBackend.saveMarkdownFile` contract is exercised through the shared App boundary; remote transport-specific failures are out of scope for this save indicator change. Risk: remote-only latency or auth behavior could need follow-up if manual save exposes a transport issue.

--- a/docs/plans/2026-05-07-save-indicator-command-s.md
+++ b/docs/plans/2026-05-07-save-indicator-command-s.md
@@ -1,0 +1,1258 @@
+# Save Indicator Command-S Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use trycycle-executing to implement this plan task-by-task.
+
+**Goal:** Give Roughdraft users persistent confidence that the visible Markdown document is saved, and make `Cmd-S` / `Ctrl-S` flush the current document instead of opening the browser's Save Page dialog.
+
+**Architecture:** Keep autosave as the primary persistence model, but promote it from a transient implementation detail into a document save controller owned by `PageCard`, because `PageCard` is the component that has the current rich-text/code markdown and debounce state. `DocumentWorkspace` should own document-level UX: persistent save status in the top-right handoff/status cluster, a capture-phase save shortcut handler, and blocked/conflict messaging. `App` remains the single backend persistence boundary through `handleSaveDocument`, preserving stale-write `expectedVersion` behavior for local and remote documents.
+
+**Tech Stack:** React 19, TypeScript, Vite, Vitest/jsdom, Playwright, TipTap, CodeMirror, shadcn-style local UI primitives, lucide-react icons.
+
+---
+
+## Strategy Gate
+
+The user's complaint is not that Roughdraft lacks a file picker or a new save workflow. The problem is that the browser currently owns `Cmd-S`, and the UI does not continuously answer whether the screen version is the persisted version. Do not implement `Save As`, a document database, a git action, or a new file lifecycle.
+
+The clean steady-state architecture is:
+
+- `PageCard` reports the truth about local markdown save state and exposes `flushSave()`.
+- `DocumentWorkspace` renders that truth and binds the platform save shortcut.
+- `App` keeps backend saves centralized and version-checked.
+
+This directly lands the requested end state: visible save confidence plus a reliable manual save shortcut. It also aligns with ADR 0001's single Markdown file boundary, ADR 0003's round-trip contract, and ADR 0004's stale-write/versioned server model.
+
+Key decisions:
+
+- Use `Cmd-S` on macOS and `Ctrl-S` elsewhere, but prevent the browser save dialog for either shortcut whenever a Roughdraft document is open. This is safer than platform-sniffing for prevention because users may use either shortcut and the browser behavior is always wrong inside the document editor.
+- Keep the persistent indicator separate from `I'm done`. `I'm done` means handoff to an agent; save status means the visible document has persisted.
+- Put the save indicator in the fixed top-right handoff/status area. When `I'm done` is visible, render the save indicator directly below it in the same vertical stack.
+- Reuse the existing stale-write path. Manual save must call the same `onSaveDocument` path as autosave, with the same `expectedVersion` logic in `App`.
+- Add a lightweight `beforeunload` warning only for risky states: dirty, saving, failed, or disk-change blocked. Do not warn for a clean saved document.
+
+## End-State Behavior
+
+- Initial opened document shows `Saved`.
+- Editing shows `Saving` while a debounced save is pending or a write is in flight.
+- After the backend acknowledges the visible markdown, the indicator returns to persistent `Saved`.
+- If saving fails for a non-conflict reason, the indicator shows `Save failed`.
+- If local content is dirty but a save is blocked, the indicator shows `Unsaved changes` or the more specific blocked state supplied by the existing conflict banner.
+- If the file changed on disk or autosave is paused, the existing amber banner remains the prominent explanation, and the top-right save status must not imply the draft was saved.
+- Pressing `Cmd-S` / `Ctrl-S` with a document open always calls `preventDefault()` in capture phase.
+- Pressing `Cmd-S` / `Ctrl-S` with pending autosave cancels the debounce and immediately writes the current rich-text or code-mode markdown.
+- Pressing `Cmd-S` / `Ctrl-S` when already saved is harmless and keeps/refocuses the `Saved` confirmation.
+- Pressing `Cmd-S` / `Ctrl-S` while conflict-blocked still prevents the browser dialog and leaves the conflict UI visible.
+- Closing/reloading the tab warns only when there is a real local risk: dirty, saving, failed, changed/conflict/paused.
+
+### Task 1: Add Failing PageCard Save Controller Tests
+
+**Files:**
+- Modify: `packages/app/test/page-card.test.tsx`
+
+**Step 1: Extend the PageCard test harness**
+
+Add support for the new controller callback before implementing it. The test should fail to compile until the production prop exists.
+
+```tsx
+import type { DocumentSaveController } from "../src/PageCard";
+
+type RenderedPageCard = {
+  container: HTMLDivElement;
+  onSave: ReturnType<typeof vi.fn>;
+  onSaveStateChange: ReturnType<typeof vi.fn>;
+  getEditor: () => Editor;
+  getSaveController: () => DocumentSaveController;
+  rerender: (overrides?: PageCardTestOptions) => Promise<void>;
+  unmount: () => Promise<void>;
+};
+
+let saveController: DocumentSaveController | null = null;
+
+let props = {
+  // existing props...
+  onSaveControllerChange: (controller: DocumentSaveController | null) => {
+    saveController = controller;
+  },
+} as const;
+```
+
+Return `getSaveController()` from `renderPageCard()`:
+
+```tsx
+getSaveController() {
+  expect(saveController).not.toBeNull();
+  return saveController as DocumentSaveController;
+},
+```
+
+**Step 2: Write the failing rich-text flush test**
+
+Add this test under `describe("PageCard editor integration", ...)` near the existing autosave tests:
+
+```tsx
+it("manual save flushes pending rich-text autosave immediately", async () => {
+  const rendered = await renderPageCard({
+    page: {
+      id: "doc-manual-save-rich-1",
+      title: "Manual Save Rich",
+      content: "Start",
+    },
+    selected: true,
+  });
+
+  vi.useFakeTimers();
+
+  await insertTextAtEnd(rendered.getEditor(), " now");
+
+  expect(rendered.onSaveStateChange.mock.calls.at(-1)?.[0]).toBe("saving");
+  expect(rendered.onSave).not.toHaveBeenCalled();
+
+  await act(async () => {
+    await rendered.getSaveController().flushSave();
+  });
+
+  expect(rendered.onSave).toHaveBeenCalledTimes(1);
+  expect(rendered.onSave).toHaveBeenCalledWith(
+    "doc-manual-save-rich-1",
+    expect.stringContaining("Start now"),
+  );
+
+  await act(async () => {
+    vi.advanceTimersByTime(500);
+    await Promise.resolve();
+  });
+
+  expect(rendered.onSave).toHaveBeenCalledTimes(1);
+  expect(rendered.onSaveStateChange.mock.calls.at(-1)?.[0]).toBe("saved");
+});
+```
+
+**Step 3: Do not add a CodeMirror jsdom input test**
+
+Do not try to simulate CodeMirror typing in jsdom here. The PageCard unit test should prove the save controller flushes the current markdown immediately, and Task 7 will cover code-mode typing plus `Cmd-S` in a real browser. This avoids a brittle unit test that depends on CodeMirror internals rather than Roughdraft behavior.
+
+**Step 4: Run the focused failing test**
+
+Run:
+
+```bash
+pnpm --filter @roughdraft/app exec vitest run test/page-card.test.tsx
+```
+
+Expected: FAIL because `DocumentSaveController` and `onSaveControllerChange` do not exist yet, and/or `flushSave` is not implemented.
+
+**Step 5: Commit**
+
+Do not commit yet if the suite cannot compile because implementation is next. Keep this as the red step for Task 2.
+
+### Task 2: Implement PageCard Save Controller
+
+**Files:**
+- Modify: `packages/app/src/PageCard.tsx`
+- Modify: `packages/app/test/page-card.test.tsx`
+
+**Step 1: Replace the narrow save-state type**
+
+At the top of `packages/app/src/PageCard.tsx`, replace:
+
+```ts
+type SaveState = "idle" | "saving" | "error";
+```
+
+with exported document save types:
+
+```ts
+export type DocumentSaveState = "saved" | "unsaved" | "saving" | "error";
+
+export type ManualSaveResult =
+  | { status: "saved" }
+  | { status: "blocked" }
+  | { status: "error"; error: unknown };
+
+export interface DocumentSaveController {
+  flushSave: () => Promise<ManualSaveResult>;
+}
+```
+
+Use `DocumentSaveState` everywhere this file currently uses `SaveState`.
+
+**Step 2: Add the controller prop**
+
+Add this prop to both `PageCardProps` and `PageCardEditorSurfaceProps`:
+
+```ts
+onSaveControllerChange?: (controller: DocumentSaveController | null) => void;
+```
+
+Pass it from `PageCard` into `PageCardEditorSurface`.
+
+**Step 3: Track save state from the editor surface**
+
+Initialize the public save state as saved:
+
+```tsx
+const [saveState, setSaveState] = useState<DocumentSaveState>("saved");
+```
+
+In `PageCardEditorSurface`, keep these refs:
+
+```ts
+const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+const inFlightSaveRef = useRef<Promise<ManualSaveResult> | null>(null);
+const pendingMarkdownRef = useRef(page.content);
+const lastAcceptedMarkdownRef = useRef(page.content);
+const localDirtyRef = useRef(false);
+```
+
+`pendingMarkdownRef.current` must be updated in every path that updates local markdown.
+
+**Step 4: Extract a single save executor**
+
+Inside `PageCardEditorSurface`, add:
+
+```ts
+const rememberRecentMarkdown = useCallback((nextMarkdown: string) => {
+  recentMarkdownRef.current.add(nextMarkdown);
+  if (recentMarkdownRef.current.size > 10) {
+    const iterator = recentMarkdownRef.current.values();
+    recentMarkdownRef.current.delete(iterator.next().value as string);
+  }
+}, []);
+
+const performSave = useCallback(
+  async (nextMarkdown: string): Promise<ManualSaveResult> => {
+    if (saveBlocked) {
+      onSaveStateChange(
+        nextMarkdown === lastAcceptedMarkdownRef.current ? "saved" : "unsaved",
+      );
+      return { status: "blocked" };
+    }
+
+    rememberRecentMarkdown(nextMarkdown);
+    onSaveStateChange("saving");
+
+    try {
+      await onSave(page.id, nextMarkdown);
+      lastAcceptedMarkdownRef.current = nextMarkdown;
+      reportDirtyState(pendingMarkdownRef.current !== nextMarkdown);
+      onSaveStateChange(
+        pendingMarkdownRef.current === nextMarkdown ? "saved" : "saving",
+      );
+      return { status: "saved" };
+    } catch (error) {
+      console.error("Failed to save page:", error);
+      onSaveStateChange("error");
+      return { status: "error", error };
+    }
+  },
+  [
+    onSave,
+    onSaveStateChange,
+    page.id,
+    rememberRecentMarkdown,
+    reportDirtyState,
+    saveBlocked,
+  ],
+);
+```
+
+If a save finishes after the user has made a newer edit, it must not clear dirty state for the newer edit. That is why the post-save state compares `pendingMarkdownRef.current` to `nextMarkdown`.
+
+**Step 5: Implement debounced autosave through the executor**
+
+Replace the existing `scheduleSave` body with:
+
+```ts
+const scheduleSave = useCallback(
+  (nextMarkdown: string) => {
+    if (saveTimer.current) {
+      clearTimeout(saveTimer.current);
+      saveTimer.current = null;
+    }
+
+    if (saveBlocked) {
+      onSaveStateChange("unsaved");
+      return;
+    }
+
+    onSaveStateChange("saving");
+    saveTimer.current = setTimeout(() => {
+      saveTimer.current = null;
+      inFlightSaveRef.current = performSave(nextMarkdown).finally(() => {
+        inFlightSaveRef.current = null;
+      });
+      void inFlightSaveRef.current;
+    }, 500);
+  },
+  [onSaveStateChange, performSave, saveBlocked],
+);
+```
+
+**Step 6: Implement manual flush**
+
+Add:
+
+```ts
+const flushSave = useCallback(async (): Promise<ManualSaveResult> => {
+  if (saveTimer.current) {
+    clearTimeout(saveTimer.current);
+    saveTimer.current = null;
+  }
+
+  const currentMarkdown = pendingMarkdownRef.current;
+
+  if (
+    currentMarkdown === lastAcceptedMarkdownRef.current &&
+    !inFlightSaveRef.current
+  ) {
+    onSaveStateChange("saved");
+    return { status: "saved" };
+  }
+
+  if (inFlightSaveRef.current) {
+    await inFlightSaveRef.current;
+    if (pendingMarkdownRef.current === lastAcceptedMarkdownRef.current) {
+      onSaveStateChange("saved");
+      return { status: "saved" };
+    }
+  }
+
+  const result = await performSave(pendingMarkdownRef.current);
+  return result;
+}, [onSaveStateChange, performSave]);
+```
+
+Then register it:
+
+```ts
+useEffect(() => {
+  onSaveControllerChange?.({ flushSave });
+  return () => onSaveControllerChange?.(null);
+}, [flushSave, onSaveControllerChange]);
+```
+
+**Step 7: Update markdown-change and accept paths**
+
+In `acceptMarkdown(nextMarkdown)`, add:
+
+```ts
+pendingMarkdownRef.current = nextMarkdown;
+onSaveStateChange("saved");
+```
+
+In `handleMarkdownChange(nextMarkdown)`, add:
+
+```ts
+pendingMarkdownRef.current = nextMarkdown;
+```
+
+before `setMarkdown(nextMarkdown)`.
+
+When `saveBlocked` becomes true and a timer is cancelled, set state to:
+
+```ts
+onSaveStateChange(
+  pendingMarkdownRef.current === lastAcceptedMarkdownRef.current
+    ? "saved"
+    : "unsaved",
+);
+```
+
+not `"idle"`.
+
+**Step 8: Run the focused tests**
+
+Run:
+
+```bash
+pnpm --filter @roughdraft/app exec vitest run test/page-card.test.tsx
+```
+
+Expected: PASS for the new manual flush test and existing autosave tests.
+
+**Step 9: Commit**
+
+```bash
+git add packages/app/src/PageCard.tsx packages/app/test/page-card.test.tsx
+git commit -m "feat: add document save controller"
+```
+
+### Task 3: Add Failing DocumentWorkspace Status and Shortcut Tests
+
+**Files:**
+- Modify: `packages/app/test/view-toggle-bugs.test.tsx`
+
+**Step 1: Update imports**
+
+Import the new types:
+
+```ts
+import type { DocumentSaveState } from "../src/PageCard";
+```
+
+**Step 2: Add direct save-status component coverage**
+
+The persistent status states are a view concern. Export the status component from `DocumentWorkspace.tsx` in Task 4 so tests can cover every state without faking PageCard internals.
+
+Add this import, which should fail until Task 4 implements it:
+
+```ts
+import {
+  DocumentSaveStatusIndicator,
+  DocumentWorkspace,
+} from "../src/DocumentWorkspace";
+```
+
+Add a helper:
+
+```tsx
+async function renderSaveStatus({
+  saveState = "saved",
+  documentDiskChangeState = "clean",
+}: {
+  saveState?: DocumentSaveState;
+  documentDiskChangeState?: "clean" | "changed" | "conflict" | "paused";
+} = {}) {
+  await act(async () => {
+    root.render(
+      <DocumentSaveStatusIndicator
+        saveState={saveState}
+        diskChangeState={documentDiskChangeState}
+      />,
+    );
+    await Promise.resolve();
+  });
+}
+```
+
+Then add:
+
+```tsx
+it.each([
+  ["saved", "Saved"],
+  ["saving", "Saving"],
+  ["unsaved", "Unsaved changes"],
+  ["error", "Save failed"],
+] satisfies Array<[DocumentSaveState, string]>)(
+  "shows persistent %s save status",
+  async (saveState, label) => {
+    await renderSaveStatus({ saveState });
+
+    expect(
+      container.querySelector(`[role="status"][aria-label="${label}"]`),
+    ).not.toBeNull();
+    expect(container.textContent).toContain(label);
+  },
+);
+
+it.each([
+  ["changed", "File changed on disk"],
+  ["conflict", "Save conflict"],
+  ["paused", "Autosave paused"],
+] as const)("shows disk-blocked %s save status", async (state, label) => {
+  await renderSaveStatus({ documentDiskChangeState: state });
+
+  expect(
+    container.querySelector(`[role="status"][aria-label="${label}"]`),
+  ).not.toBeNull();
+  expect(container.textContent).toContain(label);
+});
+```
+
+**Step 3: Make a reusable workspace renderer**
+
+In the save-status describe block, add a helper that can capture props:
+
+```tsx
+async function renderWorkspace({
+  documentDiskChangeState = "clean",
+  watcherCount = 0,
+  onSaveDocument = async () => {},
+}: {
+  documentDiskChangeState?: "clean" | "changed" | "conflict" | "paused";
+  watcherCount?: number;
+  onSaveDocument?: (id: string, content: string) => Promise<void>;
+} = {}) {
+  await act(async () => {
+    root.render(
+      <DocumentWorkspace
+        documentPage={createPage()}
+        activeDocumentPath="test.md"
+        documentFilenameLabel="test.md"
+        documentEditorViewMode="rich-text"
+        onDocumentEditorViewModeChange={() => {}}
+        onSaveDocument={onSaveDocument}
+        onDocumentSaveStateChange={() => {}}
+        onDocumentDirtyStateChange={() => {}}
+        onDocumentLocalContentChange={() => {}}
+        documentDiskChangeState={documentDiskChangeState}
+        documentForceResetKey={null}
+        onReloadDocumentFromDisk={() => {}}
+        onKeepEditingWithoutAutosave={() => {}}
+        onOverwriteDocumentOnDisk={() => {}}
+        onCompleteReview={async () => ({ delivered: false })}
+        backend={createBackend({ watcherCount })}
+      />,
+    );
+    await Promise.resolve();
+  });
+}
+```
+
+Add a handoff placement test:
+
+```tsx
+it("renders save status in the same top-right stack under the handoff button", async () => {
+  await renderWorkspace({ watcherCount: 1 });
+
+  const stack = container.querySelector('[data-document-status-stack="true"]');
+  expect(stack).not.toBeNull();
+  expect(stack?.textContent).toContain("I'm done");
+  expect(stack?.textContent).toContain("Saved");
+});
+```
+
+**Step 4: Write failing shortcut prevention tests**
+
+Add:
+
+```tsx
+it.each([
+  ["Meta+S", { key: "s", metaKey: true }],
+  ["Control+S", { key: "s", ctrlKey: true }],
+])("prevents browser save on %s", async (_label, init) => {
+  const onSaveDocument = vi.fn().mockResolvedValue(undefined);
+  await renderWorkspace({ onSaveDocument });
+
+  const event = new KeyboardEvent("keydown", {
+    ...init,
+    bubbles: true,
+    cancelable: true,
+  });
+  const preventDefault = vi.spyOn(event, "preventDefault");
+
+  await act(async () => {
+    window.dispatchEvent(event);
+    await Promise.resolve();
+  });
+
+  expect(preventDefault).toHaveBeenCalled();
+});
+```
+
+Add a blocked-state prevention test:
+
+```tsx
+it("prevents browser save even when disk conflict blocks persistence", async () => {
+  const onSaveDocument = vi.fn().mockResolvedValue(undefined);
+  await renderWorkspace({
+    documentDiskChangeState: "conflict",
+    onSaveDocument,
+  });
+
+  const event = new KeyboardEvent("keydown", {
+    key: "s",
+    metaKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  const preventDefault = vi.spyOn(event, "preventDefault");
+
+  await act(async () => {
+    window.dispatchEvent(event);
+    await Promise.resolve();
+  });
+
+  expect(preventDefault).toHaveBeenCalled();
+  expect(onSaveDocument).not.toHaveBeenCalled();
+  expect(container.textContent).toContain("Save conflict");
+});
+```
+
+The browser-level test in Task 7 proves the shortcut also flushes dirty code-mode content to disk. The PageCard test in Task 1 proves the flush cancels pending rich-text autosave immediately.
+
+**Step 5: Run the focused failing test**
+
+Run:
+
+```bash
+pnpm --filter @roughdraft/app exec vitest run test/view-toggle-bugs.test.tsx
+```
+
+Expected: FAIL because `DocumentWorkspace` does not render persistent saved/unsaved/error states and has no save shortcut handler.
+
+### Task 4: Implement Persistent Status UI and Shortcut Handling
+
+**Files:**
+- Modify: `packages/app/src/DocumentWorkspace.tsx`
+- Modify: `packages/app/test/view-toggle-bugs.test.tsx`
+
+**Step 1: Import the new save types**
+
+Replace the local `SaveState` type with:
+
+```ts
+import {
+  PageCard,
+  type DocumentInteractionMode,
+  type DocumentSaveController,
+  type DocumentSaveState,
+} from "./PageCard";
+```
+
+Remove the old `type SaveState = "idle" | "saving" | "error";`.
+
+**Step 2: Update props**
+
+Change:
+
+```ts
+onDocumentSaveStateChange: (state: SaveState) => void;
+```
+
+to:
+
+```ts
+onDocumentSaveStateChange: (state: DocumentSaveState) => void;
+```
+
+**Step 3: Replace transient saved state**
+
+Remove `showSaved`, `wasSavingRef`, and the timer logic. Initialize:
+
+```ts
+const [saveState, setSaveState] = useState<DocumentSaveState>("saved");
+const saveControllerRef = useRef<DocumentSaveController | null>(null);
+```
+
+Use:
+
+```ts
+const handleSaveStateChange = useCallback(
+  (state: DocumentSaveState) => {
+    setSaveState(state);
+    onDocumentSaveStateChange(state);
+  },
+  [onDocumentSaveStateChange],
+);
+```
+
+**Step 4: Add an exported save status indicator**
+
+Add a helper near `conflictNoticeCopy`:
+
+```ts
+function getSaveStatusViewModel(
+  saveState: DocumentSaveState,
+  diskChangeState: DiskChangeState,
+) {
+  if (diskChangeState === "conflict") {
+    return {
+      label: "Save conflict",
+      ariaLabel: "Save conflict",
+      tone: "warning" as const,
+      Icon: AlertTriangle,
+    };
+  }
+
+  if (diskChangeState === "changed") {
+    return {
+      label: "File changed",
+      ariaLabel: "File changed on disk",
+      tone: "warning" as const,
+      Icon: AlertTriangle,
+    };
+  }
+
+  if (diskChangeState === "paused") {
+    return {
+      label: "Autosave paused",
+      ariaLabel: "Autosave paused",
+      tone: "warning" as const,
+      Icon: AlertTriangle,
+    };
+  }
+
+  if (saveState === "saving") {
+    return {
+      label: "Saving",
+      ariaLabel: "Saving",
+      tone: "neutral" as const,
+      Icon: Loader2,
+    };
+  }
+
+  if (saveState === "error") {
+    return {
+      label: "Save failed",
+      ariaLabel: "Save failed",
+      tone: "danger" as const,
+      Icon: AlertTriangle,
+    };
+  }
+
+  if (saveState === "unsaved") {
+    return {
+      label: "Unsaved changes",
+      ariaLabel: "Unsaved changes",
+      tone: "warning" as const,
+      Icon: AlertTriangle,
+    };
+  }
+
+  return {
+    label: "Saved",
+    ariaLabel: "Saved",
+    tone: "success" as const,
+    Icon: Check,
+  };
+}
+```
+
+Add the exported component below the helper:
+
+```tsx
+export function DocumentSaveStatusIndicator({
+  saveState,
+  diskChangeState,
+}: {
+  saveState: DocumentSaveState;
+  diskChangeState: DiskChangeState;
+}) {
+  const saveStatus = getSaveStatusViewModel(saveState, diskChangeState);
+  const SaveStatusIcon = saveStatus.Icon;
+
+  return (
+    <span
+      role="status"
+      aria-label={saveStatus.ariaLabel}
+      className={cn(
+        "inline-flex h-7 max-w-full shrink-0 items-center gap-1.5 rounded-[7px] border bg-white/92 px-2.5 font-mono text-[0.68rem] leading-none shadow-[0_8px_22px_rgba(15,23,42,0.08)] backdrop-blur dark:bg-slate-950/88",
+        saveStatus.tone === "success" &&
+          "border-emerald-200 text-emerald-700 dark:border-emerald-800 dark:text-emerald-300",
+        saveStatus.tone === "warning" &&
+          "border-amber-200 text-amber-800 dark:border-amber-800 dark:text-amber-300",
+        saveStatus.tone === "danger" &&
+          "border-red-200 text-red-700 dark:border-red-800 dark:text-red-300",
+        saveStatus.tone === "neutral" &&
+          "border-stone-200 text-stone-500 dark:border-slate-700 dark:text-slate-300",
+      )}
+    >
+      <SaveStatusIcon
+        className={cn(
+          "size-3.5 shrink-0",
+          saveStatus.label === "Saving" && "animate-spin",
+        )}
+        aria-hidden="true"
+      />
+      <span className="min-w-0 truncate">{saveStatus.label}</span>
+    </span>
+  );
+}
+```
+
+**Step 5: Render one top-right status stack**
+
+Replace the current fixed `I'm done` button wrapper with this stack:
+
+```tsx
+<div
+  className="fixed top-3 right-3 z-[60] flex max-w-[min(16rem,calc(100vw-1rem))] flex-col items-end gap-1.5"
+  data-document-status-stack="true"
+>
+  {showReviewHandoffButton ? (
+    <Popover>
+      {/* existing PopoverTrigger/Button/PopoverContent */}
+    </Popover>
+  ) : null}
+  {documentPage ? (
+    <DocumentSaveStatusIndicator
+      saveState={saveState}
+      diskChangeState={documentDiskChangeState}
+    />
+  ) : null}
+</div>
+```
+
+This intentionally puts status below `I'm done` when the handoff button is present. Leave the inline filename row free of save chips; it can keep filename, mode toggle, interaction selector, and review watcher status.
+
+**Step 6: Register the save controller**
+
+Pass to `PageCard`:
+
+```tsx
+onSaveControllerChange={(controller) => {
+  saveControllerRef.current = controller;
+}}
+```
+
+**Step 7: Add capture-phase save shortcut**
+
+Add:
+
+```ts
+useEffect(() => {
+  if (!documentPage) return;
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    const isSaveShortcut =
+      event.key.toLowerCase() === "s" &&
+      (event.metaKey || event.ctrlKey) &&
+      !event.altKey;
+
+    if (!isSaveShortcut) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (documentDiskChangeState !== "clean") return;
+
+    void saveControllerRef.current?.flushSave();
+  };
+
+  window.addEventListener("keydown", handleKeyDown, { capture: true });
+  return () => {
+    window.removeEventListener("keydown", handleKeyDown, { capture: true });
+  };
+}, [documentDiskChangeState, documentPage]);
+```
+
+This prevents the browser Save Page dialog before TipTap, CodeMirror, or the browser default action can handle it.
+
+**Step 8: Keep handoff disabling correct**
+
+Change the `I'm done` disabled guard from `saveState === "saving"` to:
+
+```ts
+saveState === "saving" ||
+saveState === "unsaved" ||
+saveState === "error" ||
+documentDiskChangeState !== "clean"
+```
+
+This prevents handoff while visible edits are not confirmed saved.
+
+**Step 9: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @roughdraft/app exec vitest run test/view-toggle-bugs.test.tsx
+```
+
+Expected: PASS.
+
+**Step 10: Commit**
+
+```bash
+git add packages/app/src/DocumentWorkspace.tsx packages/app/test/view-toggle-bugs.test.tsx
+git commit -m "feat: show persistent document save status"
+```
+
+### Task 5: Carry Save Risk Into App-Level Beforeunload
+
+**Files:**
+- Modify: `packages/app/src/App.tsx`
+- Create: `packages/app/test/app-save-warning.test.tsx`
+
+**Step 1: Update App save-state imports/types**
+
+Import:
+
+```ts
+import type { DocumentSaveState } from "./PageCard";
+```
+
+Replace the local `type SaveState = "idle" | "saving" | "error";` with the imported type.
+
+**Step 2: Track save state in refs**
+
+Change:
+
+```ts
+const [, setDocumentSaveState] = useState<SaveState>("idle");
+```
+
+to:
+
+```ts
+const [documentSaveState, setDocumentSaveState] =
+  useState<DocumentSaveState>("saved");
+const documentSaveStateRef = useRef<DocumentSaveState>("saved");
+```
+
+Keep the ref synchronized:
+
+```ts
+documentSaveStateRef.current = documentSaveState;
+```
+
+Add:
+
+```ts
+const handleDocumentSaveStateChange = useCallback(
+  (state: DocumentSaveState) => {
+    documentSaveStateRef.current = state;
+    setDocumentSaveState(state);
+  },
+  [],
+);
+```
+
+Pass `handleDocumentSaveStateChange` to `DocumentWorkspace`.
+
+**Step 3: Add beforeunload risk detection**
+
+Add this effect in `App`, after the document refs are initialized:
+
+```ts
+useEffect(() => {
+  const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+    if (!activeDocumentPathRef.current) return;
+
+    const hasLocalRisk =
+      documentDirtyRef.current ||
+      documentSaveStateRef.current === "saving" ||
+      documentSaveStateRef.current === "unsaved" ||
+      documentSaveStateRef.current === "error" ||
+      documentDiskChangeState !== "clean";
+
+    if (!hasLocalRisk) return;
+
+    event.preventDefault();
+    event.returnValue = "";
+  };
+
+  window.addEventListener("beforeunload", handleBeforeUnload);
+  return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+}, [documentDiskChangeState]);
+```
+
+This is intentionally generic because browsers do not allow custom unload copy.
+
+**Step 4: Add tests for unload warning**
+
+Rendering the whole `App` with a mocked backend is more work than this behavior needs. Extract a pure helper from `App.tsx` and test that helper:
+
+```ts
+export function shouldWarnBeforeUnload({
+  activeDocumentPath,
+  isDirty,
+  saveState,
+  diskChangeState,
+}: {
+  activeDocumentPath: string | null;
+  isDirty: boolean;
+  saveState: DocumentSaveState;
+  diskChangeState: DocumentDiskChangeState;
+}) {
+  return (
+    !!activeDocumentPath &&
+    (isDirty ||
+      saveState === "saving" ||
+      saveState === "unsaved" ||
+      saveState === "error" ||
+      diskChangeState !== "clean")
+  );
+}
+```
+
+Export `DocumentDiskChangeState` from `App.tsx` if needed:
+
+```ts
+export type DocumentDiskChangeState =
+  | "clean"
+  | "changed"
+  | "conflict"
+  | "paused";
+```
+
+Create `packages/app/test/app-save-warning.test.tsx`:
+
+```tsx
+import { describe, expect, it } from "vitest";
+import { shouldWarnBeforeUnload } from "../src/App";
+
+describe("beforeunload save warning", () => {
+  it.each([
+    [{ isDirty: true, saveState: "saved", diskChangeState: "clean" }, true],
+    [{ isDirty: false, saveState: "saving", diskChangeState: "clean" }, true],
+    [{ isDirty: false, saveState: "unsaved", diskChangeState: "clean" }, true],
+    [{ isDirty: false, saveState: "error", diskChangeState: "clean" }, true],
+    [{ isDirty: false, saveState: "saved", diskChangeState: "conflict" }, true],
+    [{ isDirty: false, saveState: "saved", diskChangeState: "clean" }, false],
+  ] as const)("returns %s for %o", (input, expected) => {
+    expect(
+      shouldWarnBeforeUnload({
+        activeDocumentPath: "doc.md",
+        ...input,
+      }),
+    ).toBe(expected);
+  });
+
+  it("does not warn when no document is open", () => {
+    expect(
+      shouldWarnBeforeUnload({
+        activeDocumentPath: null,
+        isDirty: true,
+        saveState: "error",
+        diskChangeState: "conflict",
+      }),
+    ).toBe(false);
+  });
+});
+```
+
+**Step 5: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @roughdraft/app exec vitest run test/app-save-warning.test.tsx
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add packages/app/src/App.tsx packages/app/test/app-save-warning.test.tsx
+git commit -m "feat: warn before leaving unsaved drafts"
+```
+
+### Task 6: Preserve Backend Conflict Semantics
+
+**Files:**
+- Modify: `packages/app/test/page-card.test.tsx`
+- Modify: `packages/app/test/view-toggle-bugs.test.tsx`
+- Modify if needed: `packages/app/src/PageCard.tsx`
+- Modify if needed: `packages/app/src/DocumentWorkspace.tsx`
+
+**Step 1: Add a PageCard save failure test**
+
+In `packages/app/test/page-card.test.tsx`, add:
+
+```tsx
+it("manual save reports save failure without clearing dirty state", async () => {
+  const rendered = await renderPageCard({
+    page: {
+      id: "doc-manual-save-failure-1",
+      title: "Manual Save Failure",
+      content: "Start",
+    },
+    selected: true,
+  });
+  rendered.onSave.mockRejectedValueOnce(new Error("disk unavailable"));
+
+  vi.useFakeTimers();
+
+  await insertTextAtEnd(rendered.getEditor(), " failed");
+
+  let result;
+  await act(async () => {
+    result = await rendered.getSaveController().flushSave();
+  });
+
+  expect(result).toMatchObject({ status: "error" });
+  expect(rendered.onSaveStateChange.mock.calls.at(-1)?.[0]).toBe("error");
+});
+```
+
+**Step 2: Add a blocked manual-save test**
+
+Rerender with `saveBlocked: true` after making an edit. The expected behavior:
+
+```tsx
+it("manual save is blocked without calling onSave when disk state blocks saves", async () => {
+  const rendered = await renderPageCard({
+    page: {
+      id: "doc-manual-save-blocked-1",
+      title: "Manual Save Blocked",
+      content: "Start",
+    },
+    selected: true,
+  });
+
+  vi.useFakeTimers();
+  await insertTextAtEnd(rendered.getEditor(), " blocked");
+  await rendered.rerender({ saveBlocked: true });
+
+  let result;
+  await act(async () => {
+    result = await rendered.getSaveController().flushSave();
+  });
+
+  expect(result).toEqual({ status: "blocked" });
+  expect(rendered.onSave).not.toHaveBeenCalled();
+  expect(rendered.onSaveStateChange.mock.calls.at(-1)?.[0]).toBe("unsaved");
+});
+```
+
+Update `PageCardTestOptions` to include `saveBlocked?: boolean`.
+
+**Step 3: Add a DocumentWorkspace conflict status test**
+
+In `packages/app/test/view-toggle-bugs.test.tsx`:
+
+```tsx
+it("shows conflict status without replacing the existing conflict banner", async () => {
+  await renderWorkspace({ documentDiskChangeState: "conflict" });
+
+  expect(container.textContent).toContain("Save conflict");
+  expect(container.textContent).toContain("This file changed on disk");
+  expect(
+    container.querySelector('[aria-label="Save conflict"]'),
+  ).not.toBeNull();
+});
+```
+
+**Step 4: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @roughdraft/app exec vitest run test/page-card.test.tsx test/view-toggle-bugs.test.tsx
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add packages/app/src/PageCard.tsx packages/app/src/DocumentWorkspace.tsx packages/app/test/page-card.test.tsx packages/app/test/view-toggle-bugs.test.tsx
+git commit -m "test: cover save failure and blocked states"
+```
+
+### Task 7: Add Browser-Level Cmd-S Smoke Coverage
+
+**Files:**
+- Modify: `packages/app/e2e/markdown-roundtrip.spec.ts`
+
+**Step 1: Add the e2e test**
+
+Append to `test.describe("markdown round-trips", ...)`:
+
+```ts
+test("manual save shortcut flushes code-mode edits to disk @smoke", async ({
+  page,
+}) => {
+  const initial = ["# Manual Save", "", "Initial body.", ""].join("\n");
+  const filePath = writeProjectFile(projectDir, "manual-save.md", initial);
+
+  await openMarkdownFile(page, filePath, "code");
+  await appendInCodeEditor(page, "\nSaved by shortcut.\n");
+
+  await page.keyboard.press(
+    process.platform === "darwin" ? "Meta+S" : "Control+S",
+  );
+
+  await expect
+    .poll(() => readProjectFile(projectDir, "manual-save.md"))
+    .toContain("Saved by shortcut.");
+  await expect(page.getByRole("status", { name: "Saved" })).toBeVisible();
+
+  logE2eEvent("markdown-roundtrip.manual-save-shortcut", {
+    file: "manual-save.md",
+    size: fs.statSync(filePath).size,
+  });
+});
+```
+
+This test uses code mode because it is the fastest browser-level proof that the exact text the user typed flushes to disk. The PageCard rich-text test covers TipTap serialization.
+
+**Step 2: Run the focused e2e**
+
+Run:
+
+```bash
+pnpm exec playwright test --config packages/app/playwright.config.ts packages/app/e2e/markdown-roundtrip.spec.ts --grep "manual save shortcut"
+```
+
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+git add packages/app/e2e/markdown-roundtrip.spec.ts
+git commit -m "test: cover manual save shortcut in browser"
+```
+
+### Task 8: Final Integration Verification
+
+**Files:**
+- No new files expected unless preceding tasks reveal necessary fixes.
+
+**Step 1: Run focused component tests**
+
+Run:
+
+```bash
+pnpm --filter @roughdraft/app exec vitest run test/page-card.test.tsx test/view-toggle-bugs.test.tsx test/app-save-warning.test.tsx
+```
+
+Expected: PASS.
+
+**Step 2: Run focused e2e smoke**
+
+Run:
+
+```bash
+pnpm exec playwright test --config packages/app/playwright.config.ts packages/app/e2e/markdown-roundtrip.spec.ts --grep "@smoke|manual save shortcut"
+```
+
+Expected: PASS.
+
+**Step 3: Run full repository check**
+
+Run:
+
+```bash
+pnpm check
+```
+
+Expected: PASS for lint, unit tests, and build.
+
+**Step 4: Inspect intended changes**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected changed files after implementation:
+
+```text
+M packages/app/src/App.tsx
+M packages/app/src/DocumentWorkspace.tsx
+M packages/app/src/PageCard.tsx
+M packages/app/e2e/markdown-roundtrip.spec.ts
+M packages/app/test/page-card.test.tsx
+M packages/app/test/view-toggle-bugs.test.tsx
+A packages/app/test/app-save-warning.test.tsx
+```
+
+**Step 5: Commit final fixes if needed**
+
+If `pnpm check` required any cleanup, commit it:
+
+```bash
+git add packages/app/src/App.tsx packages/app/src/DocumentWorkspace.tsx packages/app/src/PageCard.tsx packages/app/e2e/markdown-roundtrip.spec.ts packages/app/test/page-card.test.tsx packages/app/test/view-toggle-bugs.test.tsx packages/app/test/app-save-warning.test.tsx
+git commit -m "fix: polish document save indicator integration"
+```
+
+Skip this commit if no final cleanup was needed.
+
+## Review Checklist
+
+- `Cmd-S` / `Ctrl-S` never opens the browser Save Page dialog while a document is open.
+- Manual save writes the current markdown from both rich-text and code views.
+- Autosave remains enabled and still debounces normal edits.
+- Manual save cancels pending debounce instead of causing a duplicate write.
+- Save failures show `Save failed` and do not mark dirty content as saved.
+- Disk conflicts still route through `MarkdownFileConflictError` and the existing conflict banner.
+- The save indicator is visible persistently, including the initial `Saved` state.
+- When `I'm done` is visible, save status is directly below it in the same top-right stack.
+- `I'm done` is disabled unless the document is saved and conflict-free.
+- `beforeunload` warns only when there is local risk.
+- No `Save As`, file picker, database, git behavior, or multi-file workflow was added.

--- a/packages/app/e2e/criticmarkup-review.spec.ts
+++ b/packages/app/e2e/criticmarkup-review.spec.ts
@@ -46,9 +46,11 @@ test.describe("CriticMarkup review flows", () => {
     await page
       .getByPlaceholder("Write a reply")
       .fill("Added context looks good.");
-    await page.getByLabel("Save").evaluate((element) => {
-      (element as HTMLButtonElement).click();
-    });
+    await page
+      .getByTestId("comment-rail-c2-action-save")
+      .evaluate((element) => {
+        (element as HTMLButtonElement).click();
+      });
 
     await expect
       .poll(() => readProjectFile(projectDir, "comment.md"))
@@ -80,7 +82,7 @@ test.describe("CriticMarkup review flows", () => {
     await page
       .getByRole("textbox", { name: "Add your comment" })
       .fill("Clarify this phrase.");
-    await page.locator('button[aria-label="Save"]:visible').click();
+    await page.getByTestId("comment-rail-c1-action-save").click();
 
     await expect
       .poll(() => readProjectFile(projectDir, "new-comment.md"))

--- a/packages/app/e2e/markdown-roundtrip.spec.ts
+++ b/packages/app/e2e/markdown-roundtrip.spec.ts
@@ -89,4 +89,28 @@ test.describe("markdown round-trips", () => {
       size: fs.statSync(filePath).size,
     });
   });
+
+  test("manual save shortcut flushes code-mode edits to disk @smoke", async ({
+    page,
+  }) => {
+    const initial = ["# Manual Save", "", "Initial body.", ""].join("\n");
+    const filePath = writeProjectFile(projectDir, "manual-save.md", initial);
+
+    await openMarkdownFile(page, filePath, "code");
+    await appendInCodeEditor(page, "\nSaved by shortcut.\n");
+
+    await page.keyboard.press(
+      process.platform === "darwin" ? "Meta+S" : "Control+S",
+    );
+
+    await expect
+      .poll(() => readProjectFile(projectDir, "manual-save.md"))
+      .toContain("Saved by shortcut.");
+    await expect(page.getByRole("status", { name: "Saved" })).toBeVisible();
+
+    logE2eEvent("markdown-roundtrip.manual-save-shortcut", {
+      file: "manual-save.md",
+      size: fs.statSync(filePath).size,
+    });
+  });
 });

--- a/packages/app/e2e/markdown-roundtrip.spec.ts
+++ b/packages/app/e2e/markdown-roundtrip.spec.ts
@@ -90,6 +90,22 @@ test.describe("markdown round-trips", () => {
     });
   });
 
+  test("initial open shows persistent saved status", async ({ page }) => {
+    const filePath = writeProjectFile(
+      projectDir,
+      "initial-saved.md",
+      "# Initial Saved\n\nBody.\n",
+    );
+
+    await openMarkdownFile(page, filePath);
+
+    await expect(page.getByRole("status", { name: "Saved" })).toBeVisible();
+
+    logE2eEvent("markdown-roundtrip.initial-saved", {
+      file: "initial-saved.md",
+    });
+  });
+
   test("manual save shortcut flushes code-mode edits to disk @smoke", async ({
     page,
   }) => {
@@ -111,6 +127,85 @@ test.describe("markdown round-trips", () => {
     logE2eEvent("markdown-roundtrip.manual-save-shortcut", {
       file: "manual-save.md",
       size: fs.statSync(filePath).size,
+    });
+  });
+
+  test("manual save shortcut flushes rich-text edits to disk", async ({
+    page,
+  }) => {
+    const initial = ["# Rich Save", "", "Initial body.", ""].join("\n");
+    const filePath = writeProjectFile(projectDir, "rich-save.md", initial);
+
+    await openMarkdownFile(page, filePath, "rich-text");
+    const editor = page.locator(".ProseMirror");
+    await expect(editor).toBeVisible();
+    await editor.click();
+    await page.keyboard.press(
+      process.platform === "darwin" ? "Meta+End" : "Control+End",
+    );
+    await page.keyboard.type(" Saved by shortcut.");
+    await page.keyboard.press(
+      process.platform === "darwin" ? "Meta+S" : "Control+S",
+    );
+
+    await expect
+      .poll(() => readProjectFile(projectDir, "rich-save.md"))
+      .toContain("Saved by shortcut.");
+    await expect(page.getByRole("status", { name: "Saved" })).toBeVisible();
+
+    logE2eEvent("markdown-roundtrip.rich-manual-save", {
+      file: "rich-save.md",
+      size: fs.statSync(filePath).size,
+    });
+  });
+
+  test("save shortcut prevents browser default in rich-text and code modes", async ({
+    page,
+  }) => {
+    const filePath = writeProjectFile(
+      projectDir,
+      "prevent-default.md",
+      "# Prevent Default\n\nBody.\n",
+    );
+
+    for (const editorMode of ["rich-text", "code"] as const) {
+      await openMarkdownFile(page, filePath, editorMode);
+
+      if (editorMode === "code") {
+        await page.locator(".cm-content").click();
+      } else {
+        await page.locator(".ProseMirror").click();
+      }
+
+      const events = await page.evaluate(() =>
+        [
+          { metaKey: true, ctrlKey: false },
+          { metaKey: false, ctrlKey: true },
+        ].map((init) => {
+          const event = new KeyboardEvent("keydown", {
+            key: "s",
+            ...init,
+            bubbles: true,
+            cancelable: true,
+          });
+          window.dispatchEvent(event);
+          return {
+            defaultPrevented: event.defaultPrevented,
+            metaKey: event.metaKey,
+            ctrlKey: event.ctrlKey,
+          };
+        }),
+      );
+
+      expect(events).toEqual([
+        { defaultPrevented: true, metaKey: true, ctrlKey: false },
+        { defaultPrevented: true, metaKey: false, ctrlKey: true },
+      ]);
+      await expect(page.getByRole("status", { name: "Saved" })).toBeVisible();
+    }
+
+    logE2eEvent("markdown-roundtrip.save-default-prevented", {
+      file: "prevent-default.md",
     });
   });
 });

--- a/packages/app/e2e/stale-write.spec.ts
+++ b/packages/app/e2e/stale-write.spec.ts
@@ -38,7 +38,9 @@ test.describe("stale writes", () => {
     fs.writeFileSync(filePath, "# Conflict\n\nExternal body.\n");
     await appendInCodeEditor(page, "\nLocal body.\n");
 
-    await expect(page.getByText("Save conflict")).toBeVisible();
+    await expect(
+      page.getByRole("status", { name: "Save conflict" }),
+    ).toBeVisible();
     await expect(page.getByText("Reload")).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Keep editing" }),
@@ -48,7 +50,9 @@ test.describe("stale writes", () => {
     );
 
     await page.getByRole("button", { name: "Keep editing" }).click();
-    await expect(page.getByText("Autosave paused")).toBeVisible();
+    await expect(
+      page.getByRole("status", { name: "Autosave paused" }),
+    ).toBeVisible();
     await appendInCodeEditor(page, "\nStill local.\n");
     await expect(page.locator(".cm-content")).toContainText("Local body.");
     await expect(page.locator(".cm-content")).toContainText("Still local.");
@@ -58,6 +62,80 @@ test.describe("stale writes", () => {
 
     logE2eEvent("stale-write.conflict-surfaced", {
       file: "conflict.md",
+    });
+  });
+
+  test("overwrite after conflict marks the current draft saved", async ({
+    page,
+  }) => {
+    await page.route("**/api/markdown-file/events**", (route) => route.abort());
+
+    const filePath = writeProjectFile(
+      projectDir,
+      "overwrite-conflict.md",
+      "# Conflict\n\nOriginal body.\n",
+    );
+
+    await openMarkdownFile(page, filePath, "code");
+    await expect(page.locator(".cm-content")).toContainText("Original body.");
+
+    fs.writeFileSync(filePath, "# Conflict\n\nExternal body.\n");
+    await appendInCodeEditor(page, "\nLocal overwrite body.\n");
+
+    await expect(
+      page.getByRole("status", { name: "Save conflict" }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Overwrite disk file" }).click();
+
+    await expect
+      .poll(() => readProjectFile(projectDir, "overwrite-conflict.md"))
+      .toContain("Local overwrite body.");
+    await expect(page.getByRole("status", { name: "Saved" })).toBeVisible();
+    await expect(
+      page.getByRole("status", { name: "Save failed" }),
+    ).toBeHidden();
+    await expect(
+      page.getByRole("status", { name: "Unsaved changes" }),
+    ).toBeHidden();
+
+    logE2eEvent("stale-write.overwrite-saved", {
+      file: "overwrite-conflict.md",
+      size: fs.statSync(filePath).size,
+    });
+  });
+
+  test("manual save preserves expected-version conflict behavior", async ({
+    page,
+  }) => {
+    await page.route("**/api/markdown-file/events**", (route) => route.abort());
+
+    const filePath = writeProjectFile(
+      projectDir,
+      "manual-conflict.md",
+      "# Manual Conflict\n\nOriginal body.\n",
+    );
+
+    await openMarkdownFile(page, filePath, "code");
+    await expect(page.locator(".cm-content")).toContainText("Original body.");
+
+    fs.writeFileSync(filePath, "# Manual Conflict\n\nExternal body.\n");
+    await appendInCodeEditor(page, "\nLocal body.\n");
+    await page.keyboard.press(
+      process.platform === "darwin" ? "Meta+S" : "Control+S",
+    );
+
+    await expect(
+      page.getByRole("status", { name: "Save conflict" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("status", { name: "File conflict" }),
+    ).toContainText("This file changed on disk while you have unsaved edits.");
+    expect(readProjectFile(projectDir, "manual-conflict.md")).toBe(
+      "# Manual Conflict\n\nExternal body.\n",
+    );
+
+    logE2eEvent("stale-write.manual-conflict", {
+      file: "manual-conflict.md",
     });
   });
 
@@ -139,5 +217,56 @@ test.describe("stale writes", () => {
     await expect(
       conflictNotice.getByRole("button", { name: "Overwrite disk file" }),
     ).toBeVisible();
+  });
+
+  test("keeps conflict banner and save status stack from overlapping", async ({
+    page,
+  }) => {
+    await page.route("**/api/markdown-file/events**", (route) => route.abort());
+
+    const filePath = writeProjectFile(
+      projectDir,
+      "layout-conflict.md",
+      "# Layout conflict\n\nOriginal body.\n",
+    );
+
+    for (const viewport of [
+      { width: 1280, height: 720 },
+      { width: 390, height: 844 },
+    ]) {
+      fs.writeFileSync(filePath, "# Layout conflict\n\nOriginal body.\n");
+      await page.setViewportSize(viewport);
+      await openMarkdownFile(page, filePath, "code");
+      await expect(page.locator(".cm-content")).toContainText("Original body.");
+
+      fs.writeFileSync(filePath, "# Layout conflict\n\nExternal body.\n");
+      await appendInCodeEditor(page, `\nLocal body ${viewport.width}.\n`);
+
+      const conflictNotice = page.getByRole("status", {
+        name: "File conflict",
+      });
+      const statusStack = page.locator('[data-document-status-stack="true"]');
+      await expect(conflictNotice).toBeVisible();
+      await expect(statusStack).toBeVisible();
+
+      const conflictBox = await conflictNotice.boundingBox();
+      const stackBox = await statusStack.boundingBox();
+      expect(conflictBox).not.toBeNull();
+      expect(stackBox).not.toBeNull();
+
+      if (!conflictBox || !stackBox) {
+        throw new Error("Expected conflict and status stack bounds");
+      }
+
+      const intersects =
+        conflictBox.x < stackBox.x + stackBox.width &&
+        conflictBox.x + conflictBox.width > stackBox.x &&
+        conflictBox.y < stackBox.y + stackBox.height &&
+        conflictBox.y + conflictBox.height > stackBox.y;
+
+      expect(intersects).toBe(false);
+      await page.getByRole("button", { name: "Reload from disk" }).click();
+      await expect(conflictNotice).toBeHidden();
+    }
   });
 });

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ArrowLeft,
   Braces,
@@ -9,16 +8,17 @@ import {
   MessageSquare,
   PencilLine,
 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
-  type DocumentEditorViewMode,
-  PREVIEW_PATH,
-  ROUGHDRAFT_FLAVORED_MARKDOWN_PATH,
   buildLocationForDocumentEditorViewMode,
+  type DocumentEditorViewMode,
   formatWorkspacePathForDisplay,
   getDocumentEditorViewModeFromLocation,
   getPathLeaf,
   getRequestedPathState,
   joinPath,
+  PREVIEW_PATH,
+  ROUGHDRAFT_FLAVORED_MARKDOWN_PATH,
   syncRequestedPathInUrl,
 } from "./app-navigation";
 import { Button } from "./components/ui/button";
@@ -31,8 +31,8 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "./components/ui/dialog";
-import { detectBackend } from "./detect-backend";
 import { DocumentWorkspace } from "./DocumentWorkspace";
+import { detectBackend } from "./detect-backend";
 import type { DocumentSaveState } from "./PageCard";
 import { PreviewBackend } from "./preview-backend";
 import { RoughdraftFormatDemo } from "./RoughdraftFormatDemo";
@@ -41,8 +41,8 @@ import {
   type Page,
   type StorageBackend,
 } from "./storage";
-import { fetchUpdateStatus, type UpdateStatus } from "./update-status";
 import { UpdateNotice } from "./UpdateNotice";
+import { fetchUpdateStatus, type UpdateStatus } from "./update-status";
 
 export type DocumentDiskChangeState =
   | "clean"
@@ -1003,8 +1003,12 @@ export function App() {
 
     applyDocumentPage(savedDocument);
     documentDirtyRef.current = false;
+    handleDocumentSaveStateChange("saved");
     setDocumentDiskChangeState("clean");
-  }, [applyDocumentPage]);
+    setDocumentForceResetKey(
+      `${currentPath}:${savedDocument.version ?? Date.now()}:overwrite`,
+    );
+  }, [applyDocumentPage, handleDocumentSaveStateChange]);
 
   const handleCompleteReview = useCallback(async () => {
     const currentBackend = backendRef.current;

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -33,6 +33,7 @@ import {
 } from "./components/ui/dialog";
 import { detectBackend } from "./detect-backend";
 import { DocumentWorkspace } from "./DocumentWorkspace";
+import type { DocumentSaveState } from "./PageCard";
 import { PreviewBackend } from "./preview-backend";
 import { RoughdraftFormatDemo } from "./RoughdraftFormatDemo";
 import {
@@ -43,8 +44,33 @@ import {
 import { fetchUpdateStatus, type UpdateStatus } from "./update-status";
 import { UpdateNotice } from "./UpdateNotice";
 
-type SaveState = "idle" | "saving" | "error";
-type DocumentDiskChangeState = "clean" | "changed" | "conflict" | "paused";
+export type DocumentDiskChangeState =
+  | "clean"
+  | "changed"
+  | "conflict"
+  | "paused";
+
+export function shouldWarnBeforeUnload({
+  activeDocumentPath,
+  isDirty,
+  saveState,
+  diskChangeState,
+}: {
+  activeDocumentPath: string | null;
+  isDirty: boolean;
+  saveState: DocumentSaveState;
+  diskChangeState: DocumentDiskChangeState;
+}) {
+  return (
+    !!activeDocumentPath &&
+    (isDirty ||
+      saveState === "saving" ||
+      saveState === "unsaved" ||
+      saveState === "error" ||
+      diskChangeState !== "clean")
+  );
+}
+
 const AGENT_SETUP_PROMPT =
   "Install Roughdraft for me using `npm i -g roughdraft`, then read https://roughdraft.page/setup.md and set yourself up to use it.";
 const PREVIEW_DOCUMENT_PATH = "preview.md";
@@ -606,7 +632,7 @@ export function PreviewPage() {
   const [editorViewMode, setEditorViewMode] = useState<DocumentEditorViewMode>(
     () => getDocumentEditorViewModeFromLocation("rich-text"),
   );
-  const [, setSaveState] = useState<SaveState>("idle");
+  const [, setSaveState] = useState<DocumentSaveState>("saved");
 
   useEffect(() => () => backend.dispose(), [backend]);
 
@@ -676,7 +702,8 @@ export function App() {
   const [activeDocumentPath, setActiveDocumentPath] = useState<string | null>(
     initialRequestedPathState.documentPath,
   );
-  const [, setDocumentSaveState] = useState<SaveState>("idle");
+  const [documentSaveState, setDocumentSaveState] =
+    useState<DocumentSaveState>("saved");
   const [documentDiskChangeState, setDocumentDiskChangeState] =
     useState<DocumentDiskChangeState>("clean");
   const [documentForceResetKey, setDocumentForceResetKey] = useState<
@@ -692,11 +719,13 @@ export function App() {
   const documentPageRef = useRef<Page | null>(null);
   const activeDocumentPathRef = useRef<string | null>(activeDocumentPath);
   const documentDirtyRef = useRef(false);
+  const documentSaveStateRef = useRef<DocumentSaveState>("saved");
   const documentDraftContentRef = useRef<string | null>(null);
 
   backendRef.current = backend;
   documentPageRef.current = documentPage;
   activeDocumentPathRef.current = activeDocumentPath;
+  documentSaveStateRef.current = documentSaveState;
 
   const applyDocumentPage = useCallback((nextDocument: Page) => {
     setDocumentPage(nextDocument);
@@ -901,9 +930,38 @@ export function App() {
     documentDirtyRef.current = isDirty;
   }, []);
 
+  const handleDocumentSaveStateChange = useCallback(
+    (state: DocumentSaveState) => {
+      documentSaveStateRef.current = state;
+      setDocumentSaveState(state);
+    },
+    [],
+  );
+
   const handleDocumentLocalContentChange = useCallback((markdown: string) => {
     documentDraftContentRef.current = markdown;
   }, []);
+
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (
+        !shouldWarnBeforeUnload({
+          activeDocumentPath: activeDocumentPathRef.current,
+          isDirty: documentDirtyRef.current,
+          saveState: documentSaveStateRef.current,
+          diskChangeState: documentDiskChangeState,
+        })
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [documentDiskChangeState]);
 
   const handleReloadDocumentFromDisk = useCallback(async () => {
     const currentBackend = backendRef.current;
@@ -1101,7 +1159,7 @@ export function App() {
         documentEditorViewMode={documentEditorViewMode}
         onDocumentEditorViewModeChange={handleDocumentEditorViewModeChange}
         onSaveDocument={handleSaveDocument}
-        onDocumentSaveStateChange={setDocumentSaveState}
+        onDocumentSaveStateChange={handleDocumentSaveStateChange}
         onDocumentDirtyStateChange={handleDocumentDirtyStateChange}
         onDocumentLocalContentChange={handleDocumentLocalContentChange}
         documentDiskChangeState={documentDiskChangeState}

--- a/packages/app/src/CommentEditorList.tsx
+++ b/packages/app/src/CommentEditorList.tsx
@@ -342,6 +342,7 @@ const COMMENT_AVATAR_CENTER = 16;
 
 function CommentActionButton({
   label,
+  testId,
   tone = "neutral",
   icon,
   compact = false,
@@ -349,6 +350,7 @@ function CommentActionButton({
   onClick,
 }: {
   label: string;
+  testId?: string;
   tone?: "neutral" | "danger";
   icon: ReactNode;
   compact?: boolean;
@@ -361,6 +363,7 @@ function CommentActionButton({
         render={
           <Button
             type="button"
+            data-testid={testId}
             variant="ghost"
             size={compact ? "icon-xs" : "sm"}
             className={cn(
@@ -718,6 +721,7 @@ function CommentThreadNode({
                   <CommentActionButton
                     key={action.key}
                     label={action.label}
+                    testId={`comment-${variant}-${comment.id}-action-${action.key}`}
                     tone={action.tone}
                     icon={action.icon}
                     compact={action.compact}

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { DocumentEditorViewMode } from "./app-navigation";
+import { RemoteSessionBanner } from "./components/RemoteSessionBanner";
 import { Button } from "./components/ui/button";
 import {
   Popover,
@@ -34,15 +35,20 @@ import {
 import { criticMarkdownHasReviewRail } from "./critic-markup";
 import { cn } from "./lib/utils";
 import {
-  PageCard,
   type DocumentInteractionMode,
   type DocumentSaveController,
   type DocumentSaveState,
+  PageCard,
 } from "./PageCard";
-import { RemoteSessionBanner } from "./components/RemoteSessionBanner";
 import type { Page, StorageBackend } from "./storage";
 
 type DiskChangeState = "clean" | "changed" | "conflict" | "paused";
+type ReviewHandoffState =
+  | "idle"
+  | "notifying"
+  | "notified"
+  | "undelivered"
+  | "error";
 
 const documentInteractionModeOptions = [
   { value: "editing", label: "editing", Icon: PencilLine },
@@ -179,6 +185,24 @@ export function DocumentSaveStatusIndicator({
   );
 }
 
+export function isReviewHandoffDisabled({
+  saveState,
+  documentDiskChangeState,
+  reviewHandoffState,
+}: {
+  saveState: DocumentSaveState;
+  documentDiskChangeState: DiskChangeState;
+  reviewHandoffState: ReviewHandoffState;
+}) {
+  return (
+    saveState === "saving" ||
+    saveState === "unsaved" ||
+    saveState === "error" ||
+    reviewHandoffState !== "idle" ||
+    documentDiskChangeState !== "clean"
+  );
+}
+
 interface DocumentWorkspaceProps {
   documentPage: Page | null;
   activeDocumentPath: string | null;
@@ -219,9 +243,8 @@ export function DocumentWorkspace({
   const [documentInteractionMode, setDocumentInteractionMode] =
     useState<DocumentInteractionMode>("editing");
   const [saveState, setSaveState] = useState<DocumentSaveState>("saved");
-  const [reviewHandoffState, setReviewHandoffState] = useState<
-    "idle" | "notifying" | "notified" | "undelivered" | "error"
-  >("idle");
+  const [reviewHandoffState, setReviewHandoffState] =
+    useState<ReviewHandoffState>("idle");
   const [reviewWatcherCount, setReviewWatcherCount] = useState(0);
   const sawNoWatcherAfterNotifiedRef = useRef(false);
   const saveControllerRef = useRef<DocumentSaveController | null>(null);
@@ -399,7 +422,10 @@ export function DocumentWorkspace({
     >
       <RemoteSessionBanner backend={backend} />
       <div
-        className="fixed top-3 right-3 z-[60] flex max-w-[min(16rem,calc(100vw-1rem))] flex-col items-end gap-1.5"
+        className={cn(
+          "fixed right-3 z-[60] flex max-w-[min(16rem,calc(100vw-1rem))] flex-col items-end gap-1.5",
+          conflictNotice ? "top-[19rem] sm:top-[7rem]" : "top-3",
+        )}
         data-document-status-stack="true"
       >
         {showReviewHandoffButton ? (
@@ -410,13 +436,11 @@ export function DocumentWorkspace({
                   type="button"
                   size="lg"
                   className="h-9 rounded-[7px] bg-black px-3 text-sm font-bold text-white shadow-[0_10px_28px_rgba(0,0,0,0.18)] hover:bg-black/85 focus-visible:ring-black/25 dark:bg-black dark:text-white dark:hover:bg-black/85 dark:focus-visible:ring-white/30"
-                  disabled={
-                    saveState === "saving" ||
-                    saveState === "unsaved" ||
-                    saveState === "error" ||
-                    reviewHandoffState !== "idle" ||
-                    documentDiskChangeState !== "clean"
-                  }
+                  disabled={isReviewHandoffDisabled({
+                    saveState,
+                    documentDiskChangeState,
+                    reviewHandoffState,
+                  })}
                   onClick={() => void handleCompleteReview()}
                 >
                   <ReviewHandoffButtonIcon

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -33,11 +33,15 @@ import {
 } from "./components/ui/tooltip";
 import { criticMarkdownHasReviewRail } from "./critic-markup";
 import { cn } from "./lib/utils";
-import { PageCard, type DocumentInteractionMode } from "./PageCard";
+import {
+  PageCard,
+  type DocumentInteractionMode,
+  type DocumentSaveController,
+  type DocumentSaveState,
+} from "./PageCard";
 import { RemoteSessionBanner } from "./components/RemoteSessionBanner";
 import type { Page, StorageBackend } from "./storage";
 
-type SaveState = "idle" | "saving" | "error";
 type DiskChangeState = "clean" | "changed" | "conflict" | "paused";
 
 const documentInteractionModeOptions = [
@@ -71,6 +75,110 @@ const conflictNoticeCopy: Record<
   },
 };
 
+function getSaveStatusViewModel(
+  saveState: DocumentSaveState,
+  diskChangeState: DiskChangeState,
+) {
+  if (diskChangeState === "conflict") {
+    return {
+      label: "Save conflict",
+      ariaLabel: "Save conflict",
+      tone: "warning" as const,
+      Icon: AlertTriangle,
+    };
+  }
+
+  if (diskChangeState === "changed") {
+    return {
+      label: "File changed on disk",
+      ariaLabel: "File changed on disk",
+      tone: "warning" as const,
+      Icon: AlertTriangle,
+    };
+  }
+
+  if (diskChangeState === "paused") {
+    return {
+      label: "Autosave paused",
+      ariaLabel: "Autosave paused",
+      tone: "warning" as const,
+      Icon: AlertTriangle,
+    };
+  }
+
+  if (saveState === "saving") {
+    return {
+      label: "Saving",
+      ariaLabel: "Saving",
+      tone: "neutral" as const,
+      Icon: Loader2,
+    };
+  }
+
+  if (saveState === "error") {
+    return {
+      label: "Save failed",
+      ariaLabel: "Save failed",
+      tone: "danger" as const,
+      Icon: AlertTriangle,
+    };
+  }
+
+  if (saveState === "unsaved") {
+    return {
+      label: "Unsaved changes",
+      ariaLabel: "Unsaved changes",
+      tone: "warning" as const,
+      Icon: AlertTriangle,
+    };
+  }
+
+  return {
+    label: "Saved",
+    ariaLabel: "Saved",
+    tone: "success" as const,
+    Icon: Check,
+  };
+}
+
+export function DocumentSaveStatusIndicator({
+  saveState,
+  diskChangeState,
+}: {
+  saveState: DocumentSaveState;
+  diskChangeState: DiskChangeState;
+}) {
+  const saveStatus = getSaveStatusViewModel(saveState, diskChangeState);
+  const SaveStatusIcon = saveStatus.Icon;
+
+  return (
+    <span
+      role="status"
+      aria-label={saveStatus.ariaLabel}
+      className={cn(
+        "inline-flex h-7 max-w-full shrink-0 items-center gap-1.5 rounded-[7px] border bg-white/92 px-2.5 font-mono text-[0.68rem] leading-none shadow-[0_8px_22px_rgba(15,23,42,0.08)] backdrop-blur dark:bg-slate-950/88",
+        saveStatus.tone === "success" &&
+          "border-emerald-200 text-emerald-700 dark:border-emerald-800 dark:text-emerald-300",
+        saveStatus.tone === "warning" &&
+          "border-amber-200 text-amber-800 dark:border-amber-800 dark:text-amber-300",
+        saveStatus.tone === "danger" &&
+          "border-red-200 text-red-700 dark:border-red-800 dark:text-red-300",
+        saveStatus.tone === "neutral" &&
+          "border-stone-200 text-stone-500 dark:border-slate-700 dark:text-slate-300",
+      )}
+    >
+      <SaveStatusIcon
+        className={cn(
+          "size-3.5 shrink-0",
+          saveStatus.label === "Saving" && "animate-spin",
+        )}
+        aria-hidden="true"
+      />
+      <span className="min-w-0 truncate">{saveStatus.label}</span>
+    </span>
+  );
+}
+
 interface DocumentWorkspaceProps {
   documentPage: Page | null;
   activeDocumentPath: string | null;
@@ -78,7 +186,7 @@ interface DocumentWorkspaceProps {
   documentEditorViewMode: DocumentEditorViewMode;
   onDocumentEditorViewModeChange: (mode: DocumentEditorViewMode) => void;
   onSaveDocument: (id: string, content: string) => Promise<void>;
-  onDocumentSaveStateChange: (state: SaveState) => void;
+  onDocumentSaveStateChange: (state: DocumentSaveState) => void;
   onDocumentDirtyStateChange: (isDirty: boolean) => void;
   onDocumentLocalContentChange: (markdown: string) => void;
   documentDiskChangeState: DiskChangeState;
@@ -110,28 +218,18 @@ export function DocumentWorkspace({
 }: DocumentWorkspaceProps) {
   const [documentInteractionMode, setDocumentInteractionMode] =
     useState<DocumentInteractionMode>("editing");
-  const [saveState, setSaveState] = useState<SaveState>("idle");
-  const [showSaved, setShowSaved] = useState(false);
+  const [saveState, setSaveState] = useState<DocumentSaveState>("saved");
   const [reviewHandoffState, setReviewHandoffState] = useState<
     "idle" | "notifying" | "notified" | "undelivered" | "error"
   >("idle");
   const [reviewWatcherCount, setReviewWatcherCount] = useState(0);
   const sawNoWatcherAfterNotifiedRef = useRef(false);
-  const wasSavingRef = useRef(false);
+  const saveControllerRef = useRef<DocumentSaveController | null>(null);
 
   const handleSaveStateChange = useCallback(
-    (state: SaveState) => {
+    (state: DocumentSaveState) => {
       setSaveState(state);
       onDocumentSaveStateChange(state);
-      if (state === "saving") {
-        wasSavingRef.current = true;
-        setShowSaved(false);
-      } else if (state === "idle" && wasSavingRef.current) {
-        wasSavingRef.current = false;
-        setShowSaved(true);
-        const timer = setTimeout(() => setShowSaved(false), 2000);
-        return () => clearTimeout(timer);
-      }
     },
     [onDocumentSaveStateChange],
   );
@@ -205,6 +303,31 @@ export function DocumentWorkspace({
     }
   }, [reviewHandoffState, reviewWatcherCount]);
 
+  useEffect(() => {
+    if (!documentPage) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isSaveShortcut =
+        event.key.toLowerCase() === "s" &&
+        (event.metaKey || event.ctrlKey) &&
+        !event.altKey;
+
+      if (!isSaveShortcut) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (documentDiskChangeState !== "clean") return;
+
+      void saveControllerRef.current?.flushSave();
+    };
+
+    window.addEventListener("keydown", handleKeyDown, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown, { capture: true });
+    };
+  }, [documentDiskChangeState, documentPage]);
+
   const handleCompleteReview = useCallback(async () => {
     if (!activeDocumentPath || reviewHandoffState === "notifying") return;
 
@@ -275,8 +398,11 @@ export function DocumentWorkspace({
       )}
     >
       <RemoteSessionBanner backend={backend} />
-      {showReviewHandoffButton ? (
-        <div className="fixed top-3 right-3 z-[60]">
+      <div
+        className="fixed top-3 right-3 z-[60] flex max-w-[min(16rem,calc(100vw-1rem))] flex-col items-end gap-1.5"
+        data-document-status-stack="true"
+      >
+        {showReviewHandoffButton ? (
           <Popover>
             <PopoverTrigger
               render={
@@ -286,6 +412,8 @@ export function DocumentWorkspace({
                   className="h-9 rounded-[7px] bg-black px-3 text-sm font-bold text-white shadow-[0_10px_28px_rgba(0,0,0,0.18)] hover:bg-black/85 focus-visible:ring-black/25 dark:bg-black dark:text-white dark:hover:bg-black/85 dark:focus-visible:ring-white/30"
                   disabled={
                     saveState === "saving" ||
+                    saveState === "unsaved" ||
+                    saveState === "error" ||
                     reviewHandoffState !== "idle" ||
                     documentDiskChangeState !== "clean"
                   }
@@ -324,8 +452,14 @@ export function DocumentWorkspace({
               </div>
             </PopoverContent>
           </Popover>
-        </div>
-      ) : null}
+        ) : null}
+        {documentPage ? (
+          <DocumentSaveStatusIndicator
+            saveState={saveState}
+            diskChangeState={documentDiskChangeState}
+          />
+        ) : null}
+      </div>
       {conflictNotice ? (
         <div
           role="status"
@@ -436,25 +570,6 @@ export function DocumentWorkspace({
                 >
                   {documentFilenameLabel}
                 </div>
-                {saveState === "saving" ? (
-                  <span
-                    role="status"
-                    aria-label="Saving"
-                    className="inline-flex shrink-0 items-center gap-1 font-mono text-[0.6rem] tracking-[0.01em] text-stone-400 dark:text-stone-500"
-                  >
-                    <Loader2 className="size-[0.6rem] animate-spin" />
-                    Saving
-                  </span>
-                ) : showSaved ? (
-                  <span
-                    role="status"
-                    aria-label="Saved"
-                    className="inline-flex shrink-0 items-center gap-1 font-mono text-[0.6rem] tracking-[0.01em] text-stone-400 dark:text-stone-500"
-                  >
-                    <Check className="size-[0.6rem]" />
-                    Saved
-                  </span>
-                ) : null}
                 {activeDocumentPath ? (
                   <div className="ml-auto flex shrink-0 items-center gap-1.5">
                     {reviewHandoffState !== "notified" &&
@@ -535,6 +650,9 @@ export function DocumentWorkspace({
               onCommentRailPresenceChange={setDocumentHasComments}
               onDirtyStateChange={onDocumentDirtyStateChange}
               onLocalContentChange={onDocumentLocalContentChange}
+              onSaveControllerChange={(controller) => {
+                saveControllerRef.current = controller;
+              }}
               saveBlocked={documentDiskChangeState !== "clean"}
               forceResetKey={documentForceResetKey}
             />

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -184,12 +184,7 @@ export function DocumentSaveStatusIndicator({
       role="status"
       aria-label={saveStatus.ariaLabel}
       className={cn(
-        "inline-flex h-7 max-w-full shrink-0 items-center gap-1.5 px-1 font-mono text-[0.68rem] leading-none",
-        saveStatus.tone === "success" &&
-          "text-emerald-700 dark:text-emerald-300",
-        saveStatus.tone === "warning" && "text-amber-800 dark:text-amber-300",
-        saveStatus.tone === "danger" && "text-red-700 dark:text-red-300",
-        saveStatus.tone === "neutral" && "text-stone-500 dark:text-slate-300",
+        "inline-flex h-7 max-w-full shrink-0 items-center gap-1.5 px-1 font-mono text-[0.68rem] leading-none text-stone-400 dark:text-stone-500",
       )}
     >
       <SaveStatusIcon

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -150,12 +150,34 @@ function getSaveStatusViewModel(
 export function DocumentSaveStatusIndicator({
   saveState,
   diskChangeState,
+  variant = "pill",
 }: {
   saveState: DocumentSaveState;
   diskChangeState: DiskChangeState;
+  variant?: "pill" | "inline";
 }) {
   const saveStatus = getSaveStatusViewModel(saveState, diskChangeState);
   const SaveStatusIcon = saveStatus.Icon;
+
+  if (variant === "inline") {
+    return (
+      <span
+        role="status"
+        aria-label={saveStatus.ariaLabel}
+        data-document-save-status-inline="true"
+        className="mt-0.5 inline-flex max-w-full items-center gap-1 overflow-hidden font-mono text-[0.62rem] leading-none font-semibold text-white/75 dark:text-white/75"
+      >
+        <SaveStatusIcon
+          className={cn(
+            "size-3 shrink-0",
+            saveStatus.label === "Saving" && "animate-spin",
+          )}
+          aria-hidden="true"
+        />
+        <span className="min-w-0 truncate">{saveStatus.label}</span>
+      </span>
+    );
+  }
 
   return (
     <span
@@ -435,7 +457,7 @@ export function DocumentWorkspace({
                 <Button
                   type="button"
                   size="lg"
-                  className="h-9 rounded-[7px] bg-black px-3 text-sm font-bold text-white shadow-[0_10px_28px_rgba(0,0,0,0.18)] hover:bg-black/85 focus-visible:ring-black/25 dark:bg-black dark:text-white dark:hover:bg-black/85 dark:focus-visible:ring-white/30"
+                  className="h-auto min-h-10 rounded-[7px] bg-black px-3 py-1.5 text-sm font-bold text-white shadow-[0_10px_28px_rgba(0,0,0,0.18)] hover:bg-black/85 focus-visible:ring-black/25 dark:bg-black dark:text-white dark:hover:bg-black/85 dark:focus-visible:ring-white/30"
                   disabled={isReviewHandoffDisabled({
                     saveState,
                     documentDiskChangeState,
@@ -449,7 +471,16 @@ export function DocumentWorkspace({
                       reviewHandoffState === "notifying" && "animate-spin",
                     )}
                   />
-                  {reviewHandoffButtonLabel}
+                  <span className="flex min-w-0 flex-col items-start">
+                    <span className="leading-none">
+                      {reviewHandoffButtonLabel}
+                    </span>
+                    <DocumentSaveStatusIndicator
+                      saveState={saveState}
+                      diskChangeState={documentDiskChangeState}
+                      variant="inline"
+                    />
+                  </span>
                 </Button>
               }
             />
@@ -477,7 +508,7 @@ export function DocumentWorkspace({
             </PopoverContent>
           </Popover>
         ) : null}
-        {documentPage ? (
+        {documentPage && !showReviewHandoffButton ? (
           <DocumentSaveStatusIndicator
             saveState={saveState}
             diskChangeState={documentDiskChangeState}

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -150,34 +150,12 @@ function getSaveStatusViewModel(
 export function DocumentSaveStatusIndicator({
   saveState,
   diskChangeState,
-  variant = "pill",
 }: {
   saveState: DocumentSaveState;
   diskChangeState: DiskChangeState;
-  variant?: "pill" | "inline";
 }) {
   const saveStatus = getSaveStatusViewModel(saveState, diskChangeState);
   const SaveStatusIcon = saveStatus.Icon;
-
-  if (variant === "inline") {
-    return (
-      <span
-        role="status"
-        aria-label={saveStatus.ariaLabel}
-        data-document-save-status-inline="true"
-        className="mt-0.5 inline-flex max-w-full items-center gap-1 overflow-hidden font-mono text-[0.62rem] leading-none font-semibold text-white/75 dark:text-white/75"
-      >
-        <SaveStatusIcon
-          className={cn(
-            "size-3 shrink-0",
-            saveStatus.label === "Saving" && "animate-spin",
-          )}
-          aria-hidden="true"
-        />
-        <span className="min-w-0 truncate">{saveStatus.label}</span>
-      </span>
-    );
-  }
 
   return (
     <span
@@ -449,7 +427,7 @@ export function DocumentWorkspace({
                 <Button
                   type="button"
                   size="lg"
-                  className="h-auto min-h-10 rounded-[7px] bg-black px-3 py-1.5 text-sm font-bold text-white shadow-[0_10px_28px_rgba(0,0,0,0.18)] hover:bg-black/85 focus-visible:ring-black/25 dark:bg-black dark:text-white dark:hover:bg-black/85 dark:focus-visible:ring-white/30"
+                  className="h-9 rounded-[7px] bg-black px-3 text-sm font-bold text-white shadow-[0_10px_28px_rgba(0,0,0,0.18)] hover:bg-black/85 focus-visible:ring-black/25 dark:bg-black dark:text-white dark:hover:bg-black/85 dark:focus-visible:ring-white/30"
                   disabled={isReviewHandoffDisabled({
                     saveState,
                     documentDiskChangeState,
@@ -463,16 +441,7 @@ export function DocumentWorkspace({
                       reviewHandoffState === "notifying" && "animate-spin",
                     )}
                   />
-                  <span className="flex min-w-0 flex-col items-start">
-                    <span className="leading-none">
-                      {reviewHandoffButtonLabel}
-                    </span>
-                    <DocumentSaveStatusIndicator
-                      saveState={saveState}
-                      diskChangeState={documentDiskChangeState}
-                      variant="inline"
-                    />
-                  </span>
+                  {reviewHandoffButtonLabel}
                 </Button>
               }
             />
@@ -500,7 +469,7 @@ export function DocumentWorkspace({
             </PopoverContent>
           </Popover>
         ) : null}
-        {documentPage && !showReviewHandoffButton ? (
+        {documentPage ? (
           <DocumentSaveStatusIndicator
             saveState={saveState}
             diskChangeState={documentDiskChangeState}

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -184,15 +184,12 @@ export function DocumentSaveStatusIndicator({
       role="status"
       aria-label={saveStatus.ariaLabel}
       className={cn(
-        "inline-flex h-7 max-w-full shrink-0 items-center gap-1.5 rounded-[7px] border bg-white/92 px-2.5 font-mono text-[0.68rem] leading-none shadow-[0_8px_22px_rgba(15,23,42,0.08)] backdrop-blur dark:bg-slate-950/88",
+        "inline-flex h-7 max-w-full shrink-0 items-center gap-1.5 px-1 font-mono text-[0.68rem] leading-none",
         saveStatus.tone === "success" &&
-          "border-emerald-200 text-emerald-700 dark:border-emerald-800 dark:text-emerald-300",
-        saveStatus.tone === "warning" &&
-          "border-amber-200 text-amber-800 dark:border-amber-800 dark:text-amber-300",
-        saveStatus.tone === "danger" &&
-          "border-red-200 text-red-700 dark:border-red-800 dark:text-red-300",
-        saveStatus.tone === "neutral" &&
-          "border-stone-200 text-stone-500 dark:border-slate-700 dark:text-slate-300",
+          "text-emerald-700 dark:text-emerald-300",
+        saveStatus.tone === "warning" && "text-amber-800 dark:text-amber-300",
+        saveStatus.tone === "danger" && "text-red-700 dark:text-red-300",
+        saveStatus.tone === "neutral" && "text-stone-500 dark:text-slate-300",
       )}
     >
       <SaveStatusIcon

--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -1,25 +1,25 @@
 import type { JSONContent } from "@tiptap/core";
-import type { Editor } from "@tiptap/react";
-import { EditorContent, useEditor, useEditorState } from "@tiptap/react";
 import type { Mark as ProseMirrorMark } from "@tiptap/pm/model";
 import { TextSelection } from "@tiptap/pm/state";
+import type { Editor } from "@tiptap/react";
+import { EditorContent, useEditor, useEditorState } from "@tiptap/react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { CommentEditorList } from "./CommentEditorList";
 import {
-  DocumentReviewRail,
-  type CriticChangeRailItem,
-} from "./DocumentReviewRail";
-import {
+  type CriticChangeAttrs,
+  type CriticComment,
   createCriticChange,
   createCriticComment,
   criticMarkdownHasReviewRail,
   criticMarkdownToEditorState,
   editorStateToCriticMarkdown,
   getCommentDescendantIds,
-  type CriticChangeAttrs,
-  type CriticComment,
 } from "./critic-markup";
+import {
+  type CriticChangeRailItem,
+  DocumentReviewRail,
+} from "./DocumentReviewRail";
 import { getPreferredCommentId, parseCommentIds } from "./document-comments";
 import { EditorContextMenu } from "./EditorContextMenu";
 import {
@@ -2055,7 +2055,9 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
     async (nextMarkdown: string): Promise<ManualSaveResult> => {
       if (saveBlocked) {
         onSaveStateChange(
-          nextMarkdown === lastAcceptedMarkdownRef.current ? "saved" : "unsaved",
+          nextMarkdown === lastAcceptedMarkdownRef.current
+            ? "saved"
+            : "unsaved",
         );
         return { status: "blocked" };
       }
@@ -2096,7 +2098,9 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
 
       if (saveBlocked) {
         onSaveStateChange(
-          nextMarkdown === lastAcceptedMarkdownRef.current ? "saved" : "unsaved",
+          nextMarkdown === lastAcceptedMarkdownRef.current
+            ? "saved"
+            : "unsaved",
         );
         return;
       }

--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -34,7 +34,17 @@ import { toHtml } from "./markdown";
 import type { Page, StorageBackend } from "./storage";
 import { useCommentAnchorLayout } from "./useCommentAnchorLayout";
 
-type SaveState = "idle" | "saving" | "error";
+export type DocumentSaveState = "saved" | "unsaved" | "saving" | "error";
+
+export type ManualSaveResult =
+  | { status: "saved" }
+  | { status: "blocked" }
+  | { status: "error"; error: unknown };
+
+export interface DocumentSaveController {
+  flushSave: () => Promise<ManualSaveResult>;
+}
+
 type EditorViewMode = "rich-text" | "code";
 export type DocumentInteractionMode = "viewing" | "suggesting" | "editing";
 
@@ -43,7 +53,7 @@ interface PageCardProps {
   selected?: boolean;
   focusRequestKey?: string | null;
   onSave: (id: string, content: string) => Promise<void>;
-  onSaveStateChange?: (state: SaveState) => void;
+  onSaveStateChange?: (state: DocumentSaveState) => void;
   editorViewMode?: EditorViewMode;
   interactionMode?: DocumentInteractionMode;
   backend: StorageBackend;
@@ -51,6 +61,7 @@ interface PageCardProps {
   onCommentRailPresenceChange?: (hasCommentRailSpace: boolean) => void;
   onDirtyStateChange?: (isDirty: boolean) => void;
   onLocalContentChange?: (markdown: string) => void;
+  onSaveControllerChange?: (controller: DocumentSaveController | null) => void;
   saveBlocked?: boolean;
   forceResetKey?: string | null;
 }
@@ -60,7 +71,7 @@ interface PageCardEditorSurfaceProps {
   selected: boolean;
   focusRequestKey: string | null;
   onSave: (id: string, content: string) => Promise<void>;
-  onSaveStateChange: (state: SaveState) => void;
+  onSaveStateChange: (state: DocumentSaveState) => void;
   editorViewMode: EditorViewMode;
   interactionMode: DocumentInteractionMode;
   backend: StorageBackend;
@@ -68,6 +79,7 @@ interface PageCardEditorSurfaceProps {
   onCommentRailPresenceChange?: (hasCommentRailSpace: boolean) => void;
   onDirtyStateChange?: (isDirty: boolean) => void;
   onLocalContentChange?: (markdown: string) => void;
+  onSaveControllerChange?: (controller: DocumentSaveController | null) => void;
   saveBlocked?: boolean;
   forceResetKey?: string | null;
 }
@@ -1990,10 +2002,13 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
   onCommentRailPresenceChange,
   onDirtyStateChange,
   onLocalContentChange,
+  onSaveControllerChange,
   saveBlocked = false,
   forceResetKey = null,
 }: PageCardEditorSurfaceProps) {
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inFlightSaveRef = useRef<Promise<ManualSaveResult> | null>(null);
+  const pendingMarkdownRef = useRef(page.content);
   const recentMarkdownRef = useRef<Set<string>>(new Set());
   const previousEditorViewModeRef = useRef<EditorViewMode>(editorViewMode);
   const lastAcceptedMarkdownRef = useRef(page.content);
@@ -2016,43 +2031,123 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
 
   const acceptMarkdown = useCallback(
     (nextMarkdown: string) => {
+      pendingMarkdownRef.current = nextMarkdown;
       lastAcceptedMarkdownRef.current = nextMarkdown;
       setMarkdown(nextMarkdown);
       setRichTextSourceMarkdown(nextMarkdown);
       setRichTextSourceVersion((current) => current + 1);
       onLocalContentChange?.(nextMarkdown);
       reportDirtyState(false);
+      onSaveStateChange("saved");
     },
-    [onLocalContentChange, reportDirtyState],
+    [onLocalContentChange, onSaveStateChange, reportDirtyState],
+  );
+
+  const rememberRecentMarkdown = useCallback((nextMarkdown: string) => {
+    recentMarkdownRef.current.add(nextMarkdown);
+    if (recentMarkdownRef.current.size > 10) {
+      const iterator = recentMarkdownRef.current.values();
+      recentMarkdownRef.current.delete(iterator.next().value as string);
+    }
+  }, []);
+
+  const performSave = useCallback(
+    async (nextMarkdown: string): Promise<ManualSaveResult> => {
+      if (saveBlocked) {
+        onSaveStateChange(
+          nextMarkdown === lastAcceptedMarkdownRef.current ? "saved" : "unsaved",
+        );
+        return { status: "blocked" };
+      }
+
+      rememberRecentMarkdown(nextMarkdown);
+      onSaveStateChange("saving");
+
+      try {
+        await onSave(page.id, nextMarkdown);
+        lastAcceptedMarkdownRef.current = nextMarkdown;
+        reportDirtyState(pendingMarkdownRef.current !== nextMarkdown);
+        onSaveStateChange(
+          pendingMarkdownRef.current === nextMarkdown ? "saved" : "saving",
+        );
+        return { status: "saved" };
+      } catch (error) {
+        console.error("Failed to save page:", error);
+        onSaveStateChange("error");
+        return { status: "error", error };
+      }
+    },
+    [
+      onSave,
+      onSaveStateChange,
+      page.id,
+      rememberRecentMarkdown,
+      reportDirtyState,
+      saveBlocked,
+    ],
   );
 
   const scheduleSave = useCallback(
     (nextMarkdown: string) => {
-      if (saveBlocked) return;
-
-      recentMarkdownRef.current.add(nextMarkdown);
-      if (recentMarkdownRef.current.size > 10) {
-        const iterator = recentMarkdownRef.current.values();
-        recentMarkdownRef.current.delete(iterator.next().value as string);
+      if (saveTimer.current) {
+        clearTimeout(saveTimer.current);
+        saveTimer.current = null;
       }
 
-      if (saveTimer.current) clearTimeout(saveTimer.current);
+      if (saveBlocked) {
+        onSaveStateChange(
+          nextMarkdown === lastAcceptedMarkdownRef.current ? "saved" : "unsaved",
+        );
+        return;
+      }
+
       onSaveStateChange("saving");
-      saveTimer.current = setTimeout(async () => {
-        try {
-          await onSave(page.id, nextMarkdown);
-          onSaveStateChange("idle");
-        } catch (error) {
-          console.error("Failed to save page:", error);
-          onSaveStateChange("error");
-        }
+      saveTimer.current = setTimeout(() => {
+        saveTimer.current = null;
+        inFlightSaveRef.current = performSave(nextMarkdown).finally(() => {
+          inFlightSaveRef.current = null;
+        });
+        void inFlightSaveRef.current;
       }, 500);
     },
-    [onSave, onSaveStateChange, page.id, saveBlocked],
+    [onSaveStateChange, performSave, saveBlocked],
   );
+
+  const flushSave = useCallback(async (): Promise<ManualSaveResult> => {
+    if (saveTimer.current) {
+      clearTimeout(saveTimer.current);
+      saveTimer.current = null;
+    }
+
+    const currentMarkdown = pendingMarkdownRef.current;
+
+    if (
+      currentMarkdown === lastAcceptedMarkdownRef.current &&
+      !inFlightSaveRef.current
+    ) {
+      onSaveStateChange("saved");
+      return { status: "saved" };
+    }
+
+    if (inFlightSaveRef.current) {
+      await inFlightSaveRef.current;
+      if (pendingMarkdownRef.current === lastAcceptedMarkdownRef.current) {
+        onSaveStateChange("saved");
+        return { status: "saved" };
+      }
+    }
+
+    return await performSave(pendingMarkdownRef.current);
+  }, [onSaveStateChange, performSave]);
+
+  useEffect(() => {
+    onSaveControllerChange?.({ flushSave });
+    return () => onSaveControllerChange?.(null);
+  }, [flushSave, onSaveControllerChange]);
 
   const handleMarkdownChange = useCallback(
     (nextMarkdown: string) => {
+      pendingMarkdownRef.current = nextMarkdown;
       setMarkdown(nextMarkdown);
       onLocalContentChange?.(nextMarkdown);
       reportDirtyState(nextMarkdown !== lastAcceptedMarkdownRef.current);
@@ -2074,6 +2169,7 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
     if (recentMarkdownRef.current.has(page.content)) {
       recentMarkdownRef.current.delete(page.content);
       lastAcceptedMarkdownRef.current = page.content;
+      pendingMarkdownRef.current = markdown;
       reportDirtyState(markdown !== page.content);
       return;
     }
@@ -2084,6 +2180,7 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
 
     if (markdown === page.content) {
       lastAcceptedMarkdownRef.current = page.content;
+      pendingMarkdownRef.current = page.content;
       reportDirtyState(false);
       return;
     }
@@ -2095,7 +2192,11 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
     if (!saveBlocked || !saveTimer.current) return;
     clearTimeout(saveTimer.current);
     saveTimer.current = null;
-    onSaveStateChange("idle");
+    onSaveStateChange(
+      pendingMarkdownRef.current === lastAcceptedMarkdownRef.current
+        ? "saved"
+        : "unsaved",
+    );
   }, [onSaveStateChange, saveBlocked]);
 
   useEffect(() => {
@@ -2175,10 +2276,11 @@ export function PageCard({
   onCommentRailPresenceChange,
   onDirtyStateChange,
   onLocalContentChange,
+  onSaveControllerChange,
   saveBlocked,
   forceResetKey,
 }: PageCardProps) {
-  const [saveState, setSaveState] = useState<SaveState>("idle");
+  const [saveState, setSaveState] = useState<DocumentSaveState>("saved");
 
   useEffect(() => {
     onSaveStateChange?.(saveState);
@@ -2199,6 +2301,7 @@ export function PageCard({
         onCommentRailPresenceChange={onCommentRailPresenceChange}
         onDirtyStateChange={onDirtyStateChange}
         onLocalContentChange={onLocalContentChange}
+        onSaveControllerChange={onSaveControllerChange}
         saveBlocked={saveBlocked}
         forceResetKey={forceResetKey}
       />

--- a/packages/app/src/components/ui/popover.tsx
+++ b/packages/app/src/components/ui/popover.tsx
@@ -30,7 +30,7 @@ function PopoverContent({
         alignOffset={alignOffset}
         side={side}
         sideOffset={sideOffset}
-        className="isolate z-50"
+        className="isolate z-[70]"
       >
         <PopoverPrimitive.Popup
           data-slot="popover-content"

--- a/packages/app/test/app-save-warning.test.tsx
+++ b/packages/app/test/app-save-warning.test.tsx
@@ -7,10 +7,7 @@ describe("beforeunload save warning", () => {
     [{ isDirty: false, saveState: "saving", diskChangeState: "clean" }, true],
     [{ isDirty: false, saveState: "unsaved", diskChangeState: "clean" }, true],
     [{ isDirty: false, saveState: "error", diskChangeState: "clean" }, true],
-    [
-      { isDirty: false, saveState: "saved", diskChangeState: "conflict" },
-      true,
-    ],
+    [{ isDirty: false, saveState: "saved", diskChangeState: "conflict" }, true],
     [{ isDirty: false, saveState: "saved", diskChangeState: "clean" }, false],
   ] as const)("returns %s for %o", (input, expected) => {
     expect(

--- a/packages/app/test/app-save-warning.test.tsx
+++ b/packages/app/test/app-save-warning.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { shouldWarnBeforeUnload } from "../src/App";
+
+describe("beforeunload save warning", () => {
+  it.each([
+    [{ isDirty: true, saveState: "saved", diskChangeState: "clean" }, true],
+    [{ isDirty: false, saveState: "saving", diskChangeState: "clean" }, true],
+    [{ isDirty: false, saveState: "unsaved", diskChangeState: "clean" }, true],
+    [{ isDirty: false, saveState: "error", diskChangeState: "clean" }, true],
+    [
+      { isDirty: false, saveState: "saved", diskChangeState: "conflict" },
+      true,
+    ],
+    [{ isDirty: false, saveState: "saved", diskChangeState: "clean" }, false],
+  ] as const)("returns %s for %o", (input, expected) => {
+    expect(
+      shouldWarnBeforeUnload({
+        activeDocumentPath: "doc.md",
+        ...input,
+      }),
+    ).toBe(expected);
+  });
+
+  it("does not warn when no document is open", () => {
+    expect(
+      shouldWarnBeforeUnload({
+        activeDocumentPath: null,
+        isDirty: true,
+        saveState: "error",
+        diskChangeState: "conflict",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -1,11 +1,12 @@
-import { act } from "react";
 import type { Editor } from "@tiptap/react";
+import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  type DocumentSaveController,
+  type ManualSaveResult,
   PageCard,
   shouldDismissCommentThread,
-  type DocumentSaveController,
 } from "../src/PageCard";
 import type { Page, StorageBackend } from "../src/storage";
 
@@ -536,7 +537,7 @@ describe("PageCard editor integration", () => {
 
     await insertTextAtEnd(rendered.getEditor(), " failed");
 
-    let result;
+    let result: ManualSaveResult | undefined;
     await act(async () => {
       result = await rendered.getSaveController().flushSave();
     });
@@ -559,7 +560,7 @@ describe("PageCard editor integration", () => {
     await insertTextAtEnd(rendered.getEditor(), " blocked");
     await rendered.rerender({ saveBlocked: true });
 
-    let result;
+    let result: ManualSaveResult | undefined;
     await act(async () => {
       result = await rendered.getSaveController().flushSave();
     });

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -255,6 +255,7 @@ type PageCardTestOptions = Partial<{
   interactionMode: "viewing" | "suggesting" | "editing";
   selected: boolean;
   focusRequestKey: string | null;
+  saveBlocked: boolean;
 }>;
 
 type RenderedPageCard = {
@@ -300,6 +301,7 @@ async function renderPageCard(
     onSaveControllerChange: (controller: DocumentSaveController | null) => {
       saveController = controller;
     },
+    saveBlocked: options.saveBlocked ?? false,
   } as const;
 
   const render = async () => {
@@ -517,6 +519,54 @@ describe("PageCard editor integration", () => {
 
     expect(rendered.onSave).toHaveBeenCalledTimes(1);
     expect(rendered.onSaveStateChange.mock.calls.at(-1)?.[0]).toBe("saved");
+  });
+
+  it("manual save reports save failure without clearing dirty state", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-manual-save-failure-1",
+        title: "Manual Save Failure",
+        content: "Start",
+      },
+      selected: true,
+    });
+    rendered.onSave.mockRejectedValueOnce(new Error("disk unavailable"));
+
+    vi.useFakeTimers();
+
+    await insertTextAtEnd(rendered.getEditor(), " failed");
+
+    let result;
+    await act(async () => {
+      result = await rendered.getSaveController().flushSave();
+    });
+
+    expect(result).toMatchObject({ status: "error" });
+    expect(rendered.onSaveStateChange.mock.calls.at(-1)?.[0]).toBe("error");
+  });
+
+  it("manual save is blocked without calling onSave when disk state blocks saves", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-manual-save-blocked-1",
+        title: "Manual Save Blocked",
+        content: "Start",
+      },
+      selected: true,
+    });
+
+    vi.useFakeTimers();
+    await insertTextAtEnd(rendered.getEditor(), " blocked");
+    await rendered.rerender({ saveBlocked: true });
+
+    let result;
+    await act(async () => {
+      result = await rendered.getSaveController().flushSave();
+    });
+
+    expect(result).toEqual({ status: "blocked" });
+    expect(rendered.onSave).not.toHaveBeenCalled();
+    expect(rendered.onSaveStateChange.mock.calls.at(-1)?.[0]).toBe("unsaved");
   });
 
   it("rich-text edits preserve raw YAML frontmatter on autosave", async () => {

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -2,7 +2,11 @@ import { act } from "react";
 import type { Editor } from "@tiptap/react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { PageCard, shouldDismissCommentThread } from "../src/PageCard";
+import {
+  PageCard,
+  shouldDismissCommentThread,
+  type DocumentSaveController,
+} from "../src/PageCard";
 import type { Page, StorageBackend } from "../src/storage";
 
 function createDomRect({
@@ -258,6 +262,7 @@ type RenderedPageCard = {
   onSave: ReturnType<typeof vi.fn>;
   onSaveStateChange: ReturnType<typeof vi.fn>;
   getEditor: () => Editor;
+  getSaveController: () => DocumentSaveController;
   rerender: (overrides?: PageCardTestOptions) => Promise<void>;
   unmount: () => Promise<void>;
 };
@@ -274,6 +279,7 @@ async function renderPageCard(
   const onSave = vi.fn().mockResolvedValue(undefined);
   const onSaveStateChange = vi.fn();
   let editor: Editor | null = null;
+  let saveController: DocumentSaveController | null = null;
 
   let props = {
     page: options.page ?? {
@@ -290,6 +296,9 @@ async function renderPageCard(
     backend,
     onEditorReady: (nextEditor: Editor | null) => {
       editor = nextEditor;
+    },
+    onSaveControllerChange: (controller: DocumentSaveController | null) => {
+      saveController = controller;
     },
   } as const;
 
@@ -321,6 +330,10 @@ async function renderPageCard(
     getEditor() {
       expect(editor).not.toBeNull();
       return editor as Editor;
+    },
+    getSaveController() {
+      expect(saveController).not.toBeNull();
+      return saveController as DocumentSaveController;
     },
     async rerender(overrides = {}) {
       props = {
@@ -467,7 +480,43 @@ describe("PageCard editor integration", () => {
       "doc-1",
       expect.stringContaining("Start now"),
     );
-    expect(rendered.onSaveStateChange.mock.calls.at(-1)?.[0]).toBe("idle");
+    expect(rendered.onSaveStateChange.mock.calls.at(-1)?.[0]).toBe("saved");
+  });
+
+  it("manual save flushes pending rich-text autosave immediately", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-manual-save-rich-1",
+        title: "Manual Save Rich",
+        content: "Start",
+      },
+      selected: true,
+    });
+
+    vi.useFakeTimers();
+
+    await insertTextAtEnd(rendered.getEditor(), " now");
+
+    expect(rendered.onSaveStateChange.mock.calls.at(-1)?.[0]).toBe("saving");
+    expect(rendered.onSave).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await rendered.getSaveController().flushSave();
+    });
+
+    expect(rendered.onSave).toHaveBeenCalledTimes(1);
+    expect(rendered.onSave).toHaveBeenCalledWith(
+      "doc-manual-save-rich-1",
+      expect.stringContaining("Start now"),
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(rendered.onSave).toHaveBeenCalledTimes(1);
+    expect(rendered.onSaveStateChange.mock.calls.at(-1)?.[0]).toBe("saved");
   });
 
   it("rich-text edits preserve raw YAML frontmatter on autosave", async () => {

--- a/packages/app/test/view-toggle-bugs.test.tsx
+++ b/packages/app/test/view-toggle-bugs.test.tsx
@@ -3,8 +3,8 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildLocationForDocumentEditorViewMode,
-  getDocumentEditorViewModeFromLocation,
   type DocumentEditorViewMode,
+  getDocumentEditorViewModeFromLocation,
 } from "../src/app-navigation";
 import {
   DocumentSaveStatusIndicator,
@@ -295,17 +295,16 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     ["saving", "Saving"],
     ["unsaved", "Unsaved changes"],
     ["error", "Save failed"],
-  ] satisfies Array<[DocumentSaveState, string]>)(
-    "shows persistent %s save status",
-    async (saveState, label) => {
-      await renderSaveStatus({ saveState });
+  ] satisfies Array<
+    [DocumentSaveState, string]
+  >)("shows persistent %s save status", async (saveState, label) => {
+    await renderSaveStatus({ saveState });
 
-      expect(
-        container.querySelector(`[role="status"][aria-label="${label}"]`),
-      ).not.toBeNull();
-      expect(container.textContent).toContain(label);
-    },
-  );
+    expect(
+      container.querySelector(`[role="status"][aria-label="${label}"]`),
+    ).not.toBeNull();
+    expect(container.textContent).toContain(label);
+  });
 
   it.each([
     ["changed", "File changed on disk"],
@@ -323,7 +322,9 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
   it("renders save status in the same top-right stack under the handoff button", async () => {
     await renderWorkspace({ watcherCount: 1 });
 
-    const stack = container.querySelector('[data-document-status-stack="true"]');
+    const stack = container.querySelector(
+      '[data-document-status-stack="true"]',
+    );
     expect(stack).not.toBeNull();
     expect(stack?.textContent).toContain("I'm done");
     expect(stack?.textContent).toContain("Saved");
@@ -381,7 +382,9 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
 
     expect(container.textContent).toContain("Save conflict");
     expect(container.textContent).toContain("This file changed on disk");
-    expect(container.querySelector('[aria-label="Save conflict"]')).not.toBeNull();
+    expect(
+      container.querySelector('[aria-label="Save conflict"]'),
+    ).not.toBeNull();
   });
 });
 

--- a/packages/app/test/view-toggle-bugs.test.tsx
+++ b/packages/app/test/view-toggle-bugs.test.tsx
@@ -320,15 +320,38 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     expect(container.textContent).toContain(label);
   });
 
-  it("renders save status in the same top-right stack under the handoff button", async () => {
+  it("renders save status inside the handoff button when handoff exists", async () => {
     await renderWorkspace({ watcherCount: 1 });
 
     const stack = container.querySelector(
       '[data-document-status-stack="true"]',
     );
+    const doneReviewingButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.includes("I'm done"),
+    );
     expect(stack).not.toBeNull();
-    expect(stack?.textContent).toContain("I'm done");
+    expect(doneReviewingButton).toBeDefined();
+    expect(doneReviewingButton?.textContent).toContain("I'm done");
+    expect(doneReviewingButton?.textContent).toContain("Saved");
+    expect(
+      doneReviewingButton?.querySelector(
+        '[data-document-save-status-inline="true"]',
+      ),
+    ).not.toBeNull();
+  });
+
+  it("renders standalone save status in the top-right stack without handoff", async () => {
+    await renderWorkspace();
+
+    const stack = container.querySelector(
+      '[data-document-status-stack="true"]',
+    );
+    expect(stack).not.toBeNull();
+    expect(stack?.textContent).not.toContain("I'm done");
     expect(stack?.textContent).toContain("Saved");
+    expect(
+      stack?.querySelector('[data-document-save-status-inline="true"]'),
+    ).toBeNull();
   });
 
   it.each([

--- a/packages/app/test/view-toggle-bugs.test.tsx
+++ b/packages/app/test/view-toggle-bugs.test.tsx
@@ -9,6 +9,7 @@ import {
 import {
   DocumentSaveStatusIndicator,
   DocumentWorkspace,
+  isReviewHandoffDisabled,
 } from "../src/DocumentWorkspace";
 import type { DocumentSaveState } from "../src/PageCard";
 import type {
@@ -385,6 +386,33 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     expect(
       container.querySelector('[aria-label="Save conflict"]'),
     ).not.toBeNull();
+  });
+
+  it.each([
+    ["saving", "clean"],
+    ["unsaved", "clean"],
+    ["error", "clean"],
+    ["saved", "conflict"],
+  ] satisfies Array<
+    [DocumentSaveState, "clean" | "changed" | "conflict" | "paused"]
+  >)("keeps handoff disabled for save state %s and disk state %s", (saveState, documentDiskChangeState) => {
+    expect(
+      isReviewHandoffDisabled({
+        saveState,
+        documentDiskChangeState,
+        reviewHandoffState: "idle",
+      }),
+    ).toBe(true);
+  });
+
+  it("allows handoff only when saved, conflict-free, and idle", () => {
+    expect(
+      isReviewHandoffDisabled({
+        saveState: "saved",
+        documentDiskChangeState: "clean",
+        reviewHandoffState: "idle",
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/app/test/view-toggle-bugs.test.tsx
+++ b/packages/app/test/view-toggle-bugs.test.tsx
@@ -6,7 +6,11 @@ import {
   getDocumentEditorViewModeFromLocation,
   type DocumentEditorViewMode,
 } from "../src/app-navigation";
-import { DocumentWorkspace } from "../src/DocumentWorkspace";
+import {
+  DocumentSaveStatusIndicator,
+  DocumentWorkspace,
+} from "../src/DocumentWorkspace";
+import type { DocumentSaveState } from "../src/PageCard";
 import type {
   CompleteReviewResult,
   Page,
@@ -217,6 +221,9 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     document.body.appendChild(container);
     root = createRoot(container);
     setupDomMocks();
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
   });
 
   afterEach(async () => {
@@ -227,7 +234,33 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     vi.restoreAllMocks();
   });
 
-  it("DocumentWorkspace shows a save status indicator when saving", async () => {
+  async function renderSaveStatus({
+    saveState = "saved",
+    documentDiskChangeState = "clean",
+  }: {
+    saveState?: DocumentSaveState;
+    documentDiskChangeState?: "clean" | "changed" | "conflict" | "paused";
+  } = {}) {
+    await act(async () => {
+      root.render(
+        <DocumentSaveStatusIndicator
+          saveState={saveState}
+          diskChangeState={documentDiskChangeState}
+        />,
+      );
+      await Promise.resolve();
+    });
+  }
+
+  async function renderWorkspace({
+    documentDiskChangeState = "clean",
+    watcherCount = 0,
+    onSaveDocument = async () => {},
+  }: {
+    documentDiskChangeState?: "clean" | "changed" | "conflict" | "paused";
+    watcherCount?: number;
+    onSaveDocument?: (id: string, content: string) => Promise<void>;
+  } = {}) {
     (
       globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
     ).IS_REACT_ACT_ENVIRONMENT = true;
@@ -240,30 +273,107 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
           documentFilenameLabel="test.md"
           documentEditorViewMode="rich-text"
           onDocumentEditorViewModeChange={() => {}}
-          onSaveDocument={async () => {}}
+          onSaveDocument={onSaveDocument}
           onDocumentSaveStateChange={() => {}}
           onDocumentDirtyStateChange={() => {}}
           onDocumentLocalContentChange={() => {}}
-          documentDiskChangeState="clean"
+          documentDiskChangeState={documentDiskChangeState}
           documentForceResetKey={null}
           onReloadDocumentFromDisk={() => {}}
           onKeepEditingWithoutAutosave={() => {}}
           onOverwriteDocumentOnDisk={() => {}}
           onCompleteReview={async () => ({ delivered: false })}
-          backend={createBackend()}
+          backend={createBackend({ watcherCount })}
         />,
       );
+      await Promise.resolve();
+    });
+  }
+
+  it.each([
+    ["saved", "Saved"],
+    ["saving", "Saving"],
+    ["unsaved", "Unsaved changes"],
+    ["error", "Save failed"],
+  ] satisfies Array<[DocumentSaveState, string]>)(
+    "shows persistent %s save status",
+    async (saveState, label) => {
+      await renderSaveStatus({ saveState });
+
+      expect(
+        container.querySelector(`[role="status"][aria-label="${label}"]`),
+      ).not.toBeNull();
+      expect(container.textContent).toContain(label);
+    },
+  );
+
+  it.each([
+    ["changed", "File changed on disk"],
+    ["conflict", "Save conflict"],
+    ["paused", "Autosave paused"],
+  ] as const)("shows disk-blocked %s save status", async (state, label) => {
+    await renderSaveStatus({ documentDiskChangeState: state });
+
+    expect(
+      container.querySelector(`[role="status"][aria-label="${label}"]`),
+    ).not.toBeNull();
+    expect(container.textContent).toContain(label);
+  });
+
+  it("renders save status in the same top-right stack under the handoff button", async () => {
+    await renderWorkspace({ watcherCount: 1 });
+
+    const stack = container.querySelector('[data-document-status-stack="true"]');
+    expect(stack).not.toBeNull();
+    expect(stack?.textContent).toContain("I'm done");
+    expect(stack?.textContent).toContain("Saved");
+  });
+
+  it.each([
+    ["Meta+S", { key: "s", metaKey: true }],
+    ["Control+S", { key: "s", ctrlKey: true }],
+  ])("prevents browser save on %s", async (_label, init) => {
+    const onSaveDocument = vi.fn().mockResolvedValue(undefined);
+    await renderWorkspace({ onSaveDocument });
+
+    const event = new KeyboardEvent("keydown", {
+      ...init,
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefault = vi.spyOn(event, "preventDefault");
+
+    await act(async () => {
+      window.dispatchEvent(event);
+      await Promise.resolve();
     });
 
-    // Initially idle — no indicator visible
-    const textContent = container.textContent ?? "";
-    expect(textContent).not.toContain("Saving");
-    expect(textContent).not.toContain("Saved");
+    expect(preventDefault).toHaveBeenCalled();
+  });
 
-    // The save status indicator has proper ARIA when it appears
-    expect(
-      container.querySelector('[role="status"][aria-label="Saving"]'),
-    ).toBeNull();
+  it("prevents browser save even when disk conflict blocks persistence", async () => {
+    const onSaveDocument = vi.fn().mockResolvedValue(undefined);
+    await renderWorkspace({
+      documentDiskChangeState: "conflict",
+      onSaveDocument,
+    });
+
+    const event = new KeyboardEvent("keydown", {
+      key: "s",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefault = vi.spyOn(event, "preventDefault");
+
+    await act(async () => {
+      window.dispatchEvent(event);
+      await Promise.resolve();
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(onSaveDocument).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("Save conflict");
   });
 });
 

--- a/packages/app/test/view-toggle-bugs.test.tsx
+++ b/packages/app/test/view-toggle-bugs.test.tsx
@@ -375,6 +375,14 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     expect(onSaveDocument).not.toHaveBeenCalled();
     expect(container.textContent).toContain("Save conflict");
   });
+
+  it("shows conflict status without replacing the existing conflict banner", async () => {
+    await renderWorkspace({ documentDiskChangeState: "conflict" });
+
+    expect(container.textContent).toContain("Save conflict");
+    expect(container.textContent).toContain("This file changed on disk");
+    expect(container.querySelector('[aria-label="Save conflict"]')).not.toBeNull();
+  });
 });
 
 describe("interaction mode preserved across view toggle (issue 3 fix)", () => {

--- a/packages/app/test/view-toggle-bugs.test.tsx
+++ b/packages/app/test/view-toggle-bugs.test.tsx
@@ -320,7 +320,7 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     expect(container.textContent).toContain(label);
   });
 
-  it("renders save status inside the handoff button when handoff exists", async () => {
+  it("renders save status below the handoff button when handoff exists", async () => {
     await renderWorkspace({ watcherCount: 1 });
 
     const stack = container.querySelector(
@@ -332,12 +332,8 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     expect(stack).not.toBeNull();
     expect(doneReviewingButton).toBeDefined();
     expect(doneReviewingButton?.textContent).toContain("I'm done");
-    expect(doneReviewingButton?.textContent).toContain("Saved");
-    expect(
-      doneReviewingButton?.querySelector(
-        '[data-document-save-status-inline="true"]',
-      ),
-    ).not.toBeNull();
+    expect(doneReviewingButton?.textContent).not.toContain("Saved");
+    expect(stack?.textContent).toContain("Saved");
   });
 
   it("renders standalone save status in the top-right stack without handoff", async () => {
@@ -349,9 +345,6 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     expect(stack).not.toBeNull();
     expect(stack?.textContent).not.toContain("I'm done");
     expect(stack?.textContent).toContain("Saved");
-    expect(
-      stack?.querySelector('[data-document-save-status-inline="true"]'),
-    ).toBeNull();
   });
 
   it.each([


### PR DESCRIPTION
Roughdraft now keeps the document save state visible and durable while users edit, switch views, or press Cmd+S. Save conflicts and blocked autosaves surface as unsaved/error states, and the app warns before leaving when drafts or disk conflicts could be lost. The change also tightens stale-write handling across rich text/code mode and adds unit and e2e coverage for manual saves, unload warnings, save failures, and disk-change flows. Verified with `pnpm check`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
