### PR TITLE
fix: open local markdown links in Roughdraft

### DIFF
--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -657,6 +657,7 @@ export function DocumentWorkspace({
             <PageCard
               key={`${documentPage.id}:${activeDocumentPath ?? ""}`}
               page={documentPage}
+              activeDocumentPath={activeDocumentPath}
               selected
               onSave={onSaveDocument}
               onSaveStateChange={handleSaveStateChange}

--- a/packages/app/src/EditorContextMenu.tsx
+++ b/packages/app/src/EditorContextMenu.tsx
@@ -29,6 +29,7 @@ import type { StorageBackend } from "./storage";
 interface EditorContextMenuProps {
   editor: Editor | null;
   backend: StorageBackend;
+  resolveLinkUrl?: (path: string) => string | null;
   onAddComment?: () => void;
   onSuggestDeletion?: () => void;
   onSuggestReplacement?: () => void;
@@ -78,10 +79,13 @@ function isLinkTarget(value: string) {
 function resolveEditableLinkTarget(
   value: string,
   backend: StorageBackend,
+  resolveLinkUrl?: (path: string) => string | null,
   fallback = value,
 ) {
   if (!value) return fallback;
   if (isLinkTarget(value)) return value;
+  const linkUrl = resolveLinkUrl?.(value);
+  if (linkUrl) return linkUrl;
   return backend.resolveFileUrl(value) ?? fallback;
 }
 
@@ -184,6 +188,7 @@ function SelectionMenuButton({
 export function EditorContextMenu({
   editor,
   backend,
+  resolveLinkUrl,
   onAddComment,
   onSuggestDeletion,
   onSuggestReplacement,
@@ -318,6 +323,7 @@ export function EditorContextMenu({
       const href = resolveEditableLinkTarget(
         rawHref,
         backend,
+        resolveLinkUrl,
         (editor.getAttributes("link").href as string | null) || anchor.href,
       );
       const next = {
@@ -335,7 +341,7 @@ export function EditorContextMenu({
         ? current
         : next;
     });
-  }, [backend, editor]);
+  }, [backend, editor, resolveLinkUrl]);
 
   const openExistingLinkPopover = useCallback(
     (anchor: HTMLAnchorElement) => {
@@ -367,6 +373,7 @@ export function EditorContextMenu({
       const href = resolveEditableLinkTarget(
         rawHref,
         backend,
+        resolveLinkUrl,
         (linkAttrs.href as string | null) || anchor.href,
       );
 
@@ -379,7 +386,7 @@ export function EditorContextMenu({
         focusInput: false,
       });
     },
-    [backend, editor],
+    [backend, editor, resolveLinkUrl],
   );
 
   const openLinkPopover = useCallback(() => {
@@ -402,14 +409,19 @@ export function EditorContextMenu({
       (editor.getAttributes("link").dataMarkdownSrc as string | null) || "";
 
     setLinkPopoverState({
-      href: resolveEditableLinkTarget(rawHref, backend, rawHref || "https://"),
+      href: resolveEditableLinkTarget(
+        rawHref,
+        backend,
+        resolveLinkUrl,
+        rawHref || "https://",
+      ),
       rawHref,
       left: rect.left + rect.width / 2,
       top: rect.top - 12,
       existingLink: false,
       focusInput: true,
     });
-  }, [backend, editor, openExistingLinkPopover]);
+  }, [backend, editor, openExistingLinkPopover, resolveLinkUrl]);
 
   const applyLink = useCallback(
     (nextValue: string) => {
@@ -428,12 +440,17 @@ export function EditorContextMenu({
         .focus()
         .extendMarkRange("link")
         .setMark("link", {
-          href: resolveEditableLinkTarget(nextHref, backend, nextHref),
+          href: resolveEditableLinkTarget(
+            nextHref,
+            backend,
+            resolveLinkUrl,
+            nextHref,
+          ),
           dataMarkdownSrc: nextHref,
         })
         .run();
     },
-    [backend, editor],
+    [backend, editor, resolveLinkUrl],
   );
 
   useEffect(() => {
@@ -576,6 +593,7 @@ export function EditorContextMenu({
           .insertContent(
             toHtml(text, {
               resolveFileUrl: (path) => backend.resolveFileUrl(path),
+              resolveLinkUrl,
             }),
           )
           .run();
@@ -583,7 +601,7 @@ export function EditorContextMenu({
     } finally {
       close();
     }
-  }, [backend, close, editor]);
+  }, [backend, close, editor, resolveLinkUrl]);
 
   return (
     <div
@@ -841,8 +859,11 @@ export function EditorContextMenu({
             onClick={() => {
               applyLink(linkDraft);
               const target =
-                resolveEditableLinkTarget(linkDraft.trim(), backend) ||
-                linkPopoverState.href;
+                resolveEditableLinkTarget(
+                  linkDraft.trim(),
+                  backend,
+                  resolveLinkUrl,
+                ) || linkPopoverState.href;
 
               if (target) {
                 window.open(target, "_blank", "noopener,noreferrer");

--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -30,6 +30,7 @@ import {
 } from "./editor-extensions";
 import { cn } from "./lib/utils";
 import { MarkdownCodeEditor } from "./MarkdownCodeEditor";
+import { buildLocationForLinkedMarkdownDocument } from "./app-navigation";
 import { toHtml } from "./markdown";
 import type { Page, StorageBackend } from "./storage";
 import { useCommentAnchorLayout } from "./useCommentAnchorLayout";
@@ -50,6 +51,7 @@ export type DocumentInteractionMode = "viewing" | "suggesting" | "editing";
 
 interface PageCardProps {
   page: Page;
+  activeDocumentPath?: string | null;
   selected?: boolean;
   focusRequestKey?: string | null;
   onSave: (id: string, content: string) => Promise<void>;
@@ -68,6 +70,7 @@ interface PageCardProps {
 
 interface PageCardEditorSurfaceProps {
   page: Page;
+  activeDocumentPath: string | null;
   selected: boolean;
   focusRequestKey: string | null;
   onSave: (id: string, content: string) => Promise<void>;
@@ -86,6 +89,7 @@ interface PageCardEditorSurfaceProps {
 
 interface RichTextEditorSurfaceProps {
   page: Page;
+  activeDocumentPath: string | null;
   selected: boolean;
   focusRequestKey: string | null;
   sourceMarkdown: string;
@@ -582,6 +586,7 @@ export function shouldDismissCommentThread(target: EventTarget | null) {
 
 const RichTextEditorSurface = memo(function RichTextEditorSurface({
   page,
+  activeDocumentPath,
   selected,
   focusRequestKey,
   sourceMarkdown,
@@ -618,13 +623,23 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
     (path: string) => backend.resolveFileUrl(path),
     [backend],
   );
+  const resolveLinkUrl = useCallback(
+    (path: string) =>
+      buildLocationForLinkedMarkdownDocument({
+        projectPath: backend.info.projectPath,
+        currentDocumentPath: activeDocumentPath,
+        href: path,
+      }),
+    [activeDocumentPath, backend],
+  );
 
   const parsedContent = useMemo(
     () =>
       criticMarkdownToEditorState(sourceMarkdown, {
         resolveFileUrl,
+        resolveLinkUrl,
       }),
-    [resolveFileUrl, sourceMarkdown],
+    [resolveFileUrl, resolveLinkUrl, sourceMarkdown],
   );
   const [comments, setComments] = useState<Map<string, CriticComment>>(
     () => parsedContent.comments,
@@ -686,11 +701,12 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
         .insertContent(
           toHtml(markdown, {
             resolveFileUrl,
+            resolveLinkUrl,
           }),
         )
         .run();
     },
-    [backend, resolveFileUrl],
+    [backend, resolveFileUrl, resolveLinkUrl],
   );
 
   const refreshCriticChanges = useCallback(() => {
@@ -1880,6 +1896,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
               <EditorContextMenu
                 editor={editor}
                 backend={backend}
+                resolveLinkUrl={resolveLinkUrl}
                 onAddComment={
                   interactionMode === "viewing" ? undefined : handleAddComment
                 }
@@ -1991,6 +2008,7 @@ const CodeEditorSurface = memo(function CodeEditorSurface({
 
 const PageCardEditorSurface = memo(function PageCardEditorSurface({
   page,
+  activeDocumentPath,
   selected,
   focusRequestKey,
   onSave,
@@ -2255,6 +2273,7 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
     <RichTextEditorSurface
       key={`${page.id}:${richTextSourceVersion}:${effectiveRichTextSourceMarkdown}`}
       page={page}
+      activeDocumentPath={activeDocumentPath}
       selected={selected}
       focusRequestKey={focusRequestKey}
       sourceMarkdown={effectiveRichTextSourceMarkdown}
@@ -2269,6 +2288,7 @@ const PageCardEditorSurface = memo(function PageCardEditorSurface({
 
 export function PageCard({
   page,
+  activeDocumentPath = null,
   selected = false,
   focusRequestKey = null,
   onSave,
@@ -2294,6 +2314,7 @@ export function PageCard({
     <div className="w-full">
       <PageCardEditorSurface
         page={page}
+        activeDocumentPath={activeDocumentPath}
         selected={selected}
         focusRequestKey={focusRequestKey}
         onSave={onSave}

--- a/packages/app/src/app-navigation.test.ts
+++ b/packages/app/src/app-navigation.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   PREVIEW_PATH,
   ROUGHDRAFT_FLAVORED_MARKDOWN_PATH,
+  buildLocationForLinkedMarkdownDocument,
   getRequestedPathState,
   syncRequestedPathInUrl,
 } from "./app-navigation";
@@ -52,5 +53,43 @@ describe("app navigation", () => {
       projectPath: null,
       documentPath: null,
     });
+  });
+
+  it("builds Roughdraft routes for linked markdown documents", () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/?path=%2FUsers%2Fme%2Fproject%2F.context%2Flocal-link-source.md",
+    );
+
+    expect(
+      buildLocationForLinkedMarkdownDocument({
+        projectPath: "/Users/me/project/.context",
+        currentDocumentPath: "local-link-source.md",
+        href: "local-link-target.md",
+      }),
+    ).toBe("/?path=%2FUsers%2Fme%2Fproject%2F.context%2Flocal-link-target.md");
+  });
+
+  it("resolves nested markdown links relative to the current document", () => {
+    window.history.replaceState(null, "", "/");
+
+    expect(
+      buildLocationForLinkedMarkdownDocument({
+        projectPath: "/Users/me/project",
+        currentDocumentPath: "notes/source.md",
+        href: "../index.md#summary",
+      }),
+    ).toBe("/?path=%2FUsers%2Fme%2Fproject%2Findex.md#summary");
+  });
+
+  it("leaves non-markdown links for the file resolver", () => {
+    expect(
+      buildLocationForLinkedMarkdownDocument({
+        projectPath: "/Users/me/project",
+        currentDocumentPath: "source.md",
+        href: "diagram.png",
+      }),
+    ).toBeNull();
   });
 });

--- a/packages/app/src/app-navigation.ts
+++ b/packages/app/src/app-navigation.ts
@@ -108,6 +108,65 @@ export function joinPath(basePath: string, relativePath: string) {
     );
 }
 
+function isExternalUrl(path: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(path) || path.startsWith("//");
+}
+
+function linkedMarkdownPathParts(href: string) {
+  const trimmedHref = href.trim();
+  if (
+    !trimmedHref ||
+    isExternalUrl(trimmedHref) ||
+    trimmedHref.startsWith("#")
+  ) {
+    return null;
+  }
+
+  const match = trimmedHref.match(/^([^?#]*)(?:\?[^#]*)?(#.*)?$/);
+  const documentPath = match?.[1] ?? "";
+  if (!documentPath.toLowerCase().endsWith(".md")) return null;
+
+  return {
+    documentPath,
+    hash: match?.[2] ?? "",
+  };
+}
+
+function fileUrlForAbsolutePath(absolutePath: string) {
+  const normalizedPath = normalizePathSeparators(absolutePath);
+  return new URL(`file://${encodeURI(normalizedPath)}`);
+}
+
+export function buildLocationForLinkedMarkdownDocument({
+  projectPath,
+  currentDocumentPath,
+  href,
+}: {
+  projectPath?: string | null;
+  currentDocumentPath?: string | null;
+  href: string;
+}): string | null {
+  if (!projectPath || !currentDocumentPath) return null;
+
+  const linkedPath = linkedMarkdownPathParts(href);
+  if (!linkedPath) return null;
+
+  const currentAbsolutePath = joinPath(projectPath, currentDocumentPath);
+  const targetUrl = new URL(
+    encodeURI(linkedPath.documentPath),
+    fileUrlForAbsolutePath(currentAbsolutePath),
+  );
+  const targetPath = decodeURI(targetUrl.pathname);
+  const url = new URL(window.location.href);
+
+  url.pathname = "/";
+  url.search = "";
+  url.searchParams.set("path", targetPath);
+  url.hash = linkedPath.hash;
+
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
 function buildLocationForPath(path?: string | null) {
   const nextPath = path?.trim() || null;
   const url = new URL(window.location.href);

--- a/packages/app/src/markdown.test.ts
+++ b/packages/app/src/markdown.test.ts
@@ -59,6 +59,26 @@ describe("toHtml", () => {
     );
   });
 
+  it("can resolve markdown document links separately from file assets", () => {
+    const html = toHtml(
+      "[Target](local-link-target.md)\n\n![Diagram](local-link-target.md)",
+      {
+        resolveFileUrl: (path) => `/api/files?path=${encodeURIComponent(path)}`,
+        resolveLinkUrl: (path) =>
+          path.endsWith(".md")
+            ? `/?path=${encodeURIComponent(`/project/${path}`)}`
+            : null,
+      },
+    );
+
+    expect(html).toContain(
+      '<a href="/?path=%2Fproject%2Flocal-link-target.md" data-markdown-src="local-link-target.md">Target</a>',
+    );
+    expect(html).toContain(
+      '<img src="/api/files?path=local-link-target.md" alt="Diagram" data-markdown-src="local-link-target.md">',
+    );
+  });
+
   it("renders in-page anchors, mailto links, task lists, and table fixtures", () => {
     const html = toHtml(
       `${readMarkdownFixture("links-and-images.md")}\n${readMarkdownFixture("tables-and-task-lists.md")}`,

--- a/packages/app/src/markdown.ts
+++ b/packages/app/src/markdown.ts
@@ -6,6 +6,7 @@ export const rawMarkdownBlockAttribute = "data-markdown-raw-block";
 
 export interface MarkdownOptions {
   resolveFileUrl?: (path: string) => string | null;
+  resolveLinkUrl?: (path: string) => string | null;
 }
 
 export interface YamlFrontmatterSplit {
@@ -221,6 +222,7 @@ export function createMarkedRenderer(options?: MarkdownOptions) {
   const renderer = new marked.Renderer();
   const baseRenderer = new marked.Renderer();
   const resolveFileUrl = options?.resolveFileUrl;
+  const resolveLinkUrl = options?.resolveLinkUrl;
 
   renderer.code = ({ text, lang, escaped }) => {
     const language = (lang || "").match(/\S+/)?.[0];
@@ -234,7 +236,10 @@ export function createMarkedRenderer(options?: MarkdownOptions) {
 
   renderer.link = function ({ href, title, tokens, raw }) {
     const rawHref = href || "";
-    const renderedHref = resolveRenderedUrl(rawHref, resolveFileUrl);
+    const renderedHref = resolveRenderedUrl(
+      rawHref,
+      (path) => resolveLinkUrl?.(path) ?? resolveFileUrl?.(path) ?? null,
+    );
     const text = this.parser.parseInline(tokens);
     const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
     const markdownSrcAttr = ` data-markdown-src="${escapeHtml(rawHref)}"`;

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -252,6 +252,8 @@ function getToolbarButton(container: HTMLElement, label: string) {
 
 type PageCardTestOptions = Partial<{
   page: Page;
+  activeDocumentPath: string | null;
+  backend: StorageBackend;
   editorViewMode: "rich-text" | "code";
   interactionMode: "viewing" | "suggesting" | "editing";
   selected: boolean;
@@ -277,7 +279,7 @@ async function renderPageCard(
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container);
-  const backend = createBackend();
+  const backend = options.backend ?? createBackend();
   const onSave = vi.fn().mockResolvedValue(undefined);
   const onSaveStateChange = vi.fn();
   let editor: Editor | null = null;
@@ -289,6 +291,7 @@ async function renderPageCard(
       title: "Page 1",
       content: "Start",
     },
+    activeDocumentPath: options.activeDocumentPath ?? null,
     selected: options.selected ?? true,
     focusRequestKey: options.focusRequestKey ?? null,
     editorViewMode: options.editorViewMode ?? "rich-text",
@@ -455,6 +458,7 @@ describe("PageCard editor integration", () => {
 
     vi.useRealTimers();
     vi.restoreAllMocks();
+    window.history.replaceState(null, "", "/");
   });
 
   it("document mode edits trigger autosave", async () => {
@@ -709,6 +713,90 @@ describe("PageCard editor integration", () => {
     expect(
       getEditable(rendered.container).getAttribute("contenteditable"),
     ).toBe("false");
+  });
+
+  it("renders local markdown document links as Roughdraft routes", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/?path=%2FUsers%2Fme%2Fproject%2Fnotes%2Fsource.md",
+    );
+    const backend = createBackend();
+    backend.info = {
+      ...backend.info,
+      projectPath: "/Users/me/project",
+    };
+
+    const rendered = await renderPageCard({
+      backend,
+      activeDocumentPath: "notes/source.md",
+      page: {
+        id: "notes/source",
+        title: "Source",
+        content: "[Target](target.md)\n\n![Diagram](diagram.png)",
+      },
+    });
+
+    expect(
+      rendered.container
+        .querySelector("a[data-markdown-src='target.md']")
+        ?.getAttribute("href"),
+    ).toBe("/?path=%2FUsers%2Fme%2Fproject%2Fnotes%2Ftarget.md");
+    expect(
+      rendered.container
+        .querySelector("img[data-markdown-src='diagram.png']")
+        ?.getAttribute("src"),
+    ).toBe("file://diagram.png");
+  });
+
+  it("opens local markdown document links through Roughdraft from the link popover", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/?path=%2FUsers%2Fme%2Fproject%2Fnotes%2Fsource.md",
+    );
+    const backend = createBackend();
+    backend.info = {
+      ...backend.info,
+      projectPath: "/Users/me/project",
+    };
+    const openWindow = vi.spyOn(window, "open").mockImplementation(() => null);
+    const rendered = await renderPageCard({
+      backend,
+      activeDocumentPath: "notes/source.md",
+      page: {
+        id: "notes/source",
+        title: "Source",
+        content: "[Target](target.md)",
+      },
+    });
+
+    const link = rendered.container.querySelector(
+      "a[data-markdown-src='target.md']",
+    );
+    expect(link).not.toBeNull();
+
+    await act(async () => {
+      link?.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+      );
+    });
+    await flushAnimationFrame();
+
+    const openButton = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Open link in new tab"]',
+    );
+    expect(openButton).not.toBeNull();
+
+    await act(async () => {
+      openButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(openWindow).toHaveBeenCalledWith(
+      "/?path=%2FUsers%2Fme%2Fproject%2Fnotes%2Ftarget.md",
+      "_blank",
+      "noopener,noreferrer",
+    );
   });
 
   it("keeps focus in the editor when placing the cursor inside a link", async () => {


### PR DESCRIPTION
Local Markdown links now open the linked `.md` file in Roughdraft instead of navigating to `/api/files`, including the link popover's open icon. Image and asset links still resolve through the file resolver. The fix resolves relative Markdown links against the active document path and preserves anchors. Tested with `pnpm check` and a live Playwright check against the running Roughdraft server.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
