### PR TITLE
feat: add homepage workflow storyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Roughdraft
 A local-first markdown editor and viewer for working with AI.
 
-{==Open one markdown file on your machine. Review it, comment on it, and suggest edits.==}{>>What does this mean?<<}{id="c3" by="user" at="2026-04-30T20:18:51.163Z"}{>>It means Roughdraft works with a normal local Markdown file: you open one .md file from your computer, read it in the app, leave inline comments, and propose edits that are saved back into the Markdown using CriticMarkup.<<}{id="c4" by="AI" at="2026-04-30T20:19:39.000Z" re="c3"}
+{==Open one markdown file on your machine. Review it, comment on it, and suggest edits.==}{>>What does this mean?<<}{id="c3" by="user" at="2026-04-30T20:18:51.163Z"}{>>It means Roughdraft works with a normal local Markdown file: you open one .md file from your computer, read it in the app, leave inline comments, and propose edits that are saved back into the Markdown using CriticMarkup.<<}{id="c4" by="AI" at="2026-04-30T20:19:39.000Z" re="c3"}{>>cjool<<}{id="c5" by="user" at="2026-05-07T20:38:25.621Z" re="c4"}
 
 Paste this into your coding agent:
 
@@ -83,6 +83,7 @@ That makes an agent-friendly workflow possible:
 4. You read, edit, leave comments, and suggest changes.
   
 5. You click **Done Reviewing** in Roughdraft, and the AI can respond to your comments or revise the document.
+  
 
 Agents can watch that handoff directly:
 
@@ -99,7 +100,6 @@ roughdraft mcp
 ```
 
 The MCP server exposes tools to read the review index, list pending feedback, watch review events, append replies, and mark items resolved. CriticMarkup in the Markdown file remains the durable source of truth.
-  
 ## Local development
 ```bash
 ./scripts/setup.sh

--- a/docs/plans/2026-05-07-homepage-workflow-storyboard-test-plan.md
+++ b/docs/plans/2026-05-07-homepage-workflow-storyboard-test-plan.md
@@ -1,0 +1,74 @@
+# Homepage Workflow Storyboard Test Plan
+
+## Harness requirements
+
+No new test harness needs to be built.
+
+- **Vitest/JSDOM homepage harness**: existing `packages/app/test/homepage.test.tsx` renders `Homepage` into a DOM container with React `act`, mocked clipboard, and geometry shims. It exposes DOM queries, text assertions, CTA click simulation, and document-order checks. Complexity: existing harness plus a small `renderHomepage(root)` helper. Tests depending on it: 1, 2, 5.
+- **Playwright homepage harness**: existing `packages/app/playwright.config.ts` serves the Vite app and runs browser tests under `packages/app/e2e/*.spec.ts`. It exposes real browser layout, viewport resizing, accessibility role/name queries, DOM snapshots, screenshot capture, and computed overflow checks. Complexity: one focused homepage spec. Tests depending on it: 3, 4.
+
+## Strategy reconciliation
+
+The agreed Medium strategy still holds. The implementation plan confirms the work is a static React homepage change in `packages/app/src/App.tsx` with supporting CSS in `packages/app/src/style.css`, backed by Vitest/JSDOM semantic assertions and one focused Playwright browser check. There are no new routes, runtime services, paid APIs, persistence layers, or CLI/server changes that would expand the test surface.
+
+The only adjustment is to make the Playwright work a named homepage storyboard spec rather than a generic visual check. That keeps the cost and scope unchanged while matching the implementation plan's specific DOM hooks: `[data-homepage-workflow-storyboard]` and `[data-homepage-workflow-scene]`.
+
+## Test plan
+
+1. **Name**: Visitor understands the six-step plan-review workflow before the Markdown format explanation
+   - **Type**: scenario
+   - **Harness**: Vitest/JSDOM homepage harness in `packages/app/test/homepage.test.tsx`.
+   - **Preconditions**: Render `Homepage` with the existing homepage marketing message and `updateStatus={null}`.
+   - **Actions**: Query the rendered DOM for `[data-homepage-workflow-storyboard]`, `.rfm-format-demo`, and all `[data-homepage-workflow-scene]` elements.
+   - **Expected outcome**: The storyboard exists, is labelled by `homepage-workflow-heading`, and appears before `.rfm-format-demo` in document order. The storyboard includes the source-of-truth heading `Review an agent's plan before it starts coding.`, the body copy `Ask for a plan, mark it up in Roughdraft, click Done Reviewing, and the agent continues from the edited Markdown file.`, and exactly six scenes numbered `01` through `06` with these titles in order: `Ask for a plan`, `The agent works normally`, `Roughdraft opens the plan`, `Leave comments and suggestions`, `Click Done Reviewing`, `The agent resumes`. Source of truth: user request scenes 1-6 and implementation plan Product copy and scene content.
+   - **Interactions**: React render tree, homepage section order, Roughdraft format demo placement.
+
+2. **Name**: Storyboard shows the concrete homepage conversion handoff from chat to Roughdraft to resumed agent
+   - **Type**: scenario
+   - **Harness**: Vitest/JSDOM homepage harness in `packages/app/test/homepage.test.tsx`.
+   - **Preconditions**: Render `Homepage` with the existing homepage marketing message and `updateStatus={null}`.
+   - **Actions**: Query `[data-homepage-workflow-storyboard]` text content.
+   - **Expected outcome**: The storyboard contains the canonical user request `Let's make the homepage more persuasive. Write a plan first.`, the agent response about drafting a Markdown plan and opening it in Roughdraft, the tool activity `rg "It's just Markdown" packages/app/src`, `sed -n '1,220p' packages/app/src/App.tsx`, and `write .context/homepage-conversion-plan.md`, the plan title `Homepage Conversion Plan`, the plan bullets about moving the workflow above `"It's just Markdown."`, showing the pause/review/resume signal, and keeping the format section as portable Markdown proof, the two review comments, the suggested change `Review an agent's plan before it starts coding.`, the Done popover title `Review complete`, its body `Your agent can read the edited Markdown file now.`, and the resumed-agent message beginning `I read your comments.` Source of truth: implementation plan Primary mock conversation and plan content.
+   - **Interactions**: Mock chat surface, mock Roughdraft document surface, comment/suggestion mock surface, Done Reviewing popover mock, resumed-agent mock.
+
+3. **Name**: Desktop homepage renders a usable storyboard section with browser evidence
+   - **Type**: integration
+   - **Harness**: Playwright homepage spec, for example `packages/app/e2e/homepage-workflow-storyboard.spec.ts`.
+   - **Preconditions**: Start from a clean browser page at `/` with a desktop viewport such as `1440x1100`.
+   - **Actions**: Navigate to `/`, locate `[data-homepage-workflow-storyboard]`, assert key section text is visible, count `[data-homepage-workflow-scene]`, and capture a screenshot artifact of the storyboard locator named `homepage-workflow-storyboard-desktop.png` or an equivalent Playwright snapshot name.
+   - **Expected outcome**: The storyboard locator is visible, all six scene titles are visible, the Roughdraft plan panel text `Homepage Conversion Plan` is visible, the Done Reviewing button mock is visible, and the captured screenshot is non-empty by Playwright's screenshot operation succeeding on the visible locator. Pass/fail is based on Playwright assertions and the generated targeted screenshot artifact, not human inspection. Source of truth: user request for a storyboard with text and screenshots or real UI, implementation plan requiring Playwright render and screenshot evidence.
+   - **Interactions**: Vite dev server, compiled Tailwind/CSS, browser layout engine, static image asset from the existing homepage.
+
+4. **Name**: Mobile homepage storyboard remains readable without horizontal overflow
+   - **Type**: invariant
+   - **Harness**: Playwright homepage spec, in the same focused homepage storyboard file.
+   - **Preconditions**: Start from a clean browser page at `/` with a mobile viewport such as `390x844`.
+   - **Actions**: Navigate to `/`, locate `[data-homepage-workflow-storyboard]`, assert the section heading and six scene titles are visible, then evaluate `document.documentElement.scrollWidth <= document.documentElement.clientWidth` and the same condition for the storyboard element.
+   - **Expected outcome**: The storyboard heading `Review an agent's plan before it starts coding.` remains visible, all six scene titles remain visible, and neither the page nor the storyboard element creates horizontal overflow. Source of truth: user request for a conversion section above Markdown, implementation plan's responsive in-page mock UI direction, and frontend requirement that text and UI not overlap or overflow on mobile.
+   - **Interactions**: Responsive CSS, grid layout, long strings in chat/tool-call mock surfaces, viewport constraints.
+
+5. **Name**: Existing homepage conversion affordances and Markdown proof survive the storyboard replacement
+   - **Type**: regression
+   - **Harness**: Vitest/JSDOM homepage harness in `packages/app/test/homepage.test.tsx`.
+   - **Preconditions**: Render `Homepage` with the existing homepage marketing message and `updateStatus={null}`.
+   - **Actions**: Use the existing CTA test flow: verify hero copy and trust badges, verify GitHub/spec links, verify the setup prompt is absent before opening the dialog, click `Install Now`, click `Copy prompt`, and click the existing `Review a plan` format-demo sample.
+   - **Expected outcome**: The hero still contains `Easier collaboration with your coding agent`, `Free`, `Open-source`, and `Runs locally`; the GitHub link still points to `https://github.com/Lex-Inc/roughdraft`; the spec link still points to `/roughdraft-flavored-markdown`; the setup dialog still copies the exact `AGENT_SETUP_PROMPT`; the image source remains `/sneak-peek.png`; `.rfm-format-demo` still renders source/result panes; the format demo still contains live comment and suggested-change markup surfaces; clicking `Review a plan` still shows `Agent Plan Review`, `rollback note for the migration step`, and `re="s1"`. The removed legacy two-card workflow copy is not asserted. Source of truth: existing homepage tests and implementation plan instruction to replace the old workflow while keeping the CTA and format demo.
+   - **Interactions**: shadcn Dialog and Button components, clipboard mock, RoughdraftFormatDemo, homepage image asset, React state for format-demo examples.
+
+## Coverage summary
+
+Covered action space:
+
+- A visitor reading the homepage hero, trust badges, screenshot, new workflow storyboard, and Markdown format proof.
+- The six requested storyboard scenes and their order.
+- The conversion-specific example: asking an agent to improve homepage persuasion, agent tool activity, a Markdown plan opened in Roughdraft, inline comments/suggestions, Done Reviewing handoff, and resumed agent chat.
+- The required placement above `It's just Markdown`.
+- Desktop render evidence and mobile no-overflow behavior.
+- Existing install CTA, GitHub/spec links, setup prompt copy behavior, screenshot asset, and Roughdraft format demo behavior.
+
+Explicitly excluded per the agreed Medium strategy:
+
+- Full-page visual baselines for every viewport. Risk: subtle visual polish regressions may pass if semantic/layout assertions still hold, but this avoids brittle screenshot churn for a marketing section.
+- Real CLI invocation of `roughdraft open`, server blocking behavior, and filesystem round-trip tests. Risk: the storyboard could overpromise if copy drifts toward live CLI behavior, mitigated by assertions that keep the copy scoped to the implementation plan and existing ADRs.
+- Parser, editor, and CriticMarkup serialization changes. Risk: none expected because the implementation plan does not modify parser/editor code; existing targeted tests continue to cover those systems.
+- Performance benchmarking. Risk: low because the section is static UI with no new runtime dependencies, network calls, or expensive interactions.

--- a/docs/plans/2026-05-07-homepage-workflow-storyboard.md
+++ b/docs/plans/2026-05-07-homepage-workflow-storyboard.md
@@ -22,6 +22,8 @@ The storyboard should be specifically about reviewing an agent's plan before imp
 
 This also answers the user's confusion about "Medium strategy": the testing strategy should be written down and executed from this plan, not treated as an invisible subagent output.
 
+The user also asked whether the plan is a Markdown file somewhere. The implementer should be explicit in handoff messages that this trycycle plan is the Markdown file at `docs/plans/2026-05-07-homepage-workflow-storyboard.md`, and that the implementation should proceed from that file in the current checkout. Do not add a new approval gate unless the user asks to revise the plan first.
+
 ## Relevant existing context
 
 - ADR 0001 says Roughdraft's unit of work is one Markdown file. The storyboard should show `homepage-conversion-plan.md`, not projects, vaults, or multi-file workspaces.
@@ -296,7 +298,6 @@ import {
   ArrowLeft,
   Braces,
   Check,
-  CircleDot,
   Code2,
   Copy,
   ExternalLink,
@@ -304,7 +305,6 @@ import {
   MessageSquare,
   MousePointerClick,
   PencilLine,
-  Play,
   Sparkles,
 } from "lucide-react";
 ```

--- a/docs/plans/2026-05-07-homepage-workflow-storyboard.md
+++ b/docs/plans/2026-05-07-homepage-workflow-storyboard.md
@@ -20,16 +20,16 @@ The storyboard should be specifically about reviewing an agent's plan before imp
 
 > Review an agent's plan before it starts coding.
 
-This also answers the user's confusion about "Medium strategy": the testing strategy should be written down and executed from this plan, not treated as an invisible subagent output.
+This also answers the user's confusion about "Medium strategy": the testing strategy should be written down and executed from this plan, not treated as an invisible subagent output. If the user asks again where the strategy or plan lives, answer directly: yes, it is this Markdown file at `docs/plans/2026-05-07-homepage-workflow-storyboard.md`.
 
-The user also asked whether the plan is a Markdown file somewhere. The implementer should be explicit in handoff messages that this trycycle plan is the Markdown file at `docs/plans/2026-05-07-homepage-workflow-storyboard.md`, and that the implementation should proceed from that file in the current checkout. Do not add a new approval gate unless the user asks to revise the plan first.
+Do not add a new approval gate unless the user asks to revise the plan first. The user already asked to run trycycle in the current checkout, and this plan is the execution source of truth.
 
 ## Relevant existing context
 
-- ADR 0001 says Roughdraft's unit of work is one Markdown file. The storyboard should show `homepage-conversion-plan.md`, not projects, vaults, or multi-file workspaces.
-- ADR 0002 says review feedback is portable CriticMarkup. The storyboard should show inline comments and suggested changes as visible document feedback, not hidden app state.
-- ADR 0003 says Markdown round trips matter. The storyboard should reinforce that the agent resumes by reading the same edited Markdown file.
-- ADR 0004 says the CLI opens/reuses a local server. The storyboard should say Roughdraft opens when the agent is ready, but should not introduce new server or sync claims.
+- `docs/adr/0001-single-local-markdown-file.md` says Roughdraft's unit of work is one Markdown file. The storyboard should show `homepage-conversion-plan.md`, not projects, vaults, or multi-file workspaces.
+- `docs/adr/0002-criticmarkup-as-review-format.md` says review feedback is portable CriticMarkup. The storyboard should show inline comments and suggested changes as visible document feedback, not hidden app state.
+- `docs/adr/0003-markdown-roundtrip-contract.md` says Markdown round trips matter. The storyboard should reinforce that the agent resumes by reading the same edited Markdown file.
+- `docs/adr/0004-cli-server-state-model.md` says the CLI opens/reuses a local server. The storyboard should say Roughdraft opens when the agent is ready, but should not introduce new server or sync claims.
 - `Homepage` currently renders hero -> `sneak-peek.png` -> `RoughdraftFormatDemo` -> a small two-card workflow section. The new storyboard replaces the small section and moves above `RoughdraftFormatDemo`.
 - `homepage.test.tsx` already asserts a lot of homepage copy and structure. Split the new storyboard checks into focused tests instead of making the existing CTA test larger.
 
@@ -251,20 +251,9 @@ it("explains the plan-review workflow as a six-scene storyboard above the Markdo
 });
 ```
 
-**Step 4: Add a focused style-regression assertion**
+Do not add unit assertions that parse `APP_STYLES` for storyboard implementation details. The existing CSS string assertions protect legacy format-demo regressions, but new storyboard layout should be covered by semantic DOM assertions plus Playwright render and mobile-overflow checks. This keeps the new tests behavioral instead of coupling them to a specific CSS spelling.
 
-Add this to the same test after the semantic assertions:
-
-```ts
-expect(APP_STYLES).toMatch(
-  /\.homepage-workflow-storyboard \{[^}]*overflow:\s*hidden;[^}]*border-radius:\s*0\.5rem;/s,
-);
-expect(APP_STYLES).toMatch(
-  /\.homepage-workflow-scene-list \{[^}]*grid-template-columns:\s*repeat\(6,\s*minmax\(0,\s*1fr\)\);/s,
-);
-```
-
-**Step 5: Run the focused test and verify failure**
+**Step 4: Run the focused test and verify failure**
 
 Run:
 
@@ -274,7 +263,7 @@ pnpm --filter @roughdraft/app exec vitest run test/homepage.test.tsx -t "six-sce
 
 Expected: FAIL because `[data-homepage-workflow-storyboard]` does not exist and the section copy is absent.
 
-**Step 6: Commit the failing tests**
+**Step 5: Commit the failing tests**
 
 Only commit if the test fails for the expected missing-storyboard reason.
 

--- a/docs/plans/2026-05-07-homepage-workflow-storyboard.md
+++ b/docs/plans/2026-05-07-homepage-workflow-storyboard.md
@@ -1,0 +1,984 @@
+# Homepage Workflow Storyboard Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use trycycle-executing to implement this plan task-by-task.
+
+**Goal:** Expand the homepage workflow explanation into a conversion-focused six-scene storyboard, positioned above the "It's just Markdown" / Roughdraft format demo section.
+
+**Architecture:** Keep this as static homepage UI in `packages/app/src/App.tsx`, backed by typed scene data and small presentational helper components in the same file because the storyboard is homepage-specific. Use CSS in `packages/app/src/style.css` only for the pieces Tailwind cannot express cleanly, such as the responsive horizontal connector and compact mock UI surfaces. Do not add runtime dependencies or route-level state.
+
+**Tech Stack:** React 19, TypeScript, Tailwind CSS, shadcn `Button`, lucide-react icons, Vitest/JSDOM for semantic homepage assertions, Playwright for browser layout and screenshot evidence.
+
+---
+
+## Strategy gate
+
+The user's actual conversion problem is not "show more Markdown syntax." The page already explains the format, but visitors still need to understand when Roughdraft enters the agent workflow and why the blocking review step matters. The cleanest solution is to promote the workflow section above the format demo and make it concrete with one realistic plan-review loop.
+
+Do not implement this as image-only screenshots. Static screenshots would be stale and hard to maintain. Build real in-page mock UI surfaces that look like chat, tool-call output, a Roughdraft plan window, comments, the Done Reviewing popover, and the resumed agent chat. This gives the page a richer product story while keeping the implementation deterministic, responsive, testable, and aligned with Roughdraft's single-file Markdown + CriticMarkup architecture.
+
+The storyboard should be specifically about reviewing an agent's plan before implementation, not generic document review. That is the sharp conversion hook:
+
+> Review an agent's plan before it starts coding.
+
+This also answers the user's confusion about "Medium strategy": the testing strategy should be written down and executed from this plan, not treated as an invisible subagent output.
+
+## Relevant existing context
+
+- ADR 0001 says Roughdraft's unit of work is one Markdown file. The storyboard should show `homepage-conversion-plan.md`, not projects, vaults, or multi-file workspaces.
+- ADR 0002 says review feedback is portable CriticMarkup. The storyboard should show inline comments and suggested changes as visible document feedback, not hidden app state.
+- ADR 0003 says Markdown round trips matter. The storyboard should reinforce that the agent resumes by reading the same edited Markdown file.
+- ADR 0004 says the CLI opens/reuses a local server. The storyboard should say Roughdraft opens when the agent is ready, but should not introduce new server or sync claims.
+- `Homepage` currently renders hero -> `sneak-peek.png` -> `RoughdraftFormatDemo` -> a small two-card workflow section. The new storyboard replaces the small section and moves above `RoughdraftFormatDemo`.
+- `homepage.test.tsx` already asserts a lot of homepage copy and structure. Split the new storyboard checks into focused tests instead of making the existing CTA test larger.
+
+## Product copy and scene content
+
+Use this section as the source of truth for copy. Keep punctuation ASCII and avoid typographic quotes.
+
+Section eyebrow:
+
+```text
+Workflow
+```
+
+Section heading:
+
+```text
+Review an agent's plan before it starts coding.
+```
+
+Section body:
+
+```text
+Ask for a plan, mark it up in Roughdraft, click Done Reviewing, and the agent continues from the edited Markdown file.
+```
+
+Scene data:
+
+```ts
+const HOMEPAGE_WORKFLOW_SCENES = [
+  {
+    step: "01",
+    title: "Ask for a plan",
+    description:
+      "Start in the same agent chat you already use. Ask for a reviewable Markdown plan before implementation begins.",
+  },
+  {
+    step: "02",
+    title: "The agent works normally",
+    description:
+      "It inspects files, runs tools, and drafts the plan in the background. Roughdraft does not replace your agent workflow.",
+  },
+  {
+    step: "03",
+    title: "Roughdraft opens the plan",
+    description:
+      "When the file is ready, the agent opens the Markdown plan in Roughdraft and waits while you review.",
+  },
+  {
+    step: "04",
+    title: "Leave comments and suggestions",
+    description:
+      "Ask questions, redirect priorities, and suggest exact wording inline where the agent can read it later.",
+  },
+  {
+    step: "05",
+    title: "Click Done Reviewing",
+    description:
+      "Roughdraft hands control back to the agent once you are finished with the blocking review step.",
+  },
+  {
+    step: "06",
+    title: "The agent resumes",
+    description:
+      "The next agent turn reads the same Markdown file, sees your comments, and continues with the corrected plan.",
+  },
+] as const;
+```
+
+Primary mock conversation and plan content:
+
+```text
+User: Let's make the homepage more persuasive. Write a plan first.
+Agent: I'll inspect the current homepage, draft a Markdown plan, and open it in Roughdraft for review before I code.
+Tool activity:
+- rg "It's just Markdown" packages/app/src
+- sed -n '1,220p' packages/app/src/App.tsx
+- write .context/homepage-conversion-plan.md
+
+Plan title: Homepage Conversion Plan
+Plan bullets:
+- Move the workflow story above "It's just Markdown."
+- Show the agent pause, the review window, and the resume signal.
+- Keep the format section as proof that the review data is portable Markdown.
+
+Comments:
+- This should go above "It's just Markdown."
+- Can we make the example about homepage conversion?
+
+Suggested change:
+Review an agent's plan before it starts coding.
+
+Done popover title:
+Review complete
+
+Done popover body:
+Your agent can read the edited Markdown file now.
+
+Resumed agent:
+I read your comments. I'll move the workflow storyboard above the Markdown section and use the homepage conversion example.
+```
+
+## Task 1: Add focused failing homepage tests
+
+**Files:**
+- Modify: `packages/app/test/homepage.test.tsx`
+
+**Step 1: Split storyboard assertions out of the existing CTA test**
+
+Keep the existing `"opens the agent setup prompt from the CTA and copies it"` test focused on hero, CTA, setup prompt, GitHub link, format demo survival, and existing interactive sample behavior. Remove the old assertions for the small two-card workflow section:
+
+```ts
+expect(container.textContent).toContain("Review workflow");
+expect(container.textContent).toContain(
+  "Pass the same Markdown file back and forth with your agent.",
+);
+expect(container.textContent).toContain("Review an agent's draft");
+expect(container.textContent).toContain(
+  "tell the agent to read the file again",
+);
+expect(container.textContent).toContain("Ask the agent to review yours");
+expect(container.textContent).toContain(
+  "leave detailed comments, questions, and suggested edits",
+);
+```
+
+**Step 2: Add a helper to render the homepage**
+
+Add this helper near the existing `click` helper:
+
+```ts
+async function renderHomepage(root: Root) {
+  await act(async () => {
+    root.render(
+      <Homepage
+        message="Roughdraft is a markdown editor with commenting and suggest changes mode, making it easier to align with AI on complex ideas."
+        updateStatus={null}
+      />,
+    );
+    await Promise.resolve();
+  });
+}
+```
+
+Update the CTA test to call `await renderHomepage(root);`.
+
+**Step 3: Add the failing semantic storyboard test**
+
+Add this test inside `describe("Homepage", () => { ... })`:
+
+```ts
+it("explains the plan-review workflow as a six-scene storyboard above the Markdown section", async () => {
+  await renderHomepage(root);
+
+  const text = container.textContent ?? "";
+  expect(text).toContain("Review an agent's plan before it starts coding.");
+  expect(text).toContain(
+    "Ask for a plan, mark it up in Roughdraft, click Done Reviewing, and the agent continues from the edited Markdown file.",
+  );
+
+  const storyboard = container.querySelector("[data-homepage-workflow-storyboard]");
+  expect(storyboard).not.toBeNull();
+  expect(storyboard?.getAttribute("aria-labelledby")).toBe(
+    "homepage-workflow-heading",
+  );
+
+  const markdownDemo = container.querySelector(".rfm-format-demo");
+  expect(markdownDemo).not.toBeNull();
+  expect(storyboard && markdownDemo).toBeTruthy();
+  if (!storyboard || !markdownDemo) {
+    throw new Error("Expected storyboard and Markdown demo to render");
+  }
+  expect(
+    storyboard.compareDocumentPosition(markdownDemo) &
+      Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
+
+  const scenes = [
+    "Ask for a plan",
+    "The agent works normally",
+    "Roughdraft opens the plan",
+    "Leave comments and suggestions",
+    "Click Done Reviewing",
+    "The agent resumes",
+  ];
+
+  const sceneNodes = [
+    ...storyboard.querySelectorAll("[data-homepage-workflow-scene]"),
+  ];
+  expect(sceneNodes).toHaveLength(scenes.length);
+
+  scenes.forEach((scene, index) => {
+    expect(sceneNodes[index]?.textContent).toContain(
+      String(index + 1).padStart(2, "0"),
+    );
+    expect(sceneNodes[index]?.textContent).toContain(scene);
+  });
+
+  expect(storyboard.textContent).toContain(
+    "Let's make the homepage more persuasive. Write a plan first.",
+  );
+  expect(storyboard.textContent).toContain(
+    "write .context/homepage-conversion-plan.md",
+  );
+  expect(storyboard.textContent).toContain("Homepage Conversion Plan");
+  expect(storyboard.textContent).toContain(
+    'Move the workflow story above "It\'s just Markdown."',
+  );
+  expect(storyboard.textContent).toContain(
+    "This should go above \"It's just Markdown.\"",
+  );
+  expect(storyboard.textContent).toContain(
+    "Review an agent's plan before it starts coding.",
+  );
+  expect(storyboard.textContent).toContain("Review complete");
+  expect(storyboard.textContent).toContain(
+    "Your agent can read the edited Markdown file now.",
+  );
+  expect(storyboard.textContent).toContain("I read your comments.");
+});
+```
+
+**Step 4: Add a focused style-regression assertion**
+
+Add this to the same test after the semantic assertions:
+
+```ts
+expect(APP_STYLES).toMatch(
+  /\.homepage-workflow-storyboard \{[^}]*overflow:\s*hidden;[^}]*border-radius:\s*0\.5rem;/s,
+);
+expect(APP_STYLES).toMatch(
+  /\.homepage-workflow-scene-list \{[^}]*grid-template-columns:\s*repeat\(6,\s*minmax\(0,\s*1fr\)\);/s,
+);
+```
+
+**Step 5: Run the focused test and verify failure**
+
+Run:
+
+```bash
+pnpm --filter @roughdraft/app exec vitest run test/homepage.test.tsx -t "six-scene storyboard"
+```
+
+Expected: FAIL because `[data-homepage-workflow-storyboard]` does not exist and the section copy is absent.
+
+**Step 6: Commit the failing tests**
+
+Only commit if the test fails for the expected missing-storyboard reason.
+
+```bash
+git add packages/app/test/homepage.test.tsx
+git commit -m "test: specify homepage workflow storyboard"
+```
+
+## Task 2: Replace the small workflow cards with the storyboard UI
+
+**Files:**
+- Modify: `packages/app/src/App.tsx`
+- Modify: `packages/app/src/style.css`
+
+**Step 1: Update lucide imports**
+
+Change the import from `lucide-react` to include the storyboard icons:
+
+```ts
+import {
+  ArrowLeft,
+  Braces,
+  Check,
+  CircleDot,
+  Code2,
+  Copy,
+  ExternalLink,
+  FileText,
+  MessageSquare,
+  MousePointerClick,
+  PencilLine,
+  Play,
+  Sparkles,
+} from "lucide-react";
+```
+
+Remove any icon imports that become unused after deleting `HOMEPAGE_WORKFLOWS`.
+
+**Step 2: Replace `HOMEPAGE_WORKFLOWS` with storyboard data**
+
+Delete the `HOMEPAGE_WORKFLOWS` constant and add the new `HOMEPAGE_WORKFLOW_SCENES` constant from the product copy section.
+
+**Step 3: Add small presentational helpers below `Homepage` or above it**
+
+Add these helpers in `App.tsx`. Keep them local to the file because they are static homepage presentation, not shared product components.
+
+```tsx
+function HomepageWorkflowScene({
+  active,
+  description,
+  step,
+  title,
+}: {
+  active?: boolean;
+  description: string;
+  step: string;
+  title: string;
+}) {
+  return (
+    <li
+      className="homepage-workflow-scene min-w-0"
+      data-homepage-workflow-scene=""
+    >
+      <div
+        className={
+          active
+            ? "homepage-workflow-scene-marker homepage-workflow-scene-marker-active"
+            : "homepage-workflow-scene-marker"
+        }
+      >
+        {step}
+      </div>
+      <h3 className="mt-3 text-sm font-semibold text-slate-950 dark:text-slate-50">
+        {title}
+      </h3>
+      <p className="mt-2 text-xs leading-5 text-slate-600 dark:text-slate-400">
+        {description}
+      </p>
+    </li>
+  );
+}
+
+function AgentChatMock() {
+  return (
+    <div className="homepage-workflow-panel homepage-workflow-chat">
+      <div className="homepage-workflow-panel-header">
+        <MessageSquare className="size-3.5" aria-hidden="true" />
+        Agent chat
+      </div>
+      <div className="space-y-3 p-4">
+        <div className="ml-auto max-w-[82%] rounded-lg bg-slate-950 px-3 py-2 text-sm leading-5 text-white dark:bg-slate-100 dark:text-slate-950">
+          Let's make the homepage more persuasive. Write a plan first.
+        </div>
+        <div className="max-w-[86%] rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm leading-5 text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+          I'll inspect the current homepage, draft a Markdown plan, and open it
+          in Roughdraft for review before I code.
+        </div>
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-xs leading-5 text-slate-600 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-400">
+          <div className="mb-2 flex items-center gap-1.5 font-medium text-slate-700 dark:text-slate-300">
+            <Code2 className="size-3.5" aria-hidden="true" />
+            Tool calls
+          </div>
+          <div>rg "It's just Markdown" packages/app/src</div>
+          <div>sed -n '1,220p' packages/app/src/App.tsx</div>
+          <div>write .context/homepage-conversion-plan.md</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RoughdraftPlanMock() {
+  return (
+    <div className="homepage-workflow-panel homepage-workflow-plan">
+      <div className="homepage-workflow-panel-header">
+        <FileText className="size-3.5" aria-hidden="true" />
+        homepage-conversion-plan.md
+      </div>
+      <div className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_15rem]">
+        <div className="min-w-0 p-5">
+          <p className="text-xs font-medium tracking-[0.14em] text-stone-500 uppercase">
+            Roughdraft
+          </p>
+          <h3 className="mt-2 text-xl font-semibold text-slate-950 dark:text-slate-50">
+            Homepage Conversion Plan
+          </h3>
+          <ul className="mt-4 space-y-2 text-sm leading-6 text-slate-700 dark:text-slate-300">
+            <li>Move the workflow story above "It's just Markdown."</li>
+            <li>
+              Show the agent pause, the review window, and the resume signal.
+            </li>
+            <li>
+              Keep the format section as proof that the review data is portable
+              Markdown.
+            </li>
+          </ul>
+          <div className="mt-5 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-900 dark:border-emerald-900/70 dark:bg-emerald-950/40 dark:text-emerald-200">
+            Review an agent's plan before it starts coding.
+          </div>
+        </div>
+        <div className="border-t border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-950/70 lg:border-t-0 lg:border-l">
+          <div className="space-y-3">
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs leading-5 text-amber-950 dark:border-amber-900/70 dark:bg-amber-950/40 dark:text-amber-100">
+              This should go above "It's just Markdown."
+            </div>
+            <div className="rounded-md border border-slate-200 bg-white p-3 text-xs leading-5 text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+              Can we make the example about homepage conversion?
+            </div>
+            <div className="rounded-md border border-emerald-200 bg-white p-3 text-xs leading-5 text-emerald-900 dark:border-emerald-900/70 dark:bg-slate-900 dark:text-emerald-200">
+              Suggested change
+              <div className="mt-1 font-medium">
+                Review an agent's plan before it starts coding.
+              </div>
+            </div>
+          </div>
+          <div className="mt-5 flex justify-end">
+            <div className="homepage-workflow-done-popover">
+              <Button className="h-9 gap-2 px-3 text-sm" type="button">
+                <MousePointerClick className="size-4" aria-hidden="true" />
+                Done Reviewing
+              </Button>
+              <div className="homepage-workflow-popover-card">
+                <div className="font-semibold text-slate-950 dark:text-slate-50">
+                  Review complete
+                </div>
+                <div className="mt-1 text-xs leading-5 text-slate-600 dark:text-slate-400">
+                  Your agent can read the edited Markdown file now.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AgentResumeMock() {
+  return (
+    <div className="homepage-workflow-panel homepage-workflow-resume">
+      <div className="homepage-workflow-panel-header">
+        <Sparkles className="size-3.5" aria-hidden="true" />
+        Agent resumes
+      </div>
+      <div className="p-4">
+        <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm leading-6 text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+          I read your comments. I'll move the workflow storyboard above the
+          Markdown section and use the homepage conversion example.
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+**Step 4: Replace the old workflow section placement**
+
+In `Homepage`, move the workflow section so the render order becomes:
+
+```tsx
+<div className="mx-auto mt-10 ...">
+  <img ... />
+</div>
+
+<section
+  aria-labelledby="homepage-workflow-heading"
+  className="homepage-workflow-storyboard mx-auto mt-12 w-full max-w-6xl text-left"
+  data-homepage-workflow-storyboard=""
+>
+  ...
+</section>
+
+<RoughdraftFormatDemo />
+```
+
+Delete the old two-card section that currently appears after `<RoughdraftFormatDemo />`.
+
+**Step 5: Add the storyboard section JSX**
+
+Use this JSX for the section body:
+
+```tsx
+<section
+  aria-labelledby="homepage-workflow-heading"
+  className="homepage-workflow-storyboard mx-auto mt-12 w-full max-w-6xl text-left"
+  data-homepage-workflow-storyboard=""
+>
+  <div className="grid gap-8 border-b border-slate-200 bg-[#FAFAF8] p-5 dark:border-slate-700 dark:bg-slate-950/60 sm:p-6 lg:grid-cols-[0.72fr_1.28fr] lg:p-8">
+    <div>
+      <p className="text-xs font-medium tracking-[0.16em] text-stone-500 dark:text-stone-400 uppercase">
+        Workflow
+      </p>
+      <h2
+        className="mt-3 text-3xl leading-tight font-semibold text-balance text-slate-950 dark:text-slate-50 sm:text-4xl"
+        id="homepage-workflow-heading"
+      >
+        Review an agent's plan before it starts coding.
+      </h2>
+      <p className="mt-4 text-base leading-7 text-slate-600 dark:text-slate-400">
+        Ask for a plan, mark it up in Roughdraft, click Done Reviewing, and the
+        agent continues from the edited Markdown file.
+      </p>
+    </div>
+
+    <ol className="homepage-workflow-scene-list">
+      {HOMEPAGE_WORKFLOW_SCENES.map((scene, index) => (
+        <HomepageWorkflowScene
+          active={index === 2 || index === 4}
+          description={scene.description}
+          key={scene.step}
+          step={scene.step}
+          title={scene.title}
+        />
+      ))}
+    </ol>
+  </div>
+
+  <div className="grid gap-4 bg-white p-4 dark:bg-slate-900 sm:p-5 xl:grid-cols-[0.9fr_1.35fr_0.75fr]">
+    <AgentChatMock />
+    <RoughdraftPlanMock />
+    <AgentResumeMock />
+  </div>
+</section>
+```
+
+**Step 6: Add CSS for the storyboard**
+
+Append these rules inside `@layer components` in `packages/app/src/style.css`, near the existing `rfm-*` homepage rules:
+
+```css
+.homepage-workflow-storyboard {
+  overflow: hidden;
+  border: 1px solid rgb(226 232 240);
+  border-radius: 0.5rem;
+  background-color: #fff;
+  box-shadow: 0 24px 70px rgb(15 23 42 / 10%);
+}
+
+.dark .homepage-workflow-storyboard {
+  border-color: rgb(51 65 85);
+  background-color: rgb(15 23 42);
+  box-shadow: 0 24px 70px rgb(0 0 0 / 35%);
+}
+
+.homepage-workflow-scene-list {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.homepage-workflow-scene {
+  position: relative;
+  border: 1px solid rgb(226 232 240);
+  border-radius: 0.5rem;
+  background-color: rgb(255 255 255 / 82%);
+  padding: 0.875rem;
+}
+
+.dark .homepage-workflow-scene {
+  border-color: rgb(51 65 85);
+  background-color: rgb(15 23 42 / 72%);
+}
+
+.homepage-workflow-scene-marker {
+  display: inline-flex;
+  height: 1.75rem;
+  min-width: 1.75rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid rgb(203 213 225);
+  color: rgb(100 116 139);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.homepage-workflow-scene-marker-active {
+  border-color: rgb(15 23 42);
+  background-color: rgb(15 23 42);
+  color: white;
+}
+
+.dark .homepage-workflow-scene-marker {
+  border-color: rgb(71 85 105);
+  color: rgb(148 163 184);
+}
+
+.dark .homepage-workflow-scene-marker-active {
+  border-color: rgb(241 245 249);
+  background-color: rgb(241 245 249);
+  color: rgb(15 23 42);
+}
+
+.homepage-workflow-panel {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid rgb(226 232 240);
+  border-radius: 0.5rem;
+  background-color: rgb(248 250 252);
+}
+
+.dark .homepage-workflow-panel {
+  border-color: rgb(51 65 85);
+  background-color: rgb(2 6 23);
+}
+
+.homepage-workflow-panel-header {
+  display: flex;
+  height: 2.5rem;
+  align-items: center;
+  gap: 0.375rem;
+  border-bottom: 1px solid rgb(226 232 240);
+  padding: 0 1rem;
+  color: rgb(100 116 139);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.dark .homepage-workflow-panel-header {
+  border-color: rgb(51 65 85);
+  color: rgb(148 163 184);
+}
+
+.homepage-workflow-done-popover {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+}
+
+.homepage-workflow-popover-card {
+  width: min(13rem, calc(100vw - 3rem));
+  border: 1px solid rgb(226 232 240);
+  border-radius: 0.5rem;
+  background-color: white;
+  padding: 0.75rem;
+  box-shadow: 0 14px 34px rgb(15 23 42 / 14%);
+}
+
+.dark .homepage-workflow-popover-card {
+  border-color: rgb(51 65 85);
+  background-color: rgb(15 23 42);
+  box-shadow: 0 14px 34px rgb(0 0 0 / 36%);
+}
+
+@media (min-width: 720px) {
+  .homepage-workflow-scene-list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1100px) {
+  .homepage-workflow-scene-list {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  .homepage-workflow-scene:not(:last-child)::after {
+    position: absolute;
+    top: 1.75rem;
+    right: -0.75rem;
+    z-index: 1;
+    width: 0.75rem;
+    height: 1px;
+    background-color: rgb(203 213 225);
+    content: "";
+  }
+
+  .dark .homepage-workflow-scene:not(:last-child)::after {
+    background-color: rgb(71 85 105);
+  }
+}
+```
+
+**Step 7: Run focused unit test**
+
+Run:
+
+```bash
+pnpm --filter @roughdraft/app exec vitest run test/homepage.test.tsx -t "six-scene storyboard"
+```
+
+Expected: PASS.
+
+**Step 8: Run full homepage unit test file**
+
+Run:
+
+```bash
+pnpm --filter @roughdraft/app exec vitest run test/homepage.test.tsx
+```
+
+Expected: PASS.
+
+**Step 9: Commit implementation**
+
+```bash
+git add packages/app/src/App.tsx packages/app/src/style.css packages/app/test/homepage.test.tsx
+git commit -m "feat: add homepage workflow storyboard"
+```
+
+## Task 3: Add browser coverage for placement and mobile overflow
+
+**Files:**
+- Create: `packages/app/e2e/homepage-storyboard.spec.ts`
+
+**Step 1: Write the failing Playwright spec**
+
+Create `packages/app/e2e/homepage-storyboard.spec.ts`:
+
+```ts
+import { expect, test } from "@playwright/test";
+import { logE2eEvent } from "./helpers";
+
+test.describe("homepage workflow storyboard", () => {
+  test("renders the plan-review storyboard above the Markdown section @smoke", async ({
+    page,
+  }, testInfo) => {
+    await page.goto("/");
+
+    const storyboard = page.locator("[data-homepage-workflow-storyboard]");
+    await expect(storyboard).toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        name: "Review an agent's plan before it starts coding.",
+      }),
+    ).toBeVisible();
+
+    await expect(storyboard.getByText("Ask for a plan")).toBeVisible();
+    await expect(storyboard.getByText("The agent works normally")).toBeVisible();
+    await expect(storyboard.getByText("Roughdraft opens the plan")).toBeVisible();
+    await expect(
+      storyboard.getByText("Leave comments and suggestions"),
+    ).toBeVisible();
+    await expect(storyboard.getByText("Click Done Reviewing")).toBeVisible();
+    await expect(storyboard.getByText("The agent resumes")).toBeVisible();
+    await expect(
+      storyboard.getByText(
+        "Let's make the homepage more persuasive. Write a plan first.",
+      ),
+    ).toBeVisible();
+    await expect(storyboard.getByText("Homepage Conversion Plan")).toBeVisible();
+    await expect(storyboard.getByText("Review complete")).toBeVisible();
+
+    const storyboardTop = await storyboard.evaluate(
+      (element) => element.getBoundingClientRect().top + window.scrollY,
+    );
+    const markdownTop = await page.locator(".rfm-format-demo").evaluate(
+      (element) => element.getBoundingClientRect().top + window.scrollY,
+    );
+    expect(storyboardTop).toBeLessThan(markdownTop);
+
+    await testInfo.attach("homepage-workflow-storyboard-desktop", {
+      body: await storyboard.screenshot(),
+      contentType: "image/png",
+    });
+
+    logE2eEvent("homepage.workflow-storyboard.desktop", {
+      storyboardTop,
+      markdownTop,
+    });
+  });
+
+  test("does not create horizontal overflow on mobile", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/");
+
+    const storyboard = page.locator("[data-homepage-workflow-storyboard]");
+    await expect(storyboard).toBeVisible();
+
+    const dimensions = await page.evaluate(() => ({
+      bodyScrollWidth: document.body.scrollWidth,
+      documentScrollWidth: document.documentElement.scrollWidth,
+      viewportWidth: window.innerWidth,
+    }));
+
+    expect(dimensions.bodyScrollWidth).toBeLessThanOrEqual(
+      dimensions.viewportWidth,
+    );
+    expect(dimensions.documentScrollWidth).toBeLessThanOrEqual(
+      dimensions.viewportWidth,
+    );
+
+    logE2eEvent("homepage.workflow-storyboard.mobile-overflow", dimensions);
+  });
+});
+```
+
+**Step 2: Run the focused browser spec**
+
+Run:
+
+```bash
+pnpm exec playwright test --config packages/app/playwright.config.ts packages/app/e2e/homepage-storyboard.spec.ts --project chromium
+```
+
+Expected: PASS after Task 2. If run before implementation, it should fail because the storyboard selector is missing.
+
+**Step 3: Commit browser coverage**
+
+```bash
+git add packages/app/e2e/homepage-storyboard.spec.ts
+git commit -m "test: cover homepage storyboard in browser"
+```
+
+## Task 4: Polish copy, responsiveness, and accessibility
+
+**Files:**
+- Modify: `packages/app/src/App.tsx`
+- Modify: `packages/app/src/style.css`
+- Modify if needed: `packages/app/test/homepage.test.tsx`
+- Modify if needed: `packages/app/e2e/homepage-storyboard.spec.ts`
+
+**Step 1: Start the app for manual inspection**
+
+Run:
+
+```bash
+pnpm --filter @roughdraft/app dev --host 127.0.0.1 --port 4318
+```
+
+Leave this process running while inspecting. If port `4318` is occupied, use:
+
+```bash
+PLAYWRIGHT_APP_PORT=4328 pnpm --filter @roughdraft/app dev --host 127.0.0.1 --port 4328
+```
+
+**Step 2: Inspect in browser at desktop and mobile sizes**
+
+Open:
+
+```text
+http://127.0.0.1:4318/
+```
+
+Check:
+
+- The storyboard appears immediately after the screenshot hero and before the format demo.
+- The story reads left-to-right on wide desktop and top-to-bottom on mobile.
+- No text overlaps inside scene cards, chat bubbles, the plan mock, or the Done Reviewing popover.
+- The section does not look like a nested-card stack. The outer storyboard is one framed tool surface; the repeated scene cards and mock panels are legitimate framed items inside it.
+- The color palette remains neutral and product-like, not dominated by purple, beige, dark blue, or brown.
+- The `Done Reviewing` button is visibly a shadcn button and the pointer icon communicates the click step.
+
+**Step 3: Refine styles only where the browser shows issues**
+
+Use these targeted fixes if needed:
+
+- If desktop scene labels wrap awkwardly, reduce scene body text to `text-[0.7rem] leading-4` in the JSX or set `.homepage-workflow-scene { padding: 0.75rem; }`.
+- If the plan mock is too wide on laptop widths, change the `xl:grid-cols-[0.9fr_1.35fr_0.75fr]` container to `2xl:grid-cols-[0.9fr_1.35fr_0.75fr]` so the three-panel layout only appears on wider screens.
+- If mobile overflows, add `min-width: 0;` to the direct children of the bottom grid and check that long text remains wrapped.
+- If visual hierarchy is too heavy, reduce the outer shadow to `0 18px 44px rgb(15 23 42 / 8%)`.
+
+**Step 4: Run verification**
+
+Run:
+
+```bash
+pnpm --filter @roughdraft/app exec vitest run test/homepage.test.tsx
+pnpm exec playwright test --config packages/app/playwright.config.ts packages/app/e2e/homepage-storyboard.spec.ts --project chromium
+pnpm --filter @roughdraft/app build
+```
+
+Expected: all pass.
+
+**Step 5: Commit polish**
+
+Only commit if there are additional polish edits:
+
+```bash
+git add packages/app/src/App.tsx packages/app/src/style.css packages/app/test/homepage.test.tsx packages/app/e2e/homepage-storyboard.spec.ts
+git commit -m "style: polish homepage workflow storyboard"
+```
+
+## Task 5: Final full check and handoff
+
+**Files:**
+- No new files unless verification reveals a necessary fix.
+
+**Step 1: Run the repo check**
+
+Run:
+
+```bash
+pnpm check
+```
+
+Expected: PASS.
+
+If `pnpm check` fails outside the touched files, capture the failure in the final handoff and still run the focused app checks from Task 4. Do not hide unrelated failures.
+
+**Step 2: Confirm intended changes**
+
+Run:
+
+```bash
+git status --short
+git diff origin/main... -- packages/app/src/App.tsx packages/app/src/style.css packages/app/test/homepage.test.tsx packages/app/e2e/homepage-storyboard.spec.ts
+```
+
+Expected changed files:
+
+```text
+packages/app/src/App.tsx
+packages/app/src/style.css
+packages/app/test/homepage.test.tsx
+packages/app/e2e/homepage-storyboard.spec.ts
+```
+
+There should be no `dist/` changes unless the repository convention for this branch explicitly requires built assets.
+
+**Step 3: Final implementation summary**
+
+Report:
+
+- The storyboard was added above the Markdown format section.
+- It uses six scenes matching the user's requested workflow.
+- It uses real in-page mock UI rather than static screenshots.
+- Tests run, including exact commands and outcomes.
+- Any residual risk, especially visual judgment that depends on browser inspection.
+
+**Step 4: Final commit if needed**
+
+If previous tasks were committed separately, no final commit is required. If there are uncommitted verification fixes, commit them:
+
+```bash
+git add packages/app/src/App.tsx packages/app/src/style.css packages/app/test/homepage.test.tsx packages/app/e2e/homepage-storyboard.spec.ts
+git commit -m "fix: finalize homepage workflow storyboard"
+```
+
+## Testing strategy
+
+Use a medium strategy:
+
+- Unit coverage proves semantic content, section ordering, all six scenes, and CTA/format regressions.
+- Browser coverage proves the storyboard renders in a real browser, appears above the Markdown demo, captures screenshot evidence, and does not overflow on mobile.
+- Build coverage catches TypeScript and production bundling issues.
+
+This is stronger than text-only testing because the change is conversion-oriented and layout-sensitive. It avoids heavyweight committed visual baselines because the section is static marketing UI and screenshot baselines would create maintenance churn disproportionate to the risk.
+
+## Risks and mitigations
+
+- **Risk: the storyboard becomes too busy.** Mitigation: keep the top row as concise scene cards and the bottom row as three mock surfaces, not six full screenshots.
+- **Risk: mobile overflow from chat/tool text.** Mitigation: use `min-w-0`, wrapping text, and the Playwright mobile overflow test.
+- **Risk: the page deemphasizes Markdown portability.** Mitigation: keep `RoughdraftFormatDemo` directly after the storyboard and include copy saying the agent continues from the edited Markdown file.
+- **Risk: the mock UI promises behavior not yet true.** Mitigation: show only existing workflow concepts: agent writes a Markdown file, opens Roughdraft, user comments, user clicks Done Reviewing, agent reads the edited file.
+- **Risk: style drift from shadcn/Tailwind conventions.** Mitigation: use the existing `Button`, lucide icons, 0.5rem radius, restrained neutral palette, and CSS only for reusable storyboard layout primitives.
+
+## Definition of done
+
+- Homepage render order is hero, screenshot, workflow storyboard, Roughdraft format demo, remaining homepage content.
+- The old two-card "Review workflow" section is gone.
+- The new storyboard has six explicit scenes:
+  1. Ask for a plan
+  2. The agent works normally
+  3. Roughdraft opens the plan
+  4. Leave comments and suggestions
+  5. Click Done Reviewing
+  6. The agent resumes
+- The storyboard uses the homepage conversion example requested by the user.
+- The storyboard shows comments, questions, a suggested change, a Done Reviewing popover, and the resumed agent chat.
+- `pnpm --filter @roughdraft/app exec vitest run test/homepage.test.tsx` passes.
+- `pnpm exec playwright test --config packages/app/playwright.config.ts packages/app/e2e/homepage-storyboard.spec.ts --project chromium` passes.
+- `pnpm --filter @roughdraft/app build` passes.
+- `pnpm check` passes or any unrelated failure is explicitly reported with focused checks passing.

--- a/docs/plans/2026-05-07-homepage-workflow-storyboard.md
+++ b/docs/plans/2026-05-07-homepage-workflow-storyboard.md
@@ -24,6 +24,8 @@ This also answers the user's confusion about "Medium strategy": the testing stra
 
 Do not add a new approval gate unless the user asks to revise the plan first. The user already asked to run trycycle in the current checkout, and this plan is the execution source of truth.
 
+Handoff expectation for the executor: if the user asks where the work is being planned or reviewed, name the plan file directly instead of summarizing an unseen "Medium strategy." The user's immediate confusion was about process visibility, so the implementation handoff should keep the Markdown plan path visible.
+
 ## Relevant existing context
 
 - `docs/adr/0001-single-local-markdown-file.md` says Roughdraft's unit of work is one Markdown file. The storyboard should show `homepage-conversion-plan.md`, not projects, vaults, or multi-file workspaces.
@@ -293,12 +295,11 @@ import {
   FileText,
   MessageSquare,
   MousePointerClick,
-  PencilLine,
   Sparkles,
 } from "lucide-react";
 ```
 
-Remove any icon imports that become unused after deleting `HOMEPAGE_WORKFLOWS`.
+Remove any icon imports that become unused after deleting `HOMEPAGE_WORKFLOWS`. In the current file, `PencilLine` should be removed because it is only used by the old two-card workflow data.
 
 **Step 2: Replace `HOMEPAGE_WORKFLOWS` with storyboard data**
 

--- a/packages/app/e2e/homepage-storyboard.spec.ts
+++ b/packages/app/e2e/homepage-storyboard.spec.ts
@@ -11,7 +11,7 @@ test.describe("homepage workflow storyboard", () => {
     await expect(storyboard).toBeVisible();
     await expect(
       page.getByRole("heading", {
-        name: "Review an agent's plan before it starts coding.",
+        name: "How it works",
       }),
     ).toBeVisible();
 
@@ -41,13 +41,142 @@ test.describe("homepage workflow storyboard", () => {
         "Let's make the homepage more persuasive. Write a plan first.",
       ),
     ).toBeVisible();
+
+    const agentWorkTranscript = storyboard.locator(
+      ".homepage-workflow-terminal-reveal-stack",
+    );
+    await expect(agentWorkTranscript).toHaveAttribute(
+      "data-agent-work-visible",
+      "false",
+    );
+    const hiddenTranscriptState = await agentWorkTranscript.evaluate(
+      (element) => ({
+        maxHeight: window.getComputedStyle(element).maxHeight,
+        opacity: window.getComputedStyle(element).opacity,
+      }),
+    );
+    expect(hiddenTranscriptState).toEqual({
+      maxHeight: "0px",
+      opacity: "0",
+    });
+
+    const roughdraftPopup = storyboard.locator(
+      "[data-homepage-workflow-popup]",
+    );
+    await expect(roughdraftPopup).toHaveAttribute(
+      "data-popup-visible",
+      "false",
+    );
+    await expect(roughdraftPopup).toHaveAttribute("aria-hidden", "true");
+
+    const hiddenPopupState = await roughdraftPopup.evaluate((element) => ({
+      opacity: window.getComputedStyle(element).opacity,
+      pointerEvents: window.getComputedStyle(element).pointerEvents,
+    }));
+    expect(hiddenPopupState).toEqual({
+      opacity: "0",
+      pointerEvents: "none",
+    });
+
+    await storyboard
+      .locator("[data-homepage-workflow-scene]")
+      .nth(1)
+      .evaluate((element) => {
+        window.scrollTo({
+          top: element.getBoundingClientRect().top + window.scrollY - 1,
+        });
+      });
+    await expect(agentWorkTranscript).toHaveAttribute(
+      "data-agent-work-visible",
+      "false",
+    );
+
+    await storyboard
+      .locator("[data-homepage-workflow-scene]")
+      .nth(1)
+      .evaluate((element) => {
+        window.scrollTo({
+          top: element.getBoundingClientRect().top + window.scrollY,
+        });
+      });
+    await expect(agentWorkTranscript).toHaveAttribute(
+      "data-agent-work-visible",
+      "true",
+    );
     await expect(
-      storyboard.getByText("Homepage Conversion Plan"),
+      storyboard.getByText(
+        "I'll inspect the current homepage, draft a Markdown plan, and open it in Roughdraft for review before I code.",
+      ),
+    ).toBeVisible();
+    await expect(storyboard.getByText("Tool calls")).toBeVisible();
+    await expect(roughdraftPopup).toHaveAttribute(
+      "data-popup-visible",
+      "false",
+    );
+
+    await storyboard
+      .locator("[data-homepage-workflow-scene]")
+      .nth(2)
+      .evaluate((element) => {
+        window.scrollTo({
+          top: element.getBoundingClientRect().top + window.scrollY,
+        });
+      });
+    await expect(roughdraftPopup).toHaveAttribute("data-popup-visible", "true");
+    await expect(roughdraftPopup).not.toHaveAttribute("aria-hidden", "true");
+    await expect(
+      storyboard
+        .getByRole("heading", { name: "Homepage Conversion Plan" })
+        .first(),
     ).toBeVisible();
     await expect(
       storyboard.getByRole("button", { name: "Done Reviewing" }),
     ).toBeVisible();
     await expect(storyboard.getByText("Review complete")).toBeVisible();
+
+    const stickyLayout = await storyboard.evaluate((element) => {
+      const sticky = element.querySelector(
+        "[data-homepage-workflow-sticky-visual]",
+      );
+      const sceneList = element.querySelector(".homepage-workflow-scene-list");
+      if (!sticky || !sceneList) {
+        throw new Error("Expected sticky visual and scene list");
+      }
+
+      const stickyRect = sticky.getBoundingClientRect();
+      const sceneListRect = sceneList.getBoundingClientRect();
+      return {
+        position: window.getComputedStyle(sticky).position,
+        sceneListRight: sceneListRect.right,
+        stickyLeft: stickyRect.left,
+        stickyTop: stickyRect.top,
+      };
+    });
+    expect(stickyLayout.position).toBe("sticky");
+    expect(stickyLayout.stickyLeft).toBeGreaterThan(
+      stickyLayout.sceneListRight,
+    );
+
+    const sceneLayout = await storyboard
+      .locator("[data-homepage-workflow-scene]")
+      .evaluateAll((elements) =>
+        elements.map((element) => {
+          const rect = element.getBoundingClientRect();
+          return {
+            height: rect.height,
+            top: rect.top + window.scrollY,
+          };
+        }),
+      );
+    expect(sceneLayout).toHaveLength(6);
+    for (let index = 1; index < sceneLayout.length; index += 1) {
+      expect(sceneLayout[index].top).toBeGreaterThan(
+        sceneLayout[index - 1].top,
+      );
+    }
+    for (const scene of sceneLayout) {
+      expect(scene.height).toBeGreaterThan(500);
+    }
 
     const storyboardTop = await storyboard.evaluate(
       (element) => element.getBoundingClientRect().top + window.scrollY,
@@ -65,6 +194,8 @@ test.describe("homepage workflow storyboard", () => {
     });
 
     logE2eEvent("homepage.workflow-storyboard.desktop", {
+      sceneLayout,
+      stickyLayout,
       storyboardTop,
       markdownTop,
     });
@@ -78,7 +209,7 @@ test.describe("homepage workflow storyboard", () => {
     await expect(storyboard).toBeVisible();
     await expect(
       page.getByRole("heading", {
-        name: "Review an agent's plan before it starts coding.",
+        name: "How it works",
       }),
     ).toBeVisible();
 

--- a/packages/app/e2e/homepage-storyboard.spec.ts
+++ b/packages/app/e2e/homepage-storyboard.spec.ts
@@ -7,43 +7,28 @@ test.describe("homepage workflow storyboard", () => {
   }, testInfo) => {
     await page.goto("/");
 
-    const storyboard = page.locator("[data-homepage-workflow-storyboard]");
+    const storyboard = page.getByTestId("homepage-workflow-storyboard");
     await expect(storyboard).toBeVisible();
-    await expect(
-      page.getByRole("heading", {
-        name: "How it works",
-      }),
-    ).toBeVisible();
+    await expect(page.getByTestId("homepage-workflow-heading")).toHaveText(
+      "How it works",
+    );
 
-    await expect(
-      storyboard.locator("[data-homepage-workflow-scene]"),
-    ).toHaveCount(6);
-    await expect(
-      storyboard.getByText("Ask for a plan", { exact: true }),
-    ).toBeVisible();
-    await expect(
-      storyboard.getByText("The agent works normally", { exact: true }),
-    ).toBeVisible();
-    await expect(
-      storyboard.getByText("Roughdraft opens the plan", { exact: true }),
-    ).toBeVisible();
-    await expect(
-      storyboard.getByText("Leave comments and suggestions", { exact: true }),
-    ).toBeVisible();
-    await expect(
-      storyboard.getByText("Click Done Reviewing", { exact: true }),
-    ).toBeVisible();
-    await expect(
-      storyboard.getByText("The agent resumes", { exact: true }),
-    ).toBeVisible();
-    await expect(
-      storyboard.getByText(
-        "Let's make the homepage more persuasive. Write a plan first.",
-      ),
-    ).toBeVisible();
+    const scenes = storyboard.getByTestId("homepage-workflow-scene");
+    await expect(scenes).toHaveCount(6);
+    const sceneTexts = await scenes.allTextContents();
+    expect(sceneTexts).toHaveLength(6);
+    expect(sceneTexts[0]).toContain("Ask for a plan");
+    expect(sceneTexts[1]).toContain("The agent works normally");
+    expect(sceneTexts[2]).toContain("Roughdraft opens the plan");
+    expect(sceneTexts[3]).toContain("Leave comments and suggestions");
+    expect(sceneTexts[4]).toContain("Click I'm done");
+    expect(sceneTexts[5]).toContain("The agent resumes");
+    await expect(storyboard).toContainText(
+      "Let's make the homepage more persuasive. Write a plan first.",
+    );
 
-    const agentWorkTranscript = storyboard.locator(
-      ".homepage-workflow-terminal-reveal-stack",
+    const agentWorkTranscript = storyboard.getByTestId(
+      "homepage-workflow-agent-work",
     );
     await expect(agentWorkTranscript).toHaveAttribute(
       "data-agent-work-visible",
@@ -60,9 +45,7 @@ test.describe("homepage workflow storyboard", () => {
       opacity: "0",
     });
 
-    const roughdraftPopup = storyboard.locator(
-      "[data-homepage-workflow-popup]",
-    );
+    const roughdraftPopup = storyboard.getByTestId("homepage-workflow-popup");
     await expect(roughdraftPopup).toHaveAttribute(
       "data-popup-visible",
       "false",
@@ -78,67 +61,90 @@ test.describe("homepage workflow storyboard", () => {
       pointerEvents: "none",
     });
 
-    await storyboard
-      .locator("[data-homepage-workflow-scene]")
-      .nth(1)
-      .evaluate((element) => {
-        window.scrollTo({
-          top: element.getBoundingClientRect().top + window.scrollY - 1,
-        });
+    await scenes.nth(1).evaluate((element) => {
+      window.scrollTo({
+        top: element.getBoundingClientRect().top + window.scrollY - 1,
       });
+    });
     await expect(agentWorkTranscript).toHaveAttribute(
       "data-agent-work-visible",
       "false",
     );
 
-    await storyboard
-      .locator("[data-homepage-workflow-scene]")
-      .nth(1)
-      .evaluate((element) => {
-        window.scrollTo({
-          top: element.getBoundingClientRect().top + window.scrollY,
-        });
+    await scenes.nth(1).evaluate((element) => {
+      window.scrollTo({
+        top: element.getBoundingClientRect().top + window.scrollY,
       });
+    });
     await expect(agentWorkTranscript).toHaveAttribute(
       "data-agent-work-visible",
       "true",
     );
+    await expect(storyboard).toContainText(
+      "I'll inspect the current homepage, draft a Markdown plan, and open it in Roughdraft for review before I code.",
+    );
     await expect(
-      storyboard.getByText(
-        "I'll inspect the current homepage, draft a Markdown plan, and open it in Roughdraft for review before I code.",
-      ),
-    ).toBeVisible();
-    await expect(storyboard.getByText("Tool calls")).toBeVisible();
+      storyboard.getByTestId("homepage-workflow-terminal-tools"),
+    ).toContainText("Tool calls");
     await expect(roughdraftPopup).toHaveAttribute(
       "data-popup-visible",
       "false",
     );
 
-    await storyboard
-      .locator("[data-homepage-workflow-scene]")
-      .nth(2)
-      .evaluate((element) => {
-        window.scrollTo({
-          top: element.getBoundingClientRect().top + window.scrollY,
-        });
+    await scenes.nth(2).evaluate((element) => {
+      window.scrollTo({
+        top: element.getBoundingClientRect().top + window.scrollY,
       });
+    });
     await expect(roughdraftPopup).toHaveAttribute("data-popup-visible", "true");
     await expect(roughdraftPopup).not.toHaveAttribute("aria-hidden", "true");
     await expect(
-      storyboard
-        .getByRole("heading", { name: "Homepage Conversion Plan" })
-        .first(),
+      storyboard.getByTestId("homepage-workflow-document-title"),
     ).toBeVisible();
     await expect(
-      storyboard.getByRole("button", { name: "Done Reviewing" }),
+      roughdraftPopup.getByTestId(
+        "homepage-workflow-document-shell-no-comments",
+      ),
     ).toBeVisible();
-    await expect(storyboard.getByText("Review complete")).toBeVisible();
+    await expect(
+      roughdraftPopup.getByTestId("homepage-workflow-review-comment"),
+    ).toHaveCount(0);
+    await expect(
+      storyboard.getByTestId("homepage-workflow-handoff-button"),
+    ).toHaveCount(0);
+    await expect(storyboard).not.toContainText("Review complete");
+
+    await scenes.nth(3).evaluate((element) => {
+      window.scrollTo({
+        top: element.getBoundingClientRect().top + window.scrollY,
+      });
+    });
+    await expect(
+      roughdraftPopup.getByTestId(
+        "homepage-workflow-document-shell-with-comments",
+      ),
+    ).toBeVisible();
+    await expect(
+      roughdraftPopup.getByTestId("homepage-workflow-review-comment"),
+    ).toBeVisible();
+
+    await scenes.nth(4).evaluate((element) => {
+      window.scrollTo({
+        top: element.getBoundingClientRect().top + window.scrollY,
+      });
+    });
+    await expect(
+      storyboard.getByTestId("homepage-workflow-handoff-button"),
+    ).toBeVisible();
+    await expect(storyboard).not.toContainText("Review complete");
 
     const stickyLayout = await storyboard.evaluate((element) => {
       const sticky = element.querySelector(
-        "[data-homepage-workflow-sticky-visual]",
+        '[data-testid="homepage-workflow-sticky-visual"]',
       );
-      const sceneList = element.querySelector(".homepage-workflow-scene-list");
+      const sceneList = element.querySelector(
+        '[data-testid="homepage-workflow-scene-list"]',
+      );
       if (!sticky || !sceneList) {
         throw new Error("Expected sticky visual and scene list");
       }
@@ -157,17 +163,15 @@ test.describe("homepage workflow storyboard", () => {
       stickyLayout.sceneListRight,
     );
 
-    const sceneLayout = await storyboard
-      .locator("[data-homepage-workflow-scene]")
-      .evaluateAll((elements) =>
-        elements.map((element) => {
-          const rect = element.getBoundingClientRect();
-          return {
-            height: rect.height,
-            top: rect.top + window.scrollY,
-          };
-        }),
-      );
+    const sceneLayout = await scenes.evaluateAll((elements) =>
+      elements.map((element) => {
+        const rect = element.getBoundingClientRect();
+        return {
+          height: rect.height,
+          top: rect.top + window.scrollY,
+        };
+      }),
+    );
     expect(sceneLayout).toHaveLength(6);
     for (let index = 1; index < sceneLayout.length; index += 1) {
       expect(sceneLayout[index].top).toBeGreaterThan(
@@ -182,7 +186,7 @@ test.describe("homepage workflow storyboard", () => {
       (element) => element.getBoundingClientRect().top + window.scrollY,
     );
     const markdownTop = await page
-      .locator(".rfm-format-demo")
+      .getByTestId("rfm-format-demo")
       .evaluate(
         (element) => element.getBoundingClientRect().top + window.scrollY,
       );
@@ -205,41 +209,31 @@ test.describe("homepage workflow storyboard", () => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto("/");
 
-    const storyboard = page.locator("[data-homepage-workflow-storyboard]");
+    const storyboard = page.getByTestId("homepage-workflow-storyboard");
     await expect(storyboard).toBeVisible();
-    await expect(
-      page.getByRole("heading", {
-        name: "How it works",
-      }),
-    ).toBeVisible();
+    await expect(page.getByTestId("homepage-workflow-heading")).toHaveText(
+      "How it works",
+    );
 
-    await expect(
-      storyboard.getByText("Ask for a plan", { exact: true }),
-    ).toBeVisible();
-    await expect(
-      storyboard.getByText("The agent works normally", { exact: true }),
-    ).toBeVisible();
-    await expect(
-      storyboard.getByText("Roughdraft opens the plan", { exact: true }),
-    ).toBeVisible();
-    await expect(
-      storyboard.getByText("Leave comments and suggestions", { exact: true }),
-    ).toBeVisible();
-    await expect(
-      storyboard.getByText("Click Done Reviewing", { exact: true }),
-    ).toBeVisible();
-    await expect(
-      storyboard.getByText("The agent resumes", { exact: true }),
-    ).toBeVisible();
+    const mobileSceneTexts = await storyboard
+      .getByTestId("homepage-workflow-scene")
+      .allTextContents();
+    expect(mobileSceneTexts).toHaveLength(6);
+    expect(mobileSceneTexts[0]).toContain("Ask for a plan");
+    expect(mobileSceneTexts[1]).toContain("The agent works normally");
+    expect(mobileSceneTexts[2]).toContain("Roughdraft opens the plan");
+    expect(mobileSceneTexts[3]).toContain("Leave comments and suggestions");
+    expect(mobileSceneTexts[4]).toContain("Click I'm done");
+    expect(mobileSceneTexts[5]).toContain("The agent resumes");
 
     const dimensions = await page.evaluate(() => ({
       bodyScrollWidth: document.body.scrollWidth,
       documentScrollWidth: document.documentElement.scrollWidth,
       storyboardClientWidth:
-        document.querySelector("[data-homepage-workflow-storyboard]")
+        document.querySelector('[data-testid="homepage-workflow-storyboard"]')
           ?.clientWidth ?? 0,
       storyboardScrollWidth:
-        document.querySelector("[data-homepage-workflow-storyboard]")
+        document.querySelector('[data-testid="homepage-workflow-storyboard"]')
           ?.scrollWidth ?? 0,
       viewportWidth: window.innerWidth,
     }));

--- a/packages/app/e2e/homepage-storyboard.spec.ts
+++ b/packages/app/e2e/homepage-storyboard.spec.ts
@@ -38,15 +38,19 @@ test.describe("homepage workflow storyboard", () => {
         "Let's make the homepage more persuasive. Write a plan first.",
       ),
     ).toBeVisible();
-    await expect(storyboard.getByText("Homepage Conversion Plan")).toBeVisible();
+    await expect(
+      storyboard.getByText("Homepage Conversion Plan"),
+    ).toBeVisible();
     await expect(storyboard.getByText("Review complete")).toBeVisible();
 
     const storyboardTop = await storyboard.evaluate(
       (element) => element.getBoundingClientRect().top + window.scrollY,
     );
-    const markdownTop = await page.locator(".rfm-format-demo").evaluate(
-      (element) => element.getBoundingClientRect().top + window.scrollY,
-    );
+    const markdownTop = await page
+      .locator(".rfm-format-demo")
+      .evaluate(
+        (element) => element.getBoundingClientRect().top + window.scrollY,
+      );
     expect(storyboardTop).toBeLessThan(markdownTop);
 
     await testInfo.attach("homepage-workflow-storyboard-desktop", {

--- a/packages/app/e2e/homepage-storyboard.spec.ts
+++ b/packages/app/e2e/homepage-storyboard.spec.ts
@@ -16,6 +16,9 @@ test.describe("homepage workflow storyboard", () => {
     ).toBeVisible();
 
     await expect(
+      storyboard.locator("[data-homepage-workflow-scene]"),
+    ).toHaveCount(6);
+    await expect(
       storyboard.getByText("Ask for a plan", { exact: true }),
     ).toBeVisible();
     await expect(
@@ -41,6 +44,9 @@ test.describe("homepage workflow storyboard", () => {
     await expect(
       storyboard.getByText("Homepage Conversion Plan"),
     ).toBeVisible();
+    await expect(
+      storyboard.locator("[data-homepage-workflow-done-reviewing]"),
+    ).toContainText("Done Reviewing");
     await expect(storyboard.getByText("Review complete")).toBeVisible();
 
     const storyboardTop = await storyboard.evaluate(
@@ -70,10 +76,40 @@ test.describe("homepage workflow storyboard", () => {
 
     const storyboard = page.locator("[data-homepage-workflow-storyboard]");
     await expect(storyboard).toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        name: "Review an agent's plan before it starts coding.",
+      }),
+    ).toBeVisible();
+
+    await expect(
+      storyboard.getByText("Ask for a plan", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      storyboard.getByText("The agent works normally", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      storyboard.getByText("Roughdraft opens the plan", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      storyboard.getByText("Leave comments and suggestions", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      storyboard.getByText("Click Done Reviewing", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      storyboard.getByText("The agent resumes", { exact: true }),
+    ).toBeVisible();
 
     const dimensions = await page.evaluate(() => ({
       bodyScrollWidth: document.body.scrollWidth,
       documentScrollWidth: document.documentElement.scrollWidth,
+      storyboardClientWidth:
+        document.querySelector("[data-homepage-workflow-storyboard]")
+          ?.clientWidth ?? 0,
+      storyboardScrollWidth:
+        document.querySelector("[data-homepage-workflow-storyboard]")
+          ?.scrollWidth ?? 0,
       viewportWidth: window.innerWidth,
     }));
 
@@ -82,6 +118,9 @@ test.describe("homepage workflow storyboard", () => {
     );
     expect(dimensions.documentScrollWidth).toBeLessThanOrEqual(
       dimensions.viewportWidth,
+    );
+    expect(dimensions.storyboardScrollWidth).toBeLessThanOrEqual(
+      dimensions.storyboardClientWidth,
     );
 
     logE2eEvent("homepage.workflow-storyboard.mobile-overflow", dimensions);

--- a/packages/app/e2e/homepage-storyboard.spec.ts
+++ b/packages/app/e2e/homepage-storyboard.spec.ts
@@ -45,8 +45,8 @@ test.describe("homepage workflow storyboard", () => {
       storyboard.getByText("Homepage Conversion Plan"),
     ).toBeVisible();
     await expect(
-      storyboard.locator("[data-homepage-workflow-done-reviewing]"),
-    ).toContainText("Done Reviewing");
+      storyboard.getByRole("button", { name: "Done Reviewing" }),
+    ).toBeVisible();
     await expect(storyboard.getByText("Review complete")).toBeVisible();
 
     const storyboardTop = await storyboard.evaluate(

--- a/packages/app/e2e/homepage-storyboard.spec.ts
+++ b/packages/app/e2e/homepage-storyboard.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test";
+import { logE2eEvent } from "./helpers";
+
+test.describe("homepage workflow storyboard", () => {
+  test("renders the plan-review storyboard above the Markdown section @smoke", async ({
+    page,
+  }, testInfo) => {
+    await page.goto("/");
+
+    const storyboard = page.locator("[data-homepage-workflow-storyboard]");
+    await expect(storyboard).toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        name: "Review an agent's plan before it starts coding.",
+      }),
+    ).toBeVisible();
+
+    await expect(
+      storyboard.getByText("Ask for a plan", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      storyboard.getByText("The agent works normally", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      storyboard.getByText("Roughdraft opens the plan", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      storyboard.getByText("Leave comments and suggestions", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      storyboard.getByText("Click Done Reviewing", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      storyboard.getByText("The agent resumes", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      storyboard.getByText(
+        "Let's make the homepage more persuasive. Write a plan first.",
+      ),
+    ).toBeVisible();
+    await expect(storyboard.getByText("Homepage Conversion Plan")).toBeVisible();
+    await expect(storyboard.getByText("Review complete")).toBeVisible();
+
+    const storyboardTop = await storyboard.evaluate(
+      (element) => element.getBoundingClientRect().top + window.scrollY,
+    );
+    const markdownTop = await page.locator(".rfm-format-demo").evaluate(
+      (element) => element.getBoundingClientRect().top + window.scrollY,
+    );
+    expect(storyboardTop).toBeLessThan(markdownTop);
+
+    await testInfo.attach("homepage-workflow-storyboard-desktop", {
+      body: await storyboard.screenshot(),
+      contentType: "image/png",
+    });
+
+    logE2eEvent("homepage.workflow-storyboard.desktop", {
+      storyboardTop,
+      markdownTop,
+    });
+  });
+
+  test("does not create horizontal overflow on mobile", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/");
+
+    const storyboard = page.locator("[data-homepage-workflow-storyboard]");
+    await expect(storyboard).toBeVisible();
+
+    const dimensions = await page.evaluate(() => ({
+      bodyScrollWidth: document.body.scrollWidth,
+      documentScrollWidth: document.documentElement.scrollWidth,
+      viewportWidth: window.innerWidth,
+    }));
+
+    expect(dimensions.bodyScrollWidth).toBeLessThanOrEqual(
+      dimensions.viewportWidth,
+    );
+    expect(dimensions.documentScrollWidth).toBeLessThanOrEqual(
+      dimensions.viewportWidth,
+    );
+
+    logE2eEvent("homepage.workflow-storyboard.mobile-overflow", dimensions);
+  });
+});

--- a/packages/app/e2e/homepage-storyboard.spec.ts
+++ b/packages/app/e2e/homepage-storyboard.spec.ts
@@ -106,6 +106,36 @@ test.describe("homepage workflow storyboard", () => {
         "homepage-workflow-document-shell-no-comments",
       ),
     ).toBeVisible();
+    const previewLayout = await storyboard.evaluate((element) => {
+      const terminal = element.querySelector(
+        '[data-testid="homepage-workflow-terminal"]',
+      );
+      const popup = element.querySelector(
+        '[data-testid="homepage-workflow-popup"]',
+      );
+      const scaledDocument = element.querySelector(
+        '[data-testid="homepage-workflow-document-scale"]',
+      );
+      if (!terminal || !popup || !scaledDocument) {
+        throw new Error("Expected terminal, popup, and scaled document");
+      }
+
+      const transform = window.getComputedStyle(scaledDocument).transform;
+      const matrix =
+        transform === "none"
+          ? new DOMMatrixReadOnly()
+          : new DOMMatrixReadOnly(transform);
+
+      return {
+        documentScale: matrix.a,
+        popupWidth: popup.getBoundingClientRect().width,
+        terminalWidth: terminal.getBoundingClientRect().width,
+      };
+    });
+    expect(previewLayout.popupWidth).toBeGreaterThan(
+      previewLayout.terminalWidth,
+    );
+    expect(previewLayout.documentScale).toBeCloseTo(0.6, 2);
     await expect(
       roughdraftPopup.getByTestId("homepage-workflow-review-comment"),
     ).toHaveCount(0);
@@ -127,6 +157,34 @@ test.describe("homepage workflow storyboard", () => {
     await expect(
       roughdraftPopup.getByTestId("homepage-workflow-review-comment"),
     ).toBeVisible();
+    const commentsLayout = await storyboard.evaluate((element) => {
+      const popup = element.querySelector(
+        '[data-testid="homepage-workflow-popup"]',
+      );
+      const shell = element.querySelector(
+        '[data-testid="homepage-workflow-document-shell-with-comments"]',
+      );
+      if (!popup || !shell) {
+        throw new Error("Expected popup and comments shell");
+      }
+
+      return {
+        bodyScrollWidth: document.body.scrollWidth,
+        documentScrollWidth: document.documentElement.scrollWidth,
+        popupWidth: popup.getBoundingClientRect().width,
+        shellWidth: shell.getBoundingClientRect().width,
+        viewportWidth: window.innerWidth,
+      };
+    });
+    expect(commentsLayout.bodyScrollWidth).toBeLessThanOrEqual(
+      commentsLayout.viewportWidth,
+    );
+    expect(commentsLayout.documentScrollWidth).toBeLessThanOrEqual(
+      commentsLayout.viewportWidth,
+    );
+    expect(commentsLayout.shellWidth).toBeLessThan(
+      commentsLayout.popupWidth * 0.85,
+    );
 
     await scenes.nth(4).evaluate((element) => {
       window.scrollTo({
@@ -198,6 +256,8 @@ test.describe("homepage workflow storyboard", () => {
     });
 
     logE2eEvent("homepage.workflow-storyboard.desktop", {
+      commentsLayout,
+      previewLayout,
       sceneLayout,
       stickyLayout,
       storyboardTop,
@@ -205,7 +265,9 @@ test.describe("homepage workflow storyboard", () => {
     });
   });
 
-  test("does not create horizontal overflow on mobile", async ({ page }) => {
+  test("docks the storyboard visual without mobile overlap", async ({
+    page,
+  }, testInfo) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto("/");
 
@@ -225,6 +287,169 @@ test.describe("homepage workflow storyboard", () => {
     expect(mobileSceneTexts[3]).toContain("Leave comments and suggestions");
     expect(mobileSceneTexts[4]).toContain("Click I'm done");
     expect(mobileSceneTexts[5]).toContain("The agent resumes");
+
+    const stickyVisual = storyboard.getByTestId(
+      "homepage-workflow-sticky-visual",
+    );
+    await expect(stickyVisual).toBeVisible();
+    const scenes = storyboard.getByTestId("homepage-workflow-scene");
+
+    await storyboard.evaluate((element) => {
+      window.scrollTo({
+        top: element.getBoundingClientRect().top + window.scrollY,
+      });
+    });
+
+    const layoutAtStart = await storyboard.evaluate((element) => {
+      const sticky = element.querySelector(
+        '[data-testid="homepage-workflow-sticky-visual"]',
+      );
+      const sceneList = element.querySelector(
+        '[data-testid="homepage-workflow-scene-list"]',
+      );
+      const popup = element.querySelector(
+        '[data-testid="homepage-workflow-popup"]',
+      );
+      if (!sticky || !sceneList || !popup) {
+        throw new Error("Expected sticky visual, scene list, and popup");
+      }
+
+      const stickyRect = sticky.getBoundingClientRect();
+      const popupRect = popup.getBoundingClientRect();
+      const stickyStyles = window.getComputedStyle(sticky);
+      const sceneListStyles = window.getComputedStyle(sceneList);
+      const popupStyles = window.getComputedStyle(popup);
+
+      return {
+        bodyScrollWidth: document.body.scrollWidth,
+        documentScrollWidth: document.documentElement.scrollWidth,
+        popupLeft: popupRect.left,
+        popupRight: popupRect.right,
+        popupOverhang: popupStyles.getPropertyValue(
+          "--homepage-workflow-popup-overhang",
+        ),
+        position: stickyStyles.position,
+        sceneListPaddingBottom: Number.parseFloat(
+          sceneListStyles.paddingBottom,
+        ),
+        stickyBottomGap: window.innerHeight - stickyRect.bottom,
+        stickyHeight: stickyRect.height,
+        stickyTop: stickyRect.top,
+        storyboardClientWidth: element.clientWidth,
+        storyboardScrollWidth: element.scrollWidth,
+        viewportHeight: window.innerHeight,
+        viewportWidth: window.innerWidth,
+      };
+    });
+
+    expect(layoutAtStart.position).toBe("sticky");
+    expect(layoutAtStart.stickyBottomGap).toBeGreaterThanOrEqual(8);
+    expect(layoutAtStart.stickyBottomGap).toBeLessThan(40);
+    expect(layoutAtStart.stickyHeight).toBeGreaterThan(200);
+    expect(layoutAtStart.sceneListPaddingBottom).toBeGreaterThan(
+      layoutAtStart.stickyHeight,
+    );
+    expect(layoutAtStart.popupOverhang.trim()).toBe("0rem");
+    expect(layoutAtStart.popupLeft).toBeGreaterThanOrEqual(0);
+    expect(layoutAtStart.popupRight).toBeLessThanOrEqual(
+      layoutAtStart.viewportWidth,
+    );
+
+    const stageLayouts: Array<{
+      copyBottom: number;
+      copyTop: number;
+      documentTitleBottom: number | null;
+      documentTitleTop: number | null;
+      stage: number;
+      stickyBottom: number;
+      stickyTop: number;
+      viewportHeight: number;
+    }> = [];
+    for (const index of [1, 2, 3, 4, 5]) {
+      const targetStage = String(index + 1);
+      await scenes.nth(index).evaluate((element) => {
+        const sticky = document.querySelector(
+          '[data-testid="homepage-workflow-sticky-visual"]',
+        );
+        if (!sticky) {
+          throw new Error("Expected sticky visual");
+        }
+
+        const stickyRect = sticky.getBoundingClientRect();
+        const activationLine = Math.max(
+          0,
+          Math.ceil(
+            stickyRect.top -
+              Math.min(stickyRect.height + 32, window.innerHeight * 0.35),
+          ),
+        );
+        window.scrollTo({
+          top:
+            element.getBoundingClientRect().top +
+            window.scrollY -
+            activationLine,
+        });
+      });
+
+      await expect(
+        storyboard.getByTestId("homepage-workflow-terminal"),
+      ).toHaveAttribute("data-homepage-workflow-terminal-stage", targetStage);
+
+      stageLayouts.push(
+        await scenes.nth(index).evaluate((element, stage) => {
+          const sticky = document.querySelector(
+            '[data-testid="homepage-workflow-sticky-visual"]',
+          );
+          const sceneCopy = element.querySelector(
+            ".homepage-workflow-scene-copy",
+          );
+          const documentTitle = document.querySelector(
+            '[data-testid="homepage-workflow-document-title"]',
+          );
+          if (!sticky || !sceneCopy || !documentTitle) {
+            throw new Error(
+              "Expected sticky visual, scene copy, and document title",
+            );
+          }
+
+          const stickyRect = sticky.getBoundingClientRect();
+          const copyRect = sceneCopy.getBoundingClientRect();
+          const titleRect = documentTitle.getBoundingClientRect();
+          return {
+            copyBottom: copyRect.bottom,
+            copyTop: copyRect.top,
+            documentTitleBottom: stage >= 3 ? titleRect.bottom : null,
+            documentTitleTop: stage >= 3 ? titleRect.top : null,
+            stage,
+            stickyBottom: stickyRect.bottom,
+            stickyTop: stickyRect.top,
+            viewportHeight: window.innerHeight,
+          };
+        }, index + 1),
+      );
+    }
+
+    for (const stageLayout of stageLayouts) {
+      expect(stageLayout.copyTop).toBeGreaterThanOrEqual(0);
+      expect(stageLayout.copyBottom).toBeLessThanOrEqual(
+        stageLayout.stickyTop - 8,
+      );
+      expect(stageLayout.stickyBottom).toBeLessThanOrEqual(
+        stageLayout.viewportHeight,
+      );
+      if (
+        stageLayout.stage >= 3 &&
+        stageLayout.documentTitleTop !== null &&
+        stageLayout.documentTitleBottom !== null
+      ) {
+        expect(stageLayout.documentTitleTop).toBeGreaterThanOrEqual(
+          stageLayout.stickyTop + 8,
+        );
+        expect(stageLayout.documentTitleBottom).toBeLessThanOrEqual(
+          stageLayout.stickyBottom - 8,
+        );
+      }
+    }
 
     const dimensions = await page.evaluate(() => ({
       bodyScrollWidth: document.body.scrollWidth,
@@ -248,6 +473,15 @@ test.describe("homepage workflow storyboard", () => {
       dimensions.storyboardClientWidth,
     );
 
-    logE2eEvent("homepage.workflow-storyboard.mobile-overflow", dimensions);
+    await testInfo.attach("homepage-workflow-storyboard-mobile", {
+      body: await storyboard.screenshot(),
+      contentType: "image/png",
+    });
+
+    logE2eEvent("homepage.workflow-storyboard.mobile-sticky", {
+      dimensions,
+      layoutAtStart,
+      stageLayouts,
+    });
   });
 });

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -9,7 +9,7 @@ import {
   MessageSquare,
   MousePointerClick,
   PencilLine,
-  Sparkles,
+  Terminal,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
@@ -229,6 +229,8 @@ export function Homepage({
   const [copyState, setCopyState] = useState<"idle" | "copied" | "error">(
     "idle",
   );
+  const workflowStepRefs = useRef<Record<string, HTMLLIElement | null>>({});
+  const [homepageWorkflowStage, setHomepageWorkflowStage] = useState(1);
 
   const handleCopySetupPrompt = useCallback(async () => {
     try {
@@ -238,6 +240,42 @@ export function Homepage({
     } catch {
       setCopyState("error");
     }
+  }, []);
+
+  useEffect(() => {
+    const updateHomepageWorkflowStage = () => {
+      const pageCanScroll =
+        document.documentElement.scrollHeight > window.innerHeight + 1;
+      if (!pageCanScroll) return;
+
+      let nextStage = 1;
+      for (const [step, element] of Object.entries(workflowStepRefs.current)) {
+        if (!element) continue;
+
+        const stepNumber = Number(step);
+        if (
+          element.getBoundingClientRect().top <= 0 &&
+          stepNumber > nextStage
+        ) {
+          nextStage = stepNumber;
+        }
+      }
+
+      setHomepageWorkflowStage((current) =>
+        current === nextStage ? current : nextStage,
+      );
+    };
+
+    updateHomepageWorkflowStage();
+    window.addEventListener("scroll", updateHomepageWorkflowStage, {
+      passive: true,
+    });
+    window.addEventListener("resize", updateHomepageWorkflowStage);
+
+    return () => {
+      window.removeEventListener("scroll", updateHomepageWorkflowStage);
+      window.removeEventListener("resize", updateHomepageWorkflowStage);
+    };
   }, []);
 
   return (
@@ -363,40 +401,38 @@ export function Homepage({
           className="homepage-workflow-storyboard mx-auto mt-12 w-full max-w-6xl text-left"
           data-homepage-workflow-storyboard=""
         >
-          <div className="grid gap-8 border-b border-slate-200 bg-[#FAFAF8] p-5 dark:border-slate-700 dark:bg-slate-950/60 sm:p-6 lg:grid-cols-[0.72fr_1.28fr] lg:p-8">
-            <div>
-              <p className="text-xs font-medium tracking-[0.16em] text-stone-500 dark:text-stone-400 uppercase">
-                Workflow
-              </p>
-              <h2
-                className="mt-3 text-3xl leading-tight font-semibold text-balance text-slate-950 dark:text-slate-50 sm:text-4xl"
-                id="homepage-workflow-heading"
-              >
-                Review an agent's plan before it starts coding.
-              </h2>
-              <p className="mt-4 text-base leading-7 text-slate-600 dark:text-slate-400">
-                Ask for a plan, mark it up in Roughdraft, click Done Reviewing,
-                and the agent continues from the edited Markdown file.
-              </p>
+          <div className="homepage-workflow-intro">
+            <h2
+              className="text-center text-4xl leading-tight font-semibold text-balance text-slate-950 dark:text-slate-50 sm:text-5xl"
+              id="homepage-workflow-heading"
+            >
+              How it works
+            </h2>
+          </div>
+
+          <div className="homepage-workflow-layout">
+            <div
+              className="homepage-workflow-sticky-visual"
+              data-homepage-workflow-sticky-visual=""
+            >
+              <HomepageWorkflowComposite
+                workflowStage={homepageWorkflowStage}
+              />
             </div>
 
             <ol className="homepage-workflow-scene-list">
-              {HOMEPAGE_WORKFLOW_SCENES.map((scene, index) => (
+              {HOMEPAGE_WORKFLOW_SCENES.map((scene) => (
                 <HomepageWorkflowScene
-                  active={index === 2 || index === 4}
                   description={scene.description}
                   key={scene.step}
+                  sceneRef={(element) => {
+                    workflowStepRefs.current[scene.step] = element;
+                  }}
                   step={scene.step}
                   title={scene.title}
                 />
               ))}
             </ol>
-          </div>
-
-          <div className="grid gap-4 bg-white p-4 dark:bg-slate-900 sm:p-5 xl:grid-cols-[0.9fr_1.35fr_0.75fr]">
-            <AgentChatMock />
-            <RoughdraftPlanMock />
-            <AgentResumeMock />
           </div>
         </section>
 
@@ -407,13 +443,13 @@ export function Homepage({
 }
 
 function HomepageWorkflowScene({
-  active,
   description,
+  sceneRef,
   step,
   title,
 }: {
-  active?: boolean;
   description: string;
+  sceneRef?: (element: HTMLLIElement | null) => void;
   step: string;
   title: string;
 }) {
@@ -421,58 +457,140 @@ function HomepageWorkflowScene({
     <li
       className="homepage-workflow-scene min-w-0"
       data-homepage-workflow-scene=""
+      ref={sceneRef}
     >
-      <div
-        className={
-          active
-            ? "homepage-workflow-scene-marker homepage-workflow-scene-marker-active"
-            : "homepage-workflow-scene-marker"
-        }
-      >
-        {step}
+      <div className="homepage-workflow-scene-copy">
+        <div className="homepage-workflow-scene-marker">{step}</div>
+        <h3 className="mt-5 text-3xl leading-tight font-semibold text-balance text-slate-950 dark:text-slate-50 sm:text-4xl">
+          {title}
+        </h3>
+        <p className="mt-4 max-w-md text-base leading-7 text-slate-600 dark:text-slate-400">
+          {description}
+        </p>
       </div>
-      <h3 className="mt-3 text-sm font-semibold text-slate-950 dark:text-slate-50">
-        {title}
-      </h3>
-      <p className="mt-2 text-xs leading-5 text-slate-600 dark:text-slate-400">
-        {description}
-      </p>
     </li>
   );
 }
 
-function AgentChatMock() {
+function HomepageWorkflowComposite({
+  workflowStage,
+}: {
+  workflowStage: number;
+}) {
   return (
-    <div className="homepage-workflow-panel homepage-workflow-chat">
-      <div className="homepage-workflow-panel-header">
-        <MessageSquare className="size-3.5" aria-hidden="true" />
-        Agent chat
+    <div className="homepage-workflow-composite">
+      <AgentChatMock workflowStage={workflowStage} />
+      <RoughdraftPopupMock visible={workflowStage >= 3} />
+    </div>
+  );
+}
+
+function AgentChatMock({ workflowStage }: { workflowStage: number }) {
+  const showAgentWork = workflowStage >= 2;
+  const showRoughdraftCommand = workflowStage >= 3;
+  const showAgentResume = workflowStage >= 6;
+
+  return (
+    <div
+      className="homepage-workflow-terminal homepage-workflow-chat"
+      data-homepage-workflow-terminal-stage={workflowStage}
+    >
+      <div className="homepage-workflow-terminal-titlebar">
+        <div className="flex items-center gap-1.5" aria-hidden="true">
+          <span className="homepage-workflow-terminal-dot bg-rose-500" />
+          <span className="homepage-workflow-terminal-dot bg-amber-400" />
+          <span className="homepage-workflow-terminal-dot bg-emerald-500" />
+        </div>
+        <div className="flex min-w-0 items-center gap-2">
+          <Terminal className="size-3.5 shrink-0" aria-hidden="true" />
+          <span className="truncate">local-agent / roughdraft</span>
+        </div>
       </div>
-      <div className="space-y-3 p-4">
-        <div className="ml-auto max-w-[82%] rounded-lg bg-slate-950 px-3 py-2 text-sm leading-5 text-white dark:bg-slate-100 dark:text-slate-950">
-          Let's make the homepage more persuasive. Write a plan first.
+
+      <div className="homepage-workflow-terminal-body">
+        <div className="homepage-workflow-terminal-meta">
+          <div className="font-semibold text-slate-100">Coding agent</div>
+          <div>workspace ~/roughdraft</div>
         </div>
-        <div className="max-w-[86%] rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm leading-5 text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
-          I'll inspect the current homepage, draft a Markdown plan, and open it
-          in Roughdraft for review before I code.
+
+        <div className="homepage-workflow-terminal-user-line">
+          <span className="text-slate-400">›</span>
+          <span>
+            Let's make the homepage more persuasive. Write a plan first.
+          </span>
         </div>
-        <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-xs leading-5 text-slate-600 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-400">
-          <div className="mb-2 flex items-center gap-1.5 font-medium text-slate-700 dark:text-slate-300">
-            <Code2 className="size-3.5" aria-hidden="true" />
-            Tool calls
+
+        <div
+          aria-hidden={showAgentWork ? undefined : true}
+          className="homepage-workflow-terminal-reveal-stack"
+          data-agent-work-visible={showAgentWork ? "true" : "false"}
+        >
+          <div className="homepage-workflow-terminal-agent-line homepage-workflow-stream-item homepage-workflow-stream-item-delay-short">
+            <span className="mt-1 size-2 shrink-0 rounded-full bg-slate-100" />
+            <span>
+              I'll inspect the current homepage, draft a Markdown plan, and open
+              it in Roughdraft for review before I code.
+            </span>
           </div>
-          <div>rg "It's just Markdown" packages/app/src</div>
-          <div>sed -n '1,220p' packages/app/src/App.tsx</div>
-          <div>write .context/homepage-conversion-plan.md</div>
+
+          <div className="homepage-workflow-terminal-tools homepage-workflow-stream-item homepage-workflow-stream-item-delay-long">
+            <div className="mb-2 flex items-center gap-1.5 font-medium text-slate-200">
+              <Code2 className="size-3.5" aria-hidden="true" />
+              Tool calls
+            </div>
+            <div>rg "It's just Markdown" packages/app/src</div>
+            <div>sed -n '1,220p' packages/app/src/App.tsx</div>
+            <div>write .context/homepage-conversion-plan.md</div>
+          </div>
+        </div>
+
+        <div
+          aria-hidden={showRoughdraftCommand ? undefined : true}
+          className="homepage-workflow-terminal-command homepage-workflow-stream-item"
+          data-terminal-line-visible={showRoughdraftCommand ? "true" : "false"}
+        >
+          roughdraft open "/workspace/.context/homepage-conversion-plan.md"
+          <div className="mt-2 text-slate-400">
+            Waiting for Done Reviewing...
+          </div>
+        </div>
+
+        <div
+          aria-hidden={showAgentResume ? undefined : true}
+          className="homepage-workflow-terminal-agent-line homepage-workflow-stream-item"
+          data-terminal-line-visible={showAgentResume ? "true" : "false"}
+        >
+          <span className="mt-1 size-2 shrink-0 rounded-full bg-emerald-300" />
+          <span>
+            I read your comments. I'll move the workflow storyboard above the
+            Markdown section and use the homepage conversion example.
+          </span>
+        </div>
+
+        <div
+          aria-hidden={showAgentWork ? undefined : true}
+          className="homepage-workflow-terminal-input"
+          data-terminal-line-visible={showAgentWork ? "true" : "false"}
+        >
+          <span className="text-slate-100">›</span>
+          <span
+            className="homepage-workflow-terminal-caret"
+            aria-hidden="true"
+          />
         </div>
       </div>
     </div>
   );
 }
 
-function RoughdraftPlanMock() {
+function RoughdraftPopupMock({ visible }: { visible: boolean }) {
   return (
-    <div className="homepage-workflow-panel homepage-workflow-plan">
+    <div
+      aria-hidden={visible ? undefined : true}
+      className="homepage-workflow-panel homepage-workflow-popup"
+      data-homepage-workflow-popup=""
+      data-popup-visible={visible ? "true" : "false"}
+    >
       <div className="homepage-workflow-panel-header">
         <FileText className="size-3.5" aria-hidden="true" />
         homepage-conversion-plan.md
@@ -498,6 +616,22 @@ function RoughdraftPlanMock() {
           <div className="mt-5 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-900 dark:border-emerald-900/70 dark:bg-emerald-950/40 dark:text-emerald-200">
             Review an agent's plan before it starts coding.
           </div>
+          <div className="mt-5">
+            <div className="homepage-workflow-done-popover">
+              <Button className="h-10 gap-2 px-4 text-sm" type="button">
+                <MousePointerClick className="size-4" aria-hidden="true" />
+                Done Reviewing
+              </Button>
+              <div className="homepage-workflow-popover-card">
+                <div className="font-semibold text-slate-950 dark:text-slate-50">
+                  Review complete
+                </div>
+                <div className="mt-1 text-xs leading-5 text-slate-600 dark:text-slate-400">
+                  Your agent can read the edited Markdown file now.
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
         <div className="border-t border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-950/70 lg:border-t-0 lg:border-l">
           <div className="space-y-3">
@@ -514,39 +648,6 @@ function RoughdraftPlanMock() {
               </div>
             </div>
           </div>
-          <div className="mt-5 flex justify-end">
-            <div className="homepage-workflow-done-popover">
-              <Button className="h-9 gap-2 px-3 text-sm" type="button">
-                <MousePointerClick className="size-4" aria-hidden="true" />
-                Done Reviewing
-              </Button>
-              <div className="homepage-workflow-popover-card">
-                <div className="font-semibold text-slate-950 dark:text-slate-50">
-                  Review complete
-                </div>
-                <div className="mt-1 text-xs leading-5 text-slate-600 dark:text-slate-400">
-                  Your agent can read the edited Markdown file now.
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function AgentResumeMock() {
-  return (
-    <div className="homepage-workflow-panel homepage-workflow-resume">
-      <div className="homepage-workflow-panel-header">
-        <Sparkles className="size-3.5" aria-hidden="true" />
-        Agent resumes
-      </div>
-      <div className="p-4">
-        <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm leading-6 text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
-          I read your comments. I'll move the workflow storyboard above the
-          Markdown section and use the homepage conversion example.
         </div>
       </div>
     </div>

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -2,11 +2,14 @@ import {
   ArrowLeft,
   Braces,
   Check,
+  Code2,
   Copy,
   ExternalLink,
   FileText,
   MessageSquare,
+  MousePointerClick,
   PencilLine,
+  Sparkles,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
@@ -85,18 +88,42 @@ const PREVIEW_INITIAL_MARKDOWN = [
   '{==Select this sentence==}{>>Try replying to this comment or suggesting a replacement.<<}{id="preview-comment" by="Roughdraft" at="2026-04-28T12:00:00.000Z"}',
   "",
 ].join("\n");
-const HOMEPAGE_WORKFLOWS = [
+const HOMEPAGE_WORKFLOW_SCENES = [
   {
-    title: "Review an agent's draft",
+    step: "01",
+    title: "Ask for a plan",
     description:
-      "Ask your agent to write a Markdown file, open it in Roughdraft, then leave comments and suggested changes. When you are done, tell the agent to read the file again so it can reply inline or incorporate your feedback.",
-    icon: MessageSquare,
+      "Start in the same agent chat you already use. Ask for a reviewable Markdown plan before implementation begins.",
   },
   {
-    title: "Ask the agent to review yours",
+    step: "02",
+    title: "The agent works normally",
     description:
-      "Start from your own writing and have the agent leave detailed comments, questions, and suggested edits in the document. You can accept the useful parts, push back in replies, or send the file back for another pass.",
-    icon: PencilLine,
+      "It inspects files, runs tools, and drafts the plan in the background. Roughdraft does not replace your agent workflow.",
+  },
+  {
+    step: "03",
+    title: "Roughdraft opens the plan",
+    description:
+      "When the file is ready, the agent opens the Markdown plan in Roughdraft and waits while you review.",
+  },
+  {
+    step: "04",
+    title: "Leave comments and suggestions",
+    description:
+      "Ask questions, redirect priorities, and suggest exact wording inline where the agent can read it later.",
+  },
+  {
+    step: "05",
+    title: "Click Done Reviewing",
+    description:
+      "Roughdraft hands control back to the agent once you are finished with the blocking review step.",
+  },
+  {
+    step: "06",
+    title: "The agent resumes",
+    description:
+      "The next agent turn reads the same Markdown file, sees your comments, and continues with the corrected plan.",
   },
 ] as const;
 const ROUGHDRAFT_MARKDOWN_SYNTAX = [
@@ -331,50 +358,196 @@ export function Homepage({
           />
         </div>
 
-        <RoughdraftFormatDemo />
-
         <section
           aria-labelledby="homepage-workflow-heading"
-          className="mx-auto mt-16 w-full max-w-5xl border-t border-slate-200 dark:border-slate-700 pt-10 text-left"
+          className="homepage-workflow-storyboard mx-auto mt-12 w-full max-w-6xl text-left"
+          data-homepage-workflow-storyboard=""
         >
-          <div className="grid gap-8 lg:grid-cols-[0.85fr_1.15fr] lg:items-start">
+          <div className="grid gap-8 border-b border-slate-200 bg-[#FAFAF8] p-5 dark:border-slate-700 dark:bg-slate-950/60 sm:p-6 lg:grid-cols-[0.72fr_1.28fr] lg:p-8">
             <div>
               <p className="text-xs font-medium tracking-[0.16em] text-stone-500 dark:text-stone-400 uppercase">
-                Review workflow
+                Workflow
               </p>
               <h2
                 className="mt-3 text-3xl leading-tight font-semibold text-balance text-slate-950 dark:text-slate-50 sm:text-4xl"
                 id="homepage-workflow-heading"
               >
-                Pass the same Markdown file back and forth with your agent.
+                Review an agent's plan before it starts coding.
               </h2>
               <p className="mt-4 text-base leading-7 text-slate-600 dark:text-slate-400">
-                Roughdraft makes review state part of the document, so the next
-                agent turn can see the comments, suggestions, and replies
-                without needing access to a hosted editor.
+                Ask for a plan, mark it up in Roughdraft, click Done Reviewing,
+                and the agent continues from the edited Markdown file.
               </p>
             </div>
 
-            <div className="grid gap-3 sm:grid-cols-2">
-              {HOMEPAGE_WORKFLOWS.map(({ description, icon: Icon, title }) => (
-                <div
-                  className="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-5 shadow-[0_10px_30px_rgba(15,23,42,0.05)] dark:shadow-[0_10px_30px_rgba(0,0,0,0.3)]"
-                  key={title}
-                >
-                  <div className="flex size-10 items-center justify-center rounded-md border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 text-slate-700 dark:text-slate-300">
-                    <Icon className="size-4" aria-hidden="true" />
-                  </div>
-                  <h3 className="mt-4 text-base font-semibold text-slate-950 dark:text-slate-50">
-                    {title}
-                  </h3>
-                  <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-400">
-                    {description}
-                  </p>
-                </div>
+            <ol className="homepage-workflow-scene-list">
+              {HOMEPAGE_WORKFLOW_SCENES.map((scene, index) => (
+                <HomepageWorkflowScene
+                  active={index === 2 || index === 4}
+                  description={scene.description}
+                  key={scene.step}
+                  step={scene.step}
+                  title={scene.title}
+                />
               ))}
-            </div>
+            </ol>
+          </div>
+
+          <div className="grid gap-4 bg-white p-4 dark:bg-slate-900 sm:p-5 xl:grid-cols-[0.9fr_1.35fr_0.75fr]">
+            <AgentChatMock />
+            <RoughdraftPlanMock />
+            <AgentResumeMock />
           </div>
         </section>
+
+        <RoughdraftFormatDemo />
+      </div>
+    </div>
+  );
+}
+
+function HomepageWorkflowScene({
+  active,
+  description,
+  step,
+  title,
+}: {
+  active?: boolean;
+  description: string;
+  step: string;
+  title: string;
+}) {
+  return (
+    <li
+      className="homepage-workflow-scene min-w-0"
+      data-homepage-workflow-scene=""
+    >
+      <div
+        className={
+          active
+            ? "homepage-workflow-scene-marker homepage-workflow-scene-marker-active"
+            : "homepage-workflow-scene-marker"
+        }
+      >
+        {step}
+      </div>
+      <h3 className="mt-3 text-sm font-semibold text-slate-950 dark:text-slate-50">
+        {title}
+      </h3>
+      <p className="mt-2 text-xs leading-5 text-slate-600 dark:text-slate-400">
+        {description}
+      </p>
+    </li>
+  );
+}
+
+function AgentChatMock() {
+  return (
+    <div className="homepage-workflow-panel homepage-workflow-chat">
+      <div className="homepage-workflow-panel-header">
+        <MessageSquare className="size-3.5" aria-hidden="true" />
+        Agent chat
+      </div>
+      <div className="space-y-3 p-4">
+        <div className="ml-auto max-w-[82%] rounded-lg bg-slate-950 px-3 py-2 text-sm leading-5 text-white dark:bg-slate-100 dark:text-slate-950">
+          Let's make the homepage more persuasive. Write a plan first.
+        </div>
+        <div className="max-w-[86%] rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm leading-5 text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+          I'll inspect the current homepage, draft a Markdown plan, and open it
+          in Roughdraft for review before I code.
+        </div>
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-xs leading-5 text-slate-600 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-400">
+          <div className="mb-2 flex items-center gap-1.5 font-medium text-slate-700 dark:text-slate-300">
+            <Code2 className="size-3.5" aria-hidden="true" />
+            Tool calls
+          </div>
+          <div>rg "It's just Markdown" packages/app/src</div>
+          <div>sed -n '1,220p' packages/app/src/App.tsx</div>
+          <div>write .context/homepage-conversion-plan.md</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RoughdraftPlanMock() {
+  return (
+    <div className="homepage-workflow-panel homepage-workflow-plan">
+      <div className="homepage-workflow-panel-header">
+        <FileText className="size-3.5" aria-hidden="true" />
+        homepage-conversion-plan.md
+      </div>
+      <div className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_15rem]">
+        <div className="min-w-0 p-5">
+          <p className="text-xs font-medium tracking-[0.14em] text-stone-500 uppercase">
+            Roughdraft
+          </p>
+          <h3 className="mt-2 text-xl font-semibold text-slate-950 dark:text-slate-50">
+            Homepage Conversion Plan
+          </h3>
+          <ul className="mt-4 space-y-2 text-sm leading-6 text-slate-700 dark:text-slate-300">
+            <li>Move the workflow story above "It's just Markdown."</li>
+            <li>
+              Show the agent pause, the review window, and the resume signal.
+            </li>
+            <li>
+              Keep the format section as proof that the review data is portable
+              Markdown.
+            </li>
+          </ul>
+          <div className="mt-5 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-900 dark:border-emerald-900/70 dark:bg-emerald-950/40 dark:text-emerald-200">
+            Review an agent's plan before it starts coding.
+          </div>
+        </div>
+        <div className="border-t border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-950/70 lg:border-t-0 lg:border-l">
+          <div className="space-y-3">
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs leading-5 text-amber-950 dark:border-amber-900/70 dark:bg-amber-950/40 dark:text-amber-100">
+              This should go above "It's just Markdown."
+            </div>
+            <div className="rounded-md border border-slate-200 bg-white p-3 text-xs leading-5 text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+              Can we make the example about homepage conversion?
+            </div>
+            <div className="rounded-md border border-emerald-200 bg-white p-3 text-xs leading-5 text-emerald-900 dark:border-emerald-900/70 dark:bg-slate-900 dark:text-emerald-200">
+              Suggested change
+              <div className="mt-1 font-medium">
+                Review an agent's plan before it starts coding.
+              </div>
+            </div>
+          </div>
+          <div className="mt-5 flex justify-end">
+            <div className="homepage-workflow-done-popover">
+              <Button className="h-9 gap-2 px-3 text-sm" type="button">
+                <MousePointerClick className="size-4" aria-hidden="true" />
+                Done Reviewing
+              </Button>
+              <div className="homepage-workflow-popover-card">
+                <div className="font-semibold text-slate-950 dark:text-slate-50">
+                  Review complete
+                </div>
+                <div className="mt-1 text-xs leading-5 text-slate-600 dark:text-slate-400">
+                  Your agent can read the edited Markdown file now.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AgentResumeMock() {
+  return (
+    <div className="homepage-workflow-panel homepage-workflow-resume">
+      <div className="homepage-workflow-panel-header">
+        <Sparkles className="size-3.5" aria-hidden="true" />
+        Agent resumes
+      </div>
+      <div className="p-4">
+        <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm leading-6 text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+          I read your comments. I'll move the workflow storyboard above the
+          Markdown section and use the homepage conversion example.
+        </div>
       </div>
     </div>
   );

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -3,11 +3,12 @@ import {
   Braces,
   Check,
   Code2,
+  CodeXml,
   Copy,
+  Eye,
   ExternalLink,
   FileText,
   MessageSquare,
-  MousePointerClick,
   PencilLine,
   Terminal,
 } from "lucide-react";
@@ -115,7 +116,7 @@ const HOMEPAGE_WORKFLOW_SCENES = [
   },
   {
     step: "05",
-    title: "Click Done Reviewing",
+    title: "Click I'm done",
     description:
       "Roughdraft hands control back to the agent once you are finished with the blocking review step.",
   },
@@ -400,11 +401,13 @@ export function Homepage({
           aria-labelledby="homepage-workflow-heading"
           className="homepage-workflow-storyboard mx-auto mt-12 w-full max-w-6xl text-left"
           data-homepage-workflow-storyboard=""
+          data-testid="homepage-workflow-storyboard"
         >
           <div className="homepage-workflow-intro">
             <h2
               className="text-center text-4xl leading-tight font-semibold text-balance text-slate-950 dark:text-slate-50 sm:text-5xl"
               id="homepage-workflow-heading"
+              data-testid="homepage-workflow-heading"
             >
               How it works
             </h2>
@@ -414,13 +417,17 @@ export function Homepage({
             <div
               className="homepage-workflow-sticky-visual"
               data-homepage-workflow-sticky-visual=""
+              data-testid="homepage-workflow-sticky-visual"
             >
               <HomepageWorkflowComposite
                 workflowStage={homepageWorkflowStage}
               />
             </div>
 
-            <ol className="homepage-workflow-scene-list">
+            <ol
+              className="homepage-workflow-scene-list"
+              data-testid="homepage-workflow-scene-list"
+            >
               {HOMEPAGE_WORKFLOW_SCENES.map((scene) => (
                 <HomepageWorkflowScene
                   description={scene.description}
@@ -457,6 +464,7 @@ function HomepageWorkflowScene({
     <li
       className="homepage-workflow-scene min-w-0"
       data-homepage-workflow-scene=""
+      data-testid="homepage-workflow-scene"
       ref={sceneRef}
     >
       <div className="homepage-workflow-scene-copy">
@@ -480,7 +488,7 @@ function HomepageWorkflowComposite({
   return (
     <div className="homepage-workflow-composite">
       <AgentChatMock workflowStage={workflowStage} />
-      <RoughdraftPopupMock visible={workflowStage >= 3} />
+      <RoughdraftPopupMock workflowStage={workflowStage} />
     </div>
   );
 }
@@ -494,6 +502,7 @@ function AgentChatMock({ workflowStage }: { workflowStage: number }) {
     <div
       className="homepage-workflow-terminal homepage-workflow-chat"
       data-homepage-workflow-terminal-stage={workflowStage}
+      data-testid="homepage-workflow-terminal"
     >
       <div className="homepage-workflow-terminal-titlebar">
         <div className="flex items-center gap-1.5" aria-hidden="true">
@@ -524,6 +533,7 @@ function AgentChatMock({ workflowStage }: { workflowStage: number }) {
           aria-hidden={showAgentWork ? undefined : true}
           className="homepage-workflow-terminal-reveal-stack"
           data-agent-work-visible={showAgentWork ? "true" : "false"}
+          data-testid="homepage-workflow-agent-work"
         >
           <div className="homepage-workflow-terminal-agent-line homepage-workflow-stream-item homepage-workflow-stream-item-delay-short">
             <span className="mt-1 size-2 shrink-0 rounded-full bg-slate-100" />
@@ -533,7 +543,10 @@ function AgentChatMock({ workflowStage }: { workflowStage: number }) {
             </span>
           </div>
 
-          <div className="homepage-workflow-terminal-tools homepage-workflow-stream-item homepage-workflow-stream-item-delay-long">
+          <div
+            className="homepage-workflow-terminal-tools homepage-workflow-stream-item homepage-workflow-stream-item-delay-long"
+            data-testid="homepage-workflow-terminal-tools"
+          >
             <div className="mb-2 flex items-center gap-1.5 font-medium text-slate-200">
               <Code2 className="size-3.5" aria-hidden="true" />
               Tool calls
@@ -548,17 +561,17 @@ function AgentChatMock({ workflowStage }: { workflowStage: number }) {
           aria-hidden={showRoughdraftCommand ? undefined : true}
           className="homepage-workflow-terminal-command homepage-workflow-stream-item"
           data-terminal-line-visible={showRoughdraftCommand ? "true" : "false"}
+          data-testid="homepage-workflow-terminal-command"
         >
           roughdraft open "/workspace/.context/homepage-conversion-plan.md"
-          <div className="mt-2 text-slate-400">
-            Waiting for Done Reviewing...
-          </div>
+          <div className="mt-2 text-slate-400">Waiting for I'm done...</div>
         </div>
 
         <div
           aria-hidden={showAgentResume ? undefined : true}
           className="homepage-workflow-terminal-agent-line homepage-workflow-stream-item"
           data-terminal-line-visible={showAgentResume ? "true" : "false"}
+          data-testid="homepage-workflow-agent-resume"
         >
           <span className="mt-1 size-2 shrink-0 rounded-full bg-emerald-300" />
           <span>
@@ -571,6 +584,7 @@ function AgentChatMock({ workflowStage }: { workflowStage: number }) {
           aria-hidden={showAgentWork ? undefined : true}
           className="homepage-workflow-terminal-input"
           data-terminal-line-visible={showAgentWork ? "true" : "false"}
+          data-testid="homepage-workflow-terminal-input"
         >
           <span className="text-slate-100">›</span>
           <span
@@ -583,71 +597,148 @@ function AgentChatMock({ workflowStage }: { workflowStage: number }) {
   );
 }
 
-function RoughdraftPopupMock({ visible }: { visible: boolean }) {
+function RoughdraftPopupMock({ workflowStage }: { workflowStage: number }) {
+  const visible = workflowStage >= 3;
+  const showReviewMarkup = workflowStage >= 4;
+  const showDoneButton = workflowStage >= 5;
+
   return (
     <div
       aria-hidden={visible ? undefined : true}
       className="homepage-workflow-panel homepage-workflow-popup"
       data-homepage-workflow-popup=""
       data-popup-visible={visible ? "true" : "false"}
+      data-testid="homepage-workflow-popup"
     >
       <div className="homepage-workflow-panel-header">
         <FileText className="size-3.5" aria-hidden="true" />
         homepage-conversion-plan.md
       </div>
-      <div className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_15rem]">
-        <div className="min-w-0 p-5">
-          <p className="text-xs font-medium tracking-[0.14em] text-stone-500 uppercase">
-            Roughdraft
-          </p>
-          <h3 className="mt-2 text-xl font-semibold text-slate-950 dark:text-slate-50">
-            Homepage Conversion Plan
-          </h3>
-          <ul className="mt-4 space-y-2 text-sm leading-6 text-slate-700 dark:text-slate-300">
-            <li>Move the workflow story above "It's just Markdown."</li>
-            <li>
-              Show the agent pause, the review window, and the resume signal.
-            </li>
-            <li>
-              Keep the format section as proof that the review data is portable
-              Markdown.
-            </li>
-          </ul>
-          <div className="mt-5 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-900 dark:border-emerald-900/70 dark:bg-emerald-950/40 dark:text-emerald-200">
-            Review an agent's plan before it starts coding.
+      <div
+        className="homepage-workflow-document-workspace"
+        data-homepage-workflow-review-visible={
+          showReviewMarkup ? "true" : "false"
+        }
+        data-testid="homepage-workflow-document-workspace"
+      >
+        {showDoneButton ? (
+          <Button
+            className="homepage-workflow-handoff-button"
+            data-testid="homepage-workflow-handoff-button"
+            type="button"
+            size="sm"
+          >
+            <Check className="size-4" aria-hidden="true" />
+            I'm done
+          </Button>
+        ) : null}
+        <div
+          className={`homepage-workflow-document-shell ${
+            showReviewMarkup
+              ? "homepage-workflow-document-shell-with-comments"
+              : "homepage-workflow-document-shell-no-comments"
+          }`}
+          data-testid={
+            showReviewMarkup
+              ? "homepage-workflow-document-shell-with-comments"
+              : "homepage-workflow-document-shell-no-comments"
+          }
+        >
+          <div className="homepage-workflow-document-main">
+            <div className="homepage-workflow-document-toolbar">
+              <button
+                aria-label="Switch editor view"
+                className="homepage-workflow-view-toggle"
+                type="button"
+              >
+                <span className="homepage-workflow-view-toggle-active">
+                  <Eye className="size-3" aria-hidden="true" />
+                </span>
+                <span>
+                  <CodeXml className="size-3" aria-hidden="true" />
+                </span>
+              </button>
+              <span className="homepage-workflow-document-filename">
+                homepage-conversion-plan.md
+              </span>
+              <span className="homepage-workflow-document-mode">
+                <PencilLine className="size-3" aria-hidden="true" />
+                editing
+              </span>
+            </div>
+            <div className="homepage-workflow-document-page">
+              <p className="homepage-workflow-doc-kicker">Roughdraft</p>
+              <h3 data-testid="homepage-workflow-document-title">
+                Homepage Conversion Plan
+              </h3>
+              <p>
+                Move the workflow story above{" "}
+                {showReviewMarkup ? (
+                  <span
+                    className="homepage-workflow-comment-highlight"
+                    data-testid="homepage-workflow-comment-highlight"
+                  >
+                    "It's just Markdown."
+                  </span>
+                ) : (
+                  '"It\'s just Markdown."'
+                )}
+              </p>
+              <p>
+                Show the agent pause, the review window, and the resume signal.
+              </p>
+              <p>
+                Keep the format section as proof that the review data is
+                portable Markdown.
+              </p>
+              {showReviewMarkup ? (
+                <p>
+                  <span
+                    className="homepage-workflow-suggestion-old"
+                    data-testid="homepage-workflow-suggestion-old"
+                  >
+                    Review an agent's plan
+                  </span>{" "}
+                  <span
+                    className="homepage-workflow-suggestion-new"
+                    data-testid="homepage-workflow-suggestion-new"
+                  >
+                    Review a homepage plan
+                  </span>{" "}
+                  before it starts coding.
+                </p>
+              ) : (
+                <p>Review an agent's plan before it starts coding.</p>
+              )}
+            </div>
           </div>
-          <div className="mt-5">
-            <div className="homepage-workflow-done-popover">
-              <Button className="h-10 gap-2 px-4 text-sm" type="button">
-                <MousePointerClick className="size-4" aria-hidden="true" />
-                Done Reviewing
-              </Button>
-              <div className="homepage-workflow-popover-card">
-                <div className="font-semibold text-slate-950 dark:text-slate-50">
-                  Review complete
+          {showReviewMarkup ? (
+            <div
+              className="homepage-workflow-review-rail"
+              data-testid="homepage-workflow-review-rail"
+            >
+              <div className="homepage-workflow-review-thread">
+                <div className="homepage-workflow-review-avatar">N</div>
+                <div>
+                  <div className="homepage-workflow-review-author">Nora</div>
+                  <p data-testid="homepage-workflow-review-comment">
+                    This should go above "It's just Markdown."
+                  </p>
                 </div>
-                <div className="mt-1 text-xs leading-5 text-slate-600 dark:text-slate-400">
-                  Your agent can read the edited Markdown file now.
+              </div>
+              <div className="homepage-workflow-review-thread homepage-workflow-review-thread-ai">
+                <div className="homepage-workflow-review-avatar">AI</div>
+                <div>
+                  <div className="homepage-workflow-review-author">AI</div>
+                  <p>Replace: "agent's plan" with "homepage plan"</p>
+                  <div className="homepage-workflow-review-actions">
+                    <Check className="size-3.5" aria-hidden="true" />
+                    <span aria-hidden="true">×</span>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        </div>
-        <div className="border-t border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-950/70 lg:border-t-0 lg:border-l">
-          <div className="space-y-3">
-            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs leading-5 text-amber-950 dark:border-amber-900/70 dark:bg-amber-950/40 dark:text-amber-100">
-              This should go above "It's just Markdown."
-            </div>
-            <div className="rounded-md border border-slate-200 bg-white p-3 text-xs leading-5 text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
-              Can we make the example about homepage conversion?
-            </div>
-            <div className="rounded-md border border-emerald-200 bg-white p-3 text-xs leading-5 text-emerald-900 dark:border-emerald-900/70 dark:bg-slate-900 dark:text-emerald-200">
-              Suggested change
-              <div className="mt-1 font-medium">
-                Review an agent's plan before it starts coding.
-              </div>
-            </div>
-          </div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -516,10 +516,13 @@ function RoughdraftPlanMock() {
           </div>
           <div className="mt-5 flex justify-end">
             <div className="homepage-workflow-done-popover">
-              <Button className="h-9 gap-2 px-3 text-sm" type="button">
+              <div
+                className="homepage-workflow-done-reviewing"
+                data-homepage-workflow-done-reviewing=""
+              >
                 <MousePointerClick className="size-4" aria-hidden="true" />
                 Done Reviewing
-              </Button>
+              </div>
               <div className="homepage-workflow-popover-card">
                 <div className="font-semibold text-slate-950 dark:text-slate-50">
                   Review complete

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -516,13 +516,10 @@ function RoughdraftPlanMock() {
           </div>
           <div className="mt-5 flex justify-end">
             <div className="homepage-workflow-done-popover">
-              <div
-                className="homepage-workflow-done-reviewing"
-                data-homepage-workflow-done-reviewing=""
-              >
+              <Button className="h-9 gap-2 px-3 text-sm" type="button">
                 <MousePointerClick className="size-4" aria-hidden="true" />
                 Done Reviewing
-              </div>
+              </Button>
               <div className="homepage-workflow-popover-card">
                 <div className="font-semibold text-slate-950 dark:text-slate-50">
                   Review complete

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -231,6 +231,7 @@ export function Homepage({
     "idle",
   );
   const workflowStepRefs = useRef<Record<string, HTMLLIElement | null>>({});
+  const workflowStickyVisualRef = useRef<HTMLDivElement | null>(null);
   const [homepageWorkflowStage, setHomepageWorkflowStage] = useState(1);
 
   const handleCopySetupPrompt = useCallback(async () => {
@@ -249,13 +250,26 @@ export function Homepage({
         document.documentElement.scrollHeight > window.innerHeight + 1;
       if (!pageCanScroll) return;
 
+      const stickyVisualRect =
+        workflowStickyVisualRef.current?.getBoundingClientRect();
+      const isMobileStoryboard =
+        typeof window.matchMedia === "function" &&
+        window.matchMedia("(max-width: 899px)").matches;
+      const mobileReadableOffset = stickyVisualRect
+        ? Math.min(stickyVisualRect.height + 32, window.innerHeight * 0.35)
+        : 0;
+      const activationLine =
+        isMobileStoryboard && stickyVisualRect
+          ? Math.max(0, Math.ceil(stickyVisualRect.top - mobileReadableOffset))
+          : 0;
+
       let nextStage = 1;
       for (const [step, element] of Object.entries(workflowStepRefs.current)) {
         if (!element) continue;
 
         const stepNumber = Number(step);
         if (
-          element.getBoundingClientRect().top <= 0 &&
+          element.getBoundingClientRect().top <= activationLine &&
           stepNumber > nextStage
         ) {
           nextStage = stepNumber;
@@ -418,6 +432,7 @@ export function Homepage({
               className="homepage-workflow-sticky-visual"
               data-homepage-workflow-sticky-visual=""
               data-testid="homepage-workflow-sticky-visual"
+              ref={workflowStickyVisualRef}
             >
               <HomepageWorkflowComposite
                 workflowStage={homepageWorkflowStage}
@@ -621,124 +636,130 @@ function RoughdraftPopupMock({ workflowStage }: { workflowStage: number }) {
         }
         data-testid="homepage-workflow-document-workspace"
       >
-        {showDoneButton ? (
-          <Button
-            className="homepage-workflow-handoff-button"
-            data-testid="homepage-workflow-handoff-button"
-            type="button"
-            size="sm"
-          >
-            <Check className="size-4" aria-hidden="true" />
-            I'm done
-          </Button>
-        ) : null}
         <div
-          className={`homepage-workflow-document-shell ${
-            showReviewMarkup
-              ? "homepage-workflow-document-shell-with-comments"
-              : "homepage-workflow-document-shell-no-comments"
-          }`}
-          data-testid={
-            showReviewMarkup
-              ? "homepage-workflow-document-shell-with-comments"
-              : "homepage-workflow-document-shell-no-comments"
-          }
+          className="homepage-workflow-document-scale"
+          data-testid="homepage-workflow-document-scale"
         >
-          <div className="homepage-workflow-document-main">
-            <div className="homepage-workflow-document-toolbar">
-              <button
-                aria-label="Switch editor view"
-                className="homepage-workflow-view-toggle"
-                type="button"
-              >
-                <span className="homepage-workflow-view-toggle-active">
-                  <Eye className="size-3" aria-hidden="true" />
-                </span>
-                <span>
-                  <CodeXml className="size-3" aria-hidden="true" />
-                </span>
-              </button>
-              <span className="homepage-workflow-document-filename">
-                homepage-conversion-plan.md
-              </span>
-              <span className="homepage-workflow-document-mode">
-                <PencilLine className="size-3" aria-hidden="true" />
-                editing
-              </span>
-            </div>
-            <div className="homepage-workflow-document-page">
-              <p className="homepage-workflow-doc-kicker">Roughdraft</p>
-              <h3 data-testid="homepage-workflow-document-title">
-                Homepage Conversion Plan
-              </h3>
-              <p>
-                Move the workflow story above{" "}
-                {showReviewMarkup ? (
-                  <span
-                    className="homepage-workflow-comment-highlight"
-                    data-testid="homepage-workflow-comment-highlight"
-                  >
-                    "It's just Markdown."
-                  </span>
-                ) : (
-                  '"It\'s just Markdown."'
-                )}
-              </p>
-              <p>
-                Show the agent pause, the review window, and the resume signal.
-              </p>
-              <p>
-                Keep the format section as proof that the review data is
-                portable Markdown.
-              </p>
-              {showReviewMarkup ? (
-                <p>
-                  <span
-                    className="homepage-workflow-suggestion-old"
-                    data-testid="homepage-workflow-suggestion-old"
-                  >
-                    Review an agent's plan
-                  </span>{" "}
-                  <span
-                    className="homepage-workflow-suggestion-new"
-                    data-testid="homepage-workflow-suggestion-new"
-                  >
-                    Review a homepage plan
-                  </span>{" "}
-                  before it starts coding.
-                </p>
-              ) : (
-                <p>Review an agent's plan before it starts coding.</p>
-              )}
-            </div>
-          </div>
-          {showReviewMarkup ? (
-            <div
-              className="homepage-workflow-review-rail"
-              data-testid="homepage-workflow-review-rail"
+          {showDoneButton ? (
+            <Button
+              className="homepage-workflow-handoff-button"
+              data-testid="homepage-workflow-handoff-button"
+              type="button"
+              size="sm"
             >
-              <div className="homepage-workflow-review-thread">
-                <div className="homepage-workflow-review-avatar">N</div>
-                <div>
-                  <div className="homepage-workflow-review-author">Nora</div>
-                  <p data-testid="homepage-workflow-review-comment">
-                    This should go above "It's just Markdown."
-                  </p>
-                </div>
+              <Check className="size-4" aria-hidden="true" />
+              I'm done
+            </Button>
+          ) : null}
+          <div
+            className={`homepage-workflow-document-shell ${
+              showReviewMarkup
+                ? "homepage-workflow-document-shell-with-comments"
+                : "homepage-workflow-document-shell-no-comments"
+            }`}
+            data-testid={
+              showReviewMarkup
+                ? "homepage-workflow-document-shell-with-comments"
+                : "homepage-workflow-document-shell-no-comments"
+            }
+          >
+            <div className="homepage-workflow-document-main">
+              <div className="homepage-workflow-document-toolbar">
+                <button
+                  aria-label="Switch editor view"
+                  className="homepage-workflow-view-toggle"
+                  type="button"
+                >
+                  <span className="homepage-workflow-view-toggle-active">
+                    <Eye className="size-3" aria-hidden="true" />
+                  </span>
+                  <span>
+                    <CodeXml className="size-3" aria-hidden="true" />
+                  </span>
+                </button>
+                <span className="homepage-workflow-document-filename">
+                  homepage-conversion-plan.md
+                </span>
+                <span className="homepage-workflow-document-mode">
+                  <PencilLine className="size-3" aria-hidden="true" />
+                  editing
+                </span>
               </div>
-              <div className="homepage-workflow-review-thread homepage-workflow-review-thread-ai">
-                <div className="homepage-workflow-review-avatar">AI</div>
-                <div>
-                  <div className="homepage-workflow-review-author">AI</div>
-                  <p>Replace: "agent's plan" with "homepage plan"</p>
-                  <div className="homepage-workflow-review-actions">
-                    <Check className="size-3.5" aria-hidden="true" />
-                    <span aria-hidden="true">×</span>
+              <div className="homepage-workflow-document-page">
+                <p className="homepage-workflow-doc-kicker">Roughdraft</p>
+                <h3 data-testid="homepage-workflow-document-title">
+                  Homepage Conversion Plan
+                </h3>
+                <p>
+                  Move the workflow story above{" "}
+                  {showReviewMarkup ? (
+                    <span
+                      className="homepage-workflow-comment-highlight"
+                      data-testid="homepage-workflow-comment-highlight"
+                    >
+                      "It's just Markdown."
+                    </span>
+                  ) : (
+                    '"It\'s just Markdown."'
+                  )}
+                </p>
+                <p>
+                  Show the agent pause, the review window, and the resume
+                  signal.
+                </p>
+                <p>
+                  Keep the format section as proof that the review data is
+                  portable Markdown.
+                </p>
+                {showReviewMarkup ? (
+                  <p>
+                    <span
+                      className="homepage-workflow-suggestion-old"
+                      data-testid="homepage-workflow-suggestion-old"
+                    >
+                      Review an agent's plan
+                    </span>{" "}
+                    <span
+                      className="homepage-workflow-suggestion-new"
+                      data-testid="homepage-workflow-suggestion-new"
+                    >
+                      Review a homepage plan
+                    </span>{" "}
+                    before it starts coding.
+                  </p>
+                ) : (
+                  <p>Review an agent's plan before it starts coding.</p>
+                )}
+              </div>
+            </div>
+            {showReviewMarkup ? (
+              <div
+                className="homepage-workflow-review-rail"
+                data-testid="homepage-workflow-review-rail"
+              >
+                <div className="homepage-workflow-review-thread">
+                  <div className="homepage-workflow-review-avatar">N</div>
+                  <div>
+                    <div className="homepage-workflow-review-author">Nora</div>
+                    <p data-testid="homepage-workflow-review-comment">
+                      This should go above "It's just Markdown."
+                    </p>
+                  </div>
+                </div>
+                <div className="homepage-workflow-review-thread homepage-workflow-review-thread-ai">
+                  <div className="homepage-workflow-review-avatar">AI</div>
+                  <div>
+                    <div className="homepage-workflow-review-author">AI</div>
+                    <p>Replace: "agent's plan" with "homepage plan"</p>
+                    <div className="homepage-workflow-review-actions">
+                      <Check className="size-3.5" aria-hidden="true" />
+                      <span aria-hidden="true">×</span>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-          ) : null}
+            ) : null}
+          </div>
         </div>
       </div>
     </div>

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -571,23 +571,31 @@
   }
 
   .homepage-workflow-storyboard {
-    overflow: hidden;
-    border: 1px solid rgb(226 232 240);
-    border-radius: 0.5rem;
-    background-color: #fff;
-    box-shadow: 0 24px 70px rgb(15 23 42 / 10%);
+    overflow: visible;
   }
 
   .dark .homepage-workflow-storyboard {
-    border-color: rgb(51 65 85);
-    background-color: rgb(15 23 42);
-    box-shadow: 0 24px 70px rgb(0 0 0 / 35%);
+    color: rgb(248 250 252);
+  }
+
+  .homepage-workflow-intro {
+    padding: 2rem 0 1.5rem;
+  }
+
+  .homepage-workflow-layout {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  .homepage-workflow-sticky-visual {
+    min-width: 0;
   }
 
   .homepage-workflow-scene-list {
     display: grid;
     grid-template-columns: 1fr;
-    gap: 0.75rem;
+    gap: 0;
     list-style: none;
     margin: 0;
     padding: 0;
@@ -595,43 +603,39 @@
 
   .homepage-workflow-scene {
     position: relative;
-    border: 1px solid rgb(226 232 240);
-    border-radius: 0.5rem;
-    background-color: rgb(255 255 255 / 82%);
-    padding: 0.875rem;
+    min-height: 18rem;
+    border-top: 1px solid rgb(226 232 240);
+    padding: clamp(1.75rem, 7vw, 4.5rem) 0;
   }
 
   .dark .homepage-workflow-scene {
     border-color: rgb(51 65 85);
-    background-color: rgb(15 23 42 / 72%);
+  }
+
+  .homepage-workflow-scene:first-child {
+    border-top: 0;
+  }
+
+  .homepage-workflow-scene-copy {
+    min-width: 0;
   }
 
   .homepage-workflow-scene-marker {
     display: inline-flex;
-    height: 1.75rem;
-    min-width: 1.75rem;
+    height: 2.25rem;
+    min-width: 2.25rem;
     align-items: center;
     justify-content: center;
     border-radius: 999px;
-    border: 1px solid rgb(203 213 225);
-    color: rgb(100 116 139);
-    font-size: 0.6875rem;
+    border: 1px solid rgb(15 23 42);
+    background-color: rgb(15 23 42);
+    color: white;
+    font-size: 0.8125rem;
     font-weight: 700;
     line-height: 1;
   }
 
-  .homepage-workflow-scene-marker-active {
-    border-color: rgb(15 23 42);
-    background-color: rgb(15 23 42);
-    color: white;
-  }
-
   .dark .homepage-workflow-scene-marker {
-    border-color: rgb(71 85 105);
-    color: rgb(148 163 184);
-  }
-
-  .dark .homepage-workflow-scene-marker-active {
     border-color: rgb(241 245 249);
     background-color: rgb(241 245 249);
     color: rgb(15 23 42);
@@ -639,15 +643,230 @@
 
   .homepage-workflow-panel {
     min-width: 0;
+    width: 100%;
     overflow: hidden;
     border: 1px solid rgb(226 232 240);
     border-radius: 0.5rem;
     background-color: rgb(248 250 252);
+    box-shadow: 0 18px 44px rgb(15 23 42 / 8%);
   }
 
   .dark .homepage-workflow-panel {
     border-color: rgb(51 65 85);
     background-color: rgb(2 6 23);
+    box-shadow: 0 18px 44px rgb(0 0 0 / 28%);
+  }
+
+  .homepage-workflow-composite {
+    position: relative;
+    min-height: 38rem;
+    width: min(100%, 43rem);
+  }
+
+  .homepage-workflow-terminal {
+    width: 100%;
+    overflow: hidden;
+    border: 1px solid rgb(15 23 42 / 72%);
+    border-radius: 0.5rem;
+    background-color: rgb(31 35 43);
+    box-shadow: 0 20px 48px rgb(15 23 42 / 16%);
+    color: rgb(248 250 252);
+    font-family:
+      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+      "Courier New", monospace;
+  }
+
+  .homepage-workflow-terminal-titlebar {
+    display: flex;
+    min-height: 2.5rem;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgb(148 163 184 / 20%);
+    padding: 0 0.875rem;
+    color: rgb(203 213 225);
+    font-size: 0.75rem;
+    font-weight: 700;
+  }
+
+  .homepage-workflow-terminal-dot {
+    display: inline-flex;
+    height: 0.65rem;
+    width: 0.65rem;
+    border-radius: 999px;
+  }
+
+  .homepage-workflow-terminal-body {
+    display: grid;
+    gap: 1rem;
+    padding: 1rem 0 7.5rem;
+    font-size: 0.875rem;
+    line-height: 1.55;
+  }
+
+  .homepage-workflow-terminal-meta {
+    display: grid;
+    gap: 0.125rem;
+    padding: 0 1rem;
+    color: rgb(156 163 175);
+  }
+
+  .homepage-workflow-terminal-user-line {
+    display: flex;
+    gap: 0.75rem;
+    background-color: rgb(63 63 70 / 76%);
+    padding: 0.45rem 1rem;
+    color: rgb(248 250 252);
+  }
+
+  .homepage-workflow-terminal-agent-line {
+    display: flex;
+    gap: 0.75rem;
+    padding: 0 1rem;
+    color: rgb(248 250 252);
+  }
+
+  .homepage-workflow-terminal-reveal-stack {
+    display: grid;
+    gap: 1rem;
+    max-height: 20rem;
+    overflow: hidden;
+    opacity: 1;
+    transform: translateY(0);
+    transition:
+      max-height 420ms ease,
+      opacity 240ms ease,
+      transform 300ms ease;
+  }
+
+  .homepage-workflow-terminal-reveal-stack[data-agent-work-visible="false"] {
+    max-height: 0;
+    pointer-events: none;
+    opacity: 0;
+    transform: translateY(-0.35rem);
+  }
+
+  .homepage-workflow-terminal-reveal-stack[data-agent-work-visible="true"]
+    .homepage-workflow-stream-item {
+    animation: homepage-workflow-stream-in 560ms ease both;
+  }
+
+  .homepage-workflow-stream-item-delay-short {
+    animation-delay: 40ms;
+  }
+
+  .homepage-workflow-stream-item-delay-long {
+    animation-delay: 260ms;
+  }
+
+  .homepage-workflow-terminal-tools,
+  .homepage-workflow-terminal-command {
+    margin: 0 1rem;
+    border: 1px solid rgb(148 163 184 / 20%);
+    border-radius: 0.5rem;
+    background-color: rgb(15 23 42 / 32%);
+    padding: 0.75rem;
+    color: rgb(203 213 225);
+    font-size: 0.75rem;
+    line-height: 1.55;
+  }
+
+  .homepage-workflow-terminal-command {
+    color: rgb(248 250 252);
+  }
+
+  .homepage-workflow-terminal-command,
+  .homepage-workflow-terminal-agent-line[data-terminal-line-visible],
+  .homepage-workflow-terminal-input {
+    max-height: 8rem;
+    overflow: hidden;
+    opacity: 1;
+    transform: translateY(0);
+    transition:
+      max-height 360ms ease,
+      margin 360ms ease,
+      padding 360ms ease,
+      border-width 360ms ease,
+      opacity 220ms ease,
+      transform 260ms ease;
+  }
+
+  .homepage-workflow-terminal-command[data-terminal-line-visible="false"],
+  .homepage-workflow-terminal-agent-line[data-terminal-line-visible="false"],
+  .homepage-workflow-terminal-input[data-terminal-line-visible="false"] {
+    min-height: 0;
+    max-height: 0;
+    margin-block: -1rem 0;
+    border-width: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    pointer-events: none;
+    opacity: 0;
+    transform: translateY(-0.35rem);
+  }
+
+  .homepage-workflow-terminal-command[data-terminal-line-visible="true"],
+  .homepage-workflow-terminal-agent-line[data-terminal-line-visible="true"] {
+    animation: homepage-workflow-stream-in 560ms ease both;
+  }
+
+  .homepage-workflow-terminal-input {
+    display: flex;
+    min-height: 2.65rem;
+    align-items: center;
+    gap: 0.75rem;
+    border-top: 1px solid rgb(203 213 225 / 60%);
+    border-bottom: 1px solid rgb(203 213 225 / 60%);
+    padding: 0 1rem;
+    color: rgb(248 250 252);
+  }
+
+  .homepage-workflow-terminal-caret {
+    display: inline-flex;
+    height: 1.25rem;
+    width: 0.65rem;
+    background-color: rgb(248 250 252);
+  }
+
+  @keyframes homepage-workflow-stream-in {
+    0% {
+      clip-path: inset(0 100% 0 0);
+      opacity: 0;
+      transform: translateY(0.2rem);
+    }
+
+    55% {
+      opacity: 1;
+    }
+
+    100% {
+      clip-path: inset(0 0 0 0);
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .homepage-workflow-popup {
+    position: absolute;
+    right: 0;
+    bottom: 1rem;
+    left: clamp(1rem, 8vw, 4.5rem);
+    z-index: 2;
+    width: auto;
+    transition:
+      opacity 220ms ease,
+      transform 220ms ease;
+  }
+
+  .homepage-workflow-popup[data-popup-visible="false"] {
+    pointer-events: none;
+    opacity: 0;
+    transform: translateY(0.75rem) scale(0.98);
+  }
+
+  .homepage-workflow-popup[data-popup-visible="true"] {
+    opacity: 1;
+    transform: translateY(0) scale(1);
   }
 
   .homepage-workflow-panel-header {
@@ -671,12 +890,13 @@
     position: relative;
     display: inline-flex;
     flex-direction: column;
-    align-items: flex-end;
+    align-items: flex-start;
     gap: 0.5rem;
   }
 
   .homepage-workflow-popover-card {
-    width: min(13rem, calc(100vw - 3rem));
+    width: min(13rem, 100%);
+    max-width: calc(100vw - 3rem);
     border: 1px solid rgb(226 232 240);
     border-radius: 0.5rem;
     background-color: white;
@@ -690,30 +910,59 @@
     box-shadow: 0 14px 34px rgb(0 0 0 / 36%);
   }
 
-  @media (min-width: 720px) {
+  @media (min-width: 900px) {
+    .homepage-workflow-intro {
+      padding-top: 3rem;
+      padding-bottom: 2rem;
+    }
+
+    .homepage-workflow-layout {
+      grid-template-columns: minmax(16rem, 0.72fr) minmax(0, 1.28fr);
+      gap: clamp(2rem, 5vw, 4rem);
+      align-items: start;
+    }
+
+    .homepage-workflow-sticky-visual {
+      position: sticky;
+      top: 2rem;
+      order: 2;
+      min-height: calc(100vh - 4rem);
+      display: flex;
+      align-items: center;
+    }
+
     .homepage-workflow-scene-list {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
+      order: 1;
+    }
+
+    .homepage-workflow-scene {
+      min-height: min(42rem, calc(100vh - 4rem));
+      display: flex;
+      align-items: center;
     }
   }
 
-  @media (min-width: 1100px) {
-    .homepage-workflow-scene-list {
-      grid-template-columns: repeat(6, minmax(0, 1fr));
+  @media (max-width: 520px) {
+    .homepage-workflow-composite {
+      min-height: 36rem;
     }
 
-    .homepage-workflow-scene:not(:last-child)::after {
-      position: absolute;
-      top: 1.75rem;
-      right: -0.75rem;
-      z-index: 1;
-      width: 0.75rem;
-      height: 1px;
-      background-color: rgb(203 213 225);
-      content: "";
+    .homepage-workflow-popup {
+      left: 0.75rem;
+      bottom: 0;
     }
 
-    .dark .homepage-workflow-scene:not(:last-child)::after {
-      background-color: rgb(71 85 105);
+    .homepage-workflow-popup .grid {
+      grid-template-columns: 1fr;
+    }
+
+    .homepage-workflow-popup .border-l {
+      border-left-width: 0;
+    }
+
+    .homepage-workflow-panel-header {
+      padding-left: 0.75rem;
+      padding-right: 0.75rem;
     }
   }
 

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -570,6 +570,153 @@
     @apply flex h-10 items-center border-b border-slate-200 px-4 text-xs font-semibold tracking-[0.14em] text-slate-500 uppercase dark:border-slate-700 dark:text-slate-400;
   }
 
+  .homepage-workflow-storyboard {
+    overflow: hidden;
+    border: 1px solid rgb(226 232 240);
+    border-radius: 0.5rem;
+    background-color: #fff;
+    box-shadow: 0 24px 70px rgb(15 23 42 / 10%);
+  }
+
+  .dark .homepage-workflow-storyboard {
+    border-color: rgb(51 65 85);
+    background-color: rgb(15 23 42);
+    box-shadow: 0 24px 70px rgb(0 0 0 / 35%);
+  }
+
+  .homepage-workflow-scene-list {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .homepage-workflow-scene {
+    position: relative;
+    border: 1px solid rgb(226 232 240);
+    border-radius: 0.5rem;
+    background-color: rgb(255 255 255 / 82%);
+    padding: 0.875rem;
+  }
+
+  .dark .homepage-workflow-scene {
+    border-color: rgb(51 65 85);
+    background-color: rgb(15 23 42 / 72%);
+  }
+
+  .homepage-workflow-scene-marker {
+    display: inline-flex;
+    height: 1.75rem;
+    min-width: 1.75rem;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    border: 1px solid rgb(203 213 225);
+    color: rgb(100 116 139);
+    font-size: 0.6875rem;
+    font-weight: 700;
+    line-height: 1;
+  }
+
+  .homepage-workflow-scene-marker-active {
+    border-color: rgb(15 23 42);
+    background-color: rgb(15 23 42);
+    color: white;
+  }
+
+  .dark .homepage-workflow-scene-marker {
+    border-color: rgb(71 85 105);
+    color: rgb(148 163 184);
+  }
+
+  .dark .homepage-workflow-scene-marker-active {
+    border-color: rgb(241 245 249);
+    background-color: rgb(241 245 249);
+    color: rgb(15 23 42);
+  }
+
+  .homepage-workflow-panel {
+    min-width: 0;
+    overflow: hidden;
+    border: 1px solid rgb(226 232 240);
+    border-radius: 0.5rem;
+    background-color: rgb(248 250 252);
+  }
+
+  .dark .homepage-workflow-panel {
+    border-color: rgb(51 65 85);
+    background-color: rgb(2 6 23);
+  }
+
+  .homepage-workflow-panel-header {
+    display: flex;
+    height: 2.5rem;
+    align-items: center;
+    gap: 0.375rem;
+    border-bottom: 1px solid rgb(226 232 240);
+    padding: 0 1rem;
+    color: rgb(100 116 139);
+    font-size: 0.75rem;
+    font-weight: 700;
+  }
+
+  .dark .homepage-workflow-panel-header {
+    border-color: rgb(51 65 85);
+    color: rgb(148 163 184);
+  }
+
+  .homepage-workflow-done-popover {
+    position: relative;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
+  }
+
+  .homepage-workflow-popover-card {
+    width: min(13rem, calc(100vw - 3rem));
+    border: 1px solid rgb(226 232 240);
+    border-radius: 0.5rem;
+    background-color: white;
+    padding: 0.75rem;
+    box-shadow: 0 14px 34px rgb(15 23 42 / 14%);
+  }
+
+  .dark .homepage-workflow-popover-card {
+    border-color: rgb(51 65 85);
+    background-color: rgb(15 23 42);
+    box-shadow: 0 14px 34px rgb(0 0 0 / 36%);
+  }
+
+  @media (min-width: 720px) {
+    .homepage-workflow-scene-list {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  @media (min-width: 1100px) {
+    .homepage-workflow-scene-list {
+      grid-template-columns: repeat(6, minmax(0, 1fr));
+    }
+
+    .homepage-workflow-scene:not(:last-child)::after {
+      position: absolute;
+      top: 1.75rem;
+      right: -0.75rem;
+      z-index: 1;
+      width: 0.75rem;
+      height: 1px;
+      background-color: rgb(203 213 225);
+      content: "";
+    }
+
+    .dark .homepage-workflow-scene:not(:last-child)::after {
+      background-color: rgb(71 85 105);
+    }
+  }
+
   .rfm-source-pane,
   .rfm-result-pane {
     border: 0;

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -675,6 +675,23 @@
     gap: 0.5rem;
   }
 
+  .homepage-workflow-done-reviewing {
+    display: inline-flex;
+    height: 2.25rem;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    border-radius: 0.375rem;
+    background-color: var(--primary);
+    padding: 0 0.75rem;
+    color: var(--primary-foreground);
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.25rem;
+    white-space: nowrap;
+    user-select: none;
+  }
+
   .homepage-workflow-popover-card {
     width: min(13rem, calc(100vw - 3rem));
     border: 1px solid rgb(226 232 240);

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -675,23 +675,6 @@
     gap: 0.5rem;
   }
 
-  .homepage-workflow-done-reviewing {
-    display: inline-flex;
-    height: 2.25rem;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    border-radius: 0.375rem;
-    background-color: var(--primary);
-    padding: 0 0.75rem;
-    color: var(--primary-foreground);
-    font-size: 0.875rem;
-    font-weight: 500;
-    line-height: 1.25rem;
-    white-space: nowrap;
-    user-select: none;
-  }
-
   .homepage-workflow-popover-card {
     width: min(13rem, calc(100vw - 3rem));
     border: 1px solid rgb(226 232 240);

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -886,28 +886,282 @@
     color: rgb(148 163 184);
   }
 
-  .homepage-workflow-done-popover {
+  .homepage-workflow-document-workspace {
     position: relative;
-    display: inline-flex;
-    flex-direction: column;
-    align-items: flex-start;
+    min-height: 28rem;
+    overflow: hidden;
+    background-color: rgb(250 250 249);
+    padding: 1rem;
+  }
+
+  .dark .homepage-workflow-document-workspace {
+    background-color: rgb(15 23 42);
+  }
+
+  .homepage-workflow-handoff-button {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    z-index: 3;
+    height: 2rem;
+    border-radius: 0.4375rem;
+    background-color: rgb(0 0 0);
+    padding: 0 0.75rem;
+    color: white;
+    font-size: 0.75rem;
+    font-weight: 700;
+    box-shadow: 0 10px 28px rgb(0 0 0 / 18%);
+  }
+
+  .homepage-workflow-handoff-button:hover {
+    background-color: rgb(0 0 0 / 85%);
+  }
+
+  .homepage-workflow-document-shell {
+    display: grid;
+    gap: 1rem;
+    align-items: start;
+    max-width: 39rem;
+    min-width: 0;
+    margin: 0 auto;
+    transition:
+      max-width 220ms ease,
+      grid-template-columns 220ms ease;
+  }
+
+  .homepage-workflow-document-shell-with-comments {
+    max-width: 100%;
+  }
+
+  .homepage-workflow-document-shell-no-comments {
+    max-width: 39rem;
+  }
+
+  .homepage-workflow-document-main {
+    min-width: 0;
+  }
+
+  .homepage-workflow-document-toolbar {
+    display: flex;
+    min-width: 0;
+    align-items: center;
     gap: 0.5rem;
+    padding: 0 0.25rem 0.75rem;
+    color: rgb(168 162 158);
+    font-family:
+      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+      "Courier New", monospace;
+    font-size: 0.7rem;
+    font-weight: 500;
   }
 
-  .homepage-workflow-popover-card {
-    width: min(13rem, 100%);
-    max-width: calc(100vw - 3rem);
-    border: 1px solid rgb(226 232 240);
-    border-radius: 0.5rem;
+  .homepage-workflow-view-toggle {
+    display: grid;
+    height: 1.375rem;
+    grid-template-columns: repeat(2, 1.625rem);
+    align-items: center;
+    border-radius: 999px;
+    background-color: rgb(222 216 206);
+    padding: 0.125rem;
+    box-shadow: inset 0 1px 0 rgb(255 251 245 / 72%);
+  }
+
+  .homepage-workflow-view-toggle span {
+    display: flex;
+    height: 1.125rem;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    color: rgb(120 113 108);
+  }
+
+  .homepage-workflow-view-toggle .homepage-workflow-view-toggle-active {
+    background-color: rgb(255 253 252);
+    box-shadow: 0 1px 2px rgb(41 37 36 / 12%);
+    color: rgb(68 64 60);
+  }
+
+  .homepage-workflow-document-filename {
+    min-width: 0;
+    overflow: hidden;
+    color: rgb(120 113 108);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .homepage-workflow-document-mode {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-left: auto;
+    color: rgb(168 162 158);
+  }
+
+  .homepage-workflow-document-page {
+    min-height: 25rem;
+    border: 1px solid rgb(233 233 232);
+    border-radius: 0.75rem;
     background-color: white;
-    padding: 0.75rem;
-    box-shadow: 0 14px 34px rgb(15 23 42 / 14%);
+    padding: clamp(2rem, 6vw, 3.5rem);
+    box-shadow: 0 18px 44px rgb(57 47 38 / 8%);
   }
 
-  .dark .homepage-workflow-popover-card {
+  .homepage-workflow-doc-kicker {
+    margin: 0 0 1rem;
+    color: rgb(120 113 108);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    line-height: 1;
+    text-transform: uppercase;
+  }
+
+  .homepage-workflow-document-page h3 {
+    margin: 0 0 1.5rem;
+    color: rgb(2 6 23);
+    font-size: clamp(1.6rem, 4vw, 2.35rem);
+    font-weight: 650;
+    line-height: 1.1;
+  }
+
+  .homepage-workflow-document-page p {
+    margin: 0 0 1rem;
+    color: rgb(51 65 85);
+    font-size: clamp(0.95rem, 2.25vw, 1.12rem);
+    line-height: 1.65;
+  }
+
+  .homepage-workflow-comment-highlight {
+    background-color: rgb(255 245 199);
+    box-decoration-break: clone;
+    -webkit-box-decoration-break: clone;
+  }
+
+  .homepage-workflow-suggestion-old {
+    border-radius: 0.2rem;
+    background-color: rgb(255 241 242);
+    color: rgb(136 19 55);
+    text-decoration: line-through;
+    text-decoration-color: rgb(225 29 72 / 75%);
+  }
+
+  .homepage-workflow-suggestion-new {
+    border-radius: 0.2rem;
+    background-color: rgb(236 253 245);
+    color: rgb(6 95 70);
+    text-decoration: underline;
+    text-decoration-color: rgb(16 185 129 / 75%);
+    text-underline-offset: 0.16em;
+  }
+
+  .homepage-workflow-review-rail {
+    display: grid;
+    gap: 1.25rem;
+    min-width: 0;
+    color: rgb(51 65 85);
+  }
+
+  .homepage-workflow-review-thread {
+    display: grid;
+    grid-template-columns: 2rem minmax(0, 1fr);
+    gap: 0.75rem;
+    align-items: start;
+  }
+
+  .homepage-workflow-review-avatar {
+    display: flex;
+    height: 2rem;
+    width: 2rem;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgb(214 211 209);
+    border-radius: 999px;
+    background-color: rgb(231 224 213);
+    color: rgb(68 64 60);
+    font-size: 0.72rem;
+    font-weight: 700;
+  }
+
+  .homepage-workflow-review-thread-ai .homepage-workflow-review-avatar {
+    border-color: rgb(186 230 253);
+    background-color: rgb(240 249 255);
+    color: rgb(2 132 199);
+  }
+
+  .homepage-workflow-review-author {
+    margin-bottom: 0.25rem;
+    color: rgb(15 23 42);
+    font-size: 0.85rem;
+    font-weight: 700;
+  }
+
+  .homepage-workflow-review-thread p {
+    margin: 0;
+    color: rgb(51 65 85);
+    font-size: 0.8rem;
+    line-height: 1.65;
+  }
+
+  .homepage-workflow-review-actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+    color: rgb(168 162 158);
+    font-size: 0.95rem;
+  }
+
+  .dark .homepage-workflow-document-page {
     border-color: rgb(51 65 85);
     background-color: rgb(15 23 42);
-    box-shadow: 0 14px 34px rgb(0 0 0 / 36%);
+    box-shadow: 0 18px 44px rgb(0 0 0 / 35%);
+  }
+
+  .dark .homepage-workflow-document-page h3,
+  .dark .homepage-workflow-review-author {
+    color: rgb(248 250 252);
+  }
+
+  .dark .homepage-workflow-document-page p,
+  .dark .homepage-workflow-review-thread p {
+    color: rgb(203 213 225);
+  }
+
+  .dark .homepage-workflow-doc-kicker,
+  .dark .homepage-workflow-document-filename,
+  .dark .homepage-workflow-document-mode,
+  .dark .homepage-workflow-document-toolbar {
+    color: rgb(148 163 184);
+  }
+
+  .dark .homepage-workflow-view-toggle {
+    background-color: rgb(51 65 85);
+    box-shadow: inset 0 1px 0 rgb(255 255 255 / 8%);
+  }
+
+  .dark .homepage-workflow-view-toggle .homepage-workflow-view-toggle-active {
+    background-color: rgb(100 116 139);
+    color: white;
+  }
+
+  .dark .homepage-workflow-comment-highlight {
+    background-color: rgb(133 77 14 / 35%);
+  }
+
+  .dark .homepage-workflow-suggestion-old {
+    background-color: rgb(136 19 55 / 35%);
+    color: rgb(253 164 175);
+  }
+
+  .dark .homepage-workflow-suggestion-new {
+    background-color: rgb(6 78 59 / 50%);
+    color: rgb(110 231 183);
+  }
+
+  @media (min-width: 780px) {
+    .homepage-workflow-document-shell-with-comments {
+      grid-template-columns: minmax(0, 1fr) minmax(11rem, 0.48fr);
+      gap: 1.25rem;
+    }
   }
 
   @media (min-width: 900px) {
@@ -952,12 +1206,16 @@
       bottom: 0;
     }
 
-    .homepage-workflow-popup .grid {
-      grid-template-columns: 1fr;
+    .homepage-workflow-document-workspace {
+      padding: 0.75rem;
     }
 
-    .homepage-workflow-popup .border-l {
-      border-left-width: 0;
+    .homepage-workflow-document-page {
+      padding: 1.5rem;
+    }
+
+    .homepage-workflow-document-mode {
+      display: none;
     }
 
     .homepage-workflow-panel-header {

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -583,6 +583,13 @@
   }
 
   .homepage-workflow-layout {
+    --homepage-workflow-dock-height: clamp(16rem, 38svh, 20rem);
+    --homepage-workflow-dock-bottom: calc(
+      0.75rem +
+      env(safe-area-inset-bottom, 0px)
+    );
+    --homepage-workflow-dock-gap: clamp(1rem, 4vw, 1.5rem);
+
     display: grid;
     grid-template-columns: 1fr;
     gap: 1.5rem;
@@ -618,6 +625,7 @@
 
   .homepage-workflow-scene-copy {
     min-width: 0;
+    max-width: 28rem;
   }
 
   .homepage-workflow-scene-marker {
@@ -847,10 +855,16 @@
   }
 
   .homepage-workflow-popup {
+    --homepage-workflow-popup-overhang: clamp(
+      0rem,
+      calc((100vw - 72rem) * 0.5),
+      4rem
+    );
+
     position: absolute;
-    right: 0;
+    right: calc(-1 * var(--homepage-workflow-popup-overhang));
     bottom: 1rem;
-    left: clamp(1rem, 8vw, 4.5rem);
+    left: clamp(0.5rem, 3vw, 1.5rem);
     z-index: 2;
     width: auto;
     transition:
@@ -887,11 +901,23 @@
   }
 
   .homepage-workflow-document-workspace {
+    --homepage-workflow-document-scale: 1;
+    --homepage-workflow-document-offset-y: 0rem;
+
     position: relative;
     min-height: 28rem;
     overflow: hidden;
     background-color: rgb(250 250 249);
     padding: 1rem;
+  }
+
+  .homepage-workflow-document-scale {
+    position: relative;
+    width: 100%;
+    min-width: 0;
+    transform: translateY(var(--homepage-workflow-document-offset-y))
+      scale(var(--homepage-workflow-document-scale));
+    transform-origin: top left;
   }
 
   .dark .homepage-workflow-document-workspace {
@@ -1158,9 +1184,19 @@
   }
 
   @media (min-width: 780px) {
+    .homepage-workflow-document-workspace {
+      --homepage-workflow-document-scale: 0.6;
+      min-height: 25.5rem;
+    }
+
+    .homepage-workflow-document-scale {
+      width: calc(100% / var(--homepage-workflow-document-scale));
+    }
+
     .homepage-workflow-document-shell-with-comments {
       grid-template-columns: minmax(0, 1fr) minmax(11rem, 0.48fr);
       gap: 1.25rem;
+      max-width: 56rem;
     }
   }
 
@@ -1171,6 +1207,10 @@
     }
 
     .homepage-workflow-layout {
+      --homepage-workflow-dock-height: auto;
+      --homepage-workflow-dock-bottom: 0rem;
+      --homepage-workflow-dock-gap: 0rem;
+
       grid-template-columns: minmax(16rem, 0.72fr) minmax(0, 1.28fr);
       gap: clamp(2rem, 5vw, 4rem);
       align-items: start;
@@ -1179,34 +1219,173 @@
     .homepage-workflow-sticky-visual {
       position: sticky;
       top: 2rem;
+      bottom: auto;
       order: 2;
+      z-index: auto;
+      height: auto;
       min-height: calc(100vh - 4rem);
       display: flex;
       align-items: center;
+      overflow: visible;
+    }
+
+    .homepage-workflow-composite {
+      min-height: 38rem;
+      height: auto;
     }
 
     .homepage-workflow-scene-list {
       order: 1;
+      padding-bottom: 0;
     }
 
     .homepage-workflow-scene {
       min-height: min(42rem, calc(100vh - 4rem));
       display: flex;
       align-items: center;
+      padding: clamp(1.75rem, 7vw, 4.5rem) 0;
+    }
+  }
+
+  @media (max-width: 899px) {
+    .homepage-workflow-layout {
+      gap: 0;
+    }
+
+    .homepage-workflow-sticky-visual {
+      position: sticky;
+      top: calc(
+        100svh -
+        var(--homepage-workflow-dock-height) -
+        var(--homepage-workflow-dock-bottom)
+      );
+      bottom: var(--homepage-workflow-dock-bottom);
+      z-index: 2;
+      display: flex;
+      height: var(--homepage-workflow-dock-height);
+      min-height: 0;
+      align-items: flex-end;
+      overflow: hidden;
+      border-radius: 0.65rem;
+      box-shadow: 0 18px 48px rgb(15 23 42 / 16%);
+    }
+
+    .homepage-workflow-sticky-visual .homepage-workflow-composite {
+      height: 100%;
+      min-height: 0;
+      width: 100%;
+    }
+
+    .homepage-workflow-scene-list {
+      padding-bottom: calc(
+        var(--homepage-workflow-dock-height) +
+        var(--homepage-workflow-dock-bottom) +
+        2rem
+      );
+    }
+
+    .homepage-workflow-scene {
+      min-height: calc(100svh - 3rem);
+      padding-top: clamp(2rem, 8vw, 3rem);
+      padding-bottom: calc(
+        var(--homepage-workflow-dock-height) +
+        var(--homepage-workflow-dock-bottom) +
+        var(--homepage-workflow-dock-gap)
+      );
+    }
+
+    .homepage-workflow-scene-copy {
+      max-width: min(100%, 27rem);
+    }
+
+    .homepage-workflow-terminal {
+      height: 100%;
+      border-color: rgb(15 23 42 / 64%);
+    }
+
+    .homepage-workflow-terminal-titlebar {
+      min-height: 2rem;
+      padding: 0 0.75rem;
+      font-size: 0.68rem;
+    }
+
+    .homepage-workflow-terminal-body {
+      gap: 0.625rem;
+      padding: 0.75rem 0 5.75rem;
+      font-size: 0.72rem;
+      line-height: 1.45;
+    }
+
+    .homepage-workflow-terminal-meta,
+    .homepage-workflow-terminal-agent-line {
+      padding-left: 0.75rem;
+      padding-right: 0.75rem;
+    }
+
+    .homepage-workflow-terminal-user-line {
+      gap: 0.5rem;
+      padding: 0.375rem 0.75rem;
+    }
+
+    .homepage-workflow-terminal-tools,
+    .homepage-workflow-terminal-command {
+      margin-left: 0.75rem;
+      margin-right: 0.75rem;
+      padding: 0.5rem;
+      font-size: 0.66rem;
+    }
+
+    .homepage-workflow-popup {
+      --homepage-workflow-popup-overhang: 0rem;
+
+      right: 0.5rem;
+      bottom: 0.5rem;
+      left: 0.5rem;
+    }
+
+    .homepage-workflow-document-workspace {
+      --homepage-workflow-document-scale: 0.66;
+      --homepage-workflow-document-offset-y: clamp(7rem, 15svh, 8rem);
+
+      min-height: 14.5rem;
+      padding: 0.625rem;
+    }
+
+    .homepage-workflow-document-scale {
+      width: calc(100% / var(--homepage-workflow-document-scale));
+    }
+
+    .homepage-workflow-document-shell-with-comments {
+      grid-template-columns: minmax(0, 1fr) minmax(10rem, 0.44fr);
+      gap: 0.85rem;
+      max-width: 46rem;
+    }
+
+    .homepage-workflow-document-page {
+      min-height: 19rem;
+      padding: 1.5rem;
+    }
+
+    .homepage-workflow-review-rail {
+      gap: 0.75rem;
     }
   }
 
   @media (max-width: 520px) {
     .homepage-workflow-composite {
-      min-height: 36rem;
+      min-height: 0;
     }
 
     .homepage-workflow-popup {
-      left: 0.75rem;
-      bottom: 0;
+      right: 0.375rem;
+      bottom: 0.375rem;
+      left: 0.375rem;
     }
 
     .homepage-workflow-document-workspace {
+      --homepage-workflow-document-scale: 0.6;
+      --homepage-workflow-document-offset-y: clamp(7rem, 15svh, 8rem);
+
       padding: 0.75rem;
     }
 

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -277,14 +277,11 @@ describe("Homepage", () => {
     expect(document.body.textContent).toContain("Copied");
   });
 
-  it("explains the plan-review workflow as a six-scene storyboard above the Markdown section", async () => {
+  it("explains the plan-review workflow with scrolling steps and a fixed visual", async () => {
     await renderHomepage(root);
 
     const text = container.textContent ?? "";
-    expect(text).toContain("Review an agent's plan before it starts coding.");
-    expect(text).toContain(
-      "Ask for a plan, mark it up in Roughdraft, click Done Reviewing, and the agent continues from the edited Markdown file.",
-    );
+    expect(text).toContain("How it works");
 
     const storyboard = container.querySelector(
       "[data-homepage-workflow-storyboard]",
@@ -293,6 +290,9 @@ describe("Homepage", () => {
     expect(storyboard?.getAttribute("aria-labelledby")).toBe(
       "homepage-workflow-heading",
     );
+    expect(
+      storyboard.querySelector("#homepage-workflow-heading")?.textContent,
+    ).toBe("How it works");
 
     const markdownDemo = container.querySelector(".rfm-format-demo");
     expect(markdownDemo).not.toBeNull();
@@ -318,6 +318,59 @@ describe("Homepage", () => {
       ...storyboard.querySelectorAll("[data-homepage-workflow-scene]"),
     ];
     expect(sceneNodes).toHaveLength(scenes.length);
+
+    const stickyVisual = storyboard.querySelector(
+      "[data-homepage-workflow-sticky-visual]",
+    );
+    expect(stickyVisual).not.toBeNull();
+    expect(
+      storyboard.querySelectorAll(".homepage-workflow-terminal"),
+    ).toHaveLength(1);
+    expect(
+      storyboard
+        .querySelector(".homepage-workflow-terminal")
+        ?.getAttribute("data-homepage-workflow-terminal-stage"),
+    ).toBe("1");
+    expect(
+      storyboard
+        .querySelector(".homepage-workflow-terminal-reveal-stack")
+        ?.getAttribute("data-agent-work-visible"),
+    ).toBe("false");
+    expect(
+      storyboard
+        .querySelector(".homepage-workflow-terminal-command")
+        ?.getAttribute("data-terminal-line-visible"),
+    ).toBe("false");
+    expect(
+      storyboard
+        .querySelector(".homepage-workflow-terminal-input")
+        ?.getAttribute("data-terminal-line-visible"),
+    ).toBe("false");
+    expect(
+      storyboard.querySelectorAll("[data-homepage-workflow-popup]"),
+    ).toHaveLength(1);
+    expect(
+      storyboard
+        .querySelector("[data-homepage-workflow-popup]")
+        ?.getAttribute("data-popup-visible"),
+    ).toBe("false");
+    expect(
+      storyboard
+        .querySelector("[data-homepage-workflow-popup]")
+        ?.getAttribute("aria-hidden"),
+    ).toBe("true");
+    expect(APP_STYLES).toMatch(
+      /\.homepage-workflow-sticky-visual \{[^}]*position:\s*sticky;[^}]*top:\s*2rem;/s,
+    );
+    expect(APP_STYLES).toMatch(
+      /\.homepage-workflow-popup \{[^}]*position:\s*absolute;[^}]*bottom:\s*1rem;/s,
+    );
+    expect(APP_STYLES).toMatch(
+      /\.homepage-workflow-popup\[data-popup-visible="false"\] \{[^}]*opacity:\s*0;/s,
+    );
+    expect(APP_STYLES).toMatch(
+      /\.homepage-workflow-terminal-reveal-stack\[data-agent-work-visible="false"\] \{[^}]*max-height:\s*0;[^}]*opacity:\s*0;/s,
+    );
 
     scenes.forEach((scene, index) => {
       expect(sceneNodes[index]?.textContent).toContain(

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -283,23 +283,15 @@ describe("Homepage", () => {
     const text = container.textContent ?? "";
     expect(text).toContain("How it works");
 
-    const storyboard = container.querySelector(
-      "[data-homepage-workflow-storyboard]",
-    );
-    expect(storyboard).not.toBeNull();
-    expect(storyboard?.getAttribute("aria-labelledby")).toBe(
+    const storyboard = getByTestId(container, "homepage-workflow-storyboard");
+    expect(storyboard.getAttribute("aria-labelledby")).toBe(
       "homepage-workflow-heading",
     );
     expect(
-      storyboard.querySelector("#homepage-workflow-heading")?.textContent,
+      getByTestId(storyboard, "homepage-workflow-heading").textContent,
     ).toBe("How it works");
 
-    const markdownDemo = container.querySelector(".rfm-format-demo");
-    expect(markdownDemo).not.toBeNull();
-    expect(storyboard && markdownDemo).toBeTruthy();
-    if (!storyboard || !markdownDemo) {
-      throw new Error("Expected storyboard and Markdown demo to render");
-    }
+    const markdownDemo = getByTestId(container, "rfm-format-demo");
     expect(
       storyboard.compareDocumentPosition(markdownDemo) &
         Node.DOCUMENT_POSITION_FOLLOWING,
@@ -310,54 +302,56 @@ describe("Homepage", () => {
       "The agent works normally",
       "Roughdraft opens the plan",
       "Leave comments and suggestions",
-      "Click Done Reviewing",
+      "Click I'm done",
       "The agent resumes",
     ];
 
     const sceneNodes = [
-      ...storyboard.querySelectorAll("[data-homepage-workflow-scene]"),
+      ...storyboard.querySelectorAll('[data-testid="homepage-workflow-scene"]'),
     ];
     expect(sceneNodes).toHaveLength(scenes.length);
 
-    const stickyVisual = storyboard.querySelector(
-      "[data-homepage-workflow-sticky-visual]",
+    const stickyVisual = getByTestId(
+      storyboard,
+      "homepage-workflow-sticky-visual",
     );
     expect(stickyVisual).not.toBeNull();
     expect(
-      storyboard.querySelectorAll(".homepage-workflow-terminal"),
+      storyboard.querySelectorAll('[data-testid="homepage-workflow-terminal"]'),
     ).toHaveLength(1);
     expect(
-      storyboard
-        .querySelector(".homepage-workflow-terminal")
-        ?.getAttribute("data-homepage-workflow-terminal-stage"),
+      getByTestId(storyboard, "homepage-workflow-terminal").getAttribute(
+        "data-homepage-workflow-terminal-stage",
+      ),
     ).toBe("1");
     expect(
-      storyboard
-        .querySelector(".homepage-workflow-terminal-reveal-stack")
-        ?.getAttribute("data-agent-work-visible"),
+      getByTestId(storyboard, "homepage-workflow-agent-work").getAttribute(
+        "data-agent-work-visible",
+      ),
     ).toBe("false");
     expect(
-      storyboard
-        .querySelector(".homepage-workflow-terminal-command")
-        ?.getAttribute("data-terminal-line-visible"),
+      getByTestId(
+        storyboard,
+        "homepage-workflow-terminal-command",
+      ).getAttribute("data-terminal-line-visible"),
     ).toBe("false");
     expect(
-      storyboard
-        .querySelector(".homepage-workflow-terminal-input")
-        ?.getAttribute("data-terminal-line-visible"),
+      getByTestId(storyboard, "homepage-workflow-terminal-input").getAttribute(
+        "data-terminal-line-visible",
+      ),
     ).toBe("false");
     expect(
-      storyboard.querySelectorAll("[data-homepage-workflow-popup]"),
+      storyboard.querySelectorAll('[data-testid="homepage-workflow-popup"]'),
     ).toHaveLength(1);
     expect(
-      storyboard
-        .querySelector("[data-homepage-workflow-popup]")
-        ?.getAttribute("data-popup-visible"),
+      getByTestId(storyboard, "homepage-workflow-popup").getAttribute(
+        "data-popup-visible",
+      ),
     ).toBe("false");
     expect(
-      storyboard
-        .querySelector("[data-homepage-workflow-popup]")
-        ?.getAttribute("aria-hidden"),
+      getByTestId(storyboard, "homepage-workflow-popup").getAttribute(
+        "aria-hidden",
+      ),
     ).toBe("true");
     expect(APP_STYLES).toMatch(
       /\.homepage-workflow-sticky-visual \{[^}]*position:\s*sticky;[^}]*top:\s*2rem;/s,
@@ -370,6 +364,9 @@ describe("Homepage", () => {
     );
     expect(APP_STYLES).toMatch(
       /\.homepage-workflow-terminal-reveal-stack\[data-agent-work-visible="false"\] \{[^}]*max-height:\s*0;[^}]*opacity:\s*0;/s,
+    );
+    expect(APP_STYLES).toMatch(
+      /\.homepage-workflow-document-shell-no-comments \{[^}]*max-width:\s*39rem;/s,
     );
 
     scenes.forEach((scene, index) => {
@@ -405,25 +402,14 @@ describe("Homepage", () => {
       "Keep the format section as proof that the review data is portable Markdown.",
     );
     expect(storyboard.textContent).toContain(
-      'This should go above "It\'s just Markdown."',
-    );
-    expect(storyboard.textContent).toContain(
-      "Can we make the example about homepage conversion?",
-    );
-    expect(storyboard.textContent).toContain(
       "Review an agent's plan before it starts coding.",
     );
-    expect(storyboard.textContent).toContain("Done Reviewing");
-    expect(storyboard.textContent).toContain("Review complete");
-    expect(storyboard.textContent).toContain(
-      "Your agent can read the edited Markdown file now.",
+    expect(storyboard.textContent).not.toContain(
+      'This should go above "It\'s just Markdown."',
     );
+    expect(storyboard.textContent).not.toContain("Review complete");
     expect(storyboard.textContent).toContain("I read your comments.");
-    const doneReviewingButton = [...storyboard.querySelectorAll("button")].find(
-      (button) => button.textContent?.includes("Done Reviewing"),
-    );
-    expect(doneReviewingButton).toBeDefined();
-    expect(doneReviewingButton?.getAttribute("data-slot")).toBe("button");
+    expect(storyboard.textContent).toContain("Waiting for I'm done...");
   });
 
   it("renders the Roughdraft flavored Markdown spec page", async () => {

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -66,6 +66,18 @@ function getByTestId<T extends Element = HTMLElement>(
   return element as T;
 }
 
+async function renderHomepage(root: Root) {
+  await act(async () => {
+    root.render(
+      <Homepage
+        message="Roughdraft is a markdown editor with commenting and suggest changes mode, making it easier to align with AI on complex ideas."
+        updateStatus={null}
+      />,
+    );
+    await Promise.resolve();
+  });
+}
+
 describe("Homepage", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -134,15 +146,7 @@ describe("Homepage", () => {
   });
 
   it("opens the agent setup prompt from the CTA and copies it", async () => {
-    await act(async () => {
-      root.render(
-        <Homepage
-          message="Roughdraft is a markdown editor with commenting and suggest changes mode, making it easier to align with AI on complex ideas."
-          updateStatus={null}
-        />,
-      );
-      await Promise.resolve();
-    });
+    await renderHomepage(root);
 
     expect(container.textContent).toContain(
       "Easier collaboration with your coding agent",
@@ -216,18 +220,6 @@ describe("Homepage", () => {
     expect(
       container.querySelector(".critic-change[data-critic-change-id]"),
     ).not.toBeNull();
-    expect(container.textContent).toContain("Review workflow");
-    expect(container.textContent).toContain(
-      "Pass the same Markdown file back and forth with your agent.",
-    );
-    expect(container.textContent).toContain("Review an agent's draft");
-    expect(container.textContent).toContain(
-      "tell the agent to read the file again",
-    );
-    expect(container.textContent).toContain("Ask the agent to review yours");
-    expect(container.textContent).toContain(
-      "leave detailed comments, questions, and suggested edits",
-    );
     expect(container.innerHTML).not.toContain(
       'contenteditable="plaintext-only"',
     );
@@ -283,6 +275,78 @@ describe("Homepage", () => {
 
     expect(writeText).toHaveBeenCalledWith(AGENT_SETUP_PROMPT);
     expect(document.body.textContent).toContain("Copied");
+  });
+
+  it("explains the plan-review workflow as a six-scene storyboard above the Markdown section", async () => {
+    await renderHomepage(root);
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("Review an agent's plan before it starts coding.");
+    expect(text).toContain(
+      "Ask for a plan, mark it up in Roughdraft, click Done Reviewing, and the agent continues from the edited Markdown file.",
+    );
+
+    const storyboard = container.querySelector(
+      "[data-homepage-workflow-storyboard]",
+    );
+    expect(storyboard).not.toBeNull();
+    expect(storyboard?.getAttribute("aria-labelledby")).toBe(
+      "homepage-workflow-heading",
+    );
+
+    const markdownDemo = container.querySelector(".rfm-format-demo");
+    expect(markdownDemo).not.toBeNull();
+    expect(storyboard && markdownDemo).toBeTruthy();
+    if (!storyboard || !markdownDemo) {
+      throw new Error("Expected storyboard and Markdown demo to render");
+    }
+    expect(
+      storyboard.compareDocumentPosition(markdownDemo) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    const scenes = [
+      "Ask for a plan",
+      "The agent works normally",
+      "Roughdraft opens the plan",
+      "Leave comments and suggestions",
+      "Click Done Reviewing",
+      "The agent resumes",
+    ];
+
+    const sceneNodes = [
+      ...storyboard.querySelectorAll("[data-homepage-workflow-scene]"),
+    ];
+    expect(sceneNodes).toHaveLength(scenes.length);
+
+    scenes.forEach((scene, index) => {
+      expect(sceneNodes[index]?.textContent).toContain(
+        String(index + 1).padStart(2, "0"),
+      );
+      expect(sceneNodes[index]?.textContent).toContain(scene);
+    });
+
+    expect(storyboard.textContent).toContain(
+      "Let's make the homepage more persuasive. Write a plan first.",
+    );
+    expect(storyboard.textContent).toContain(
+      "write .context/homepage-conversion-plan.md",
+    );
+    expect(storyboard.textContent).toContain("Homepage Conversion Plan");
+    expect(storyboard.textContent).toContain(
+      'Move the workflow story above "It\'s just Markdown."',
+    );
+    expect(storyboard.textContent).toContain(
+      "This should go above \"It's just Markdown.\"",
+    );
+    expect(storyboard.textContent).toContain(
+      "Review an agent's plan before it starts coding.",
+    );
+    expect(storyboard.textContent).toContain("Review complete");
+    expect(storyboard.textContent).toContain(
+      "Your agent can read the edited Markdown file now.",
+    );
+    expect(storyboard.textContent).toContain("I read your comments.");
   });
 
   it("renders the Roughdraft flavored Markdown spec page", async () => {

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -366,11 +366,11 @@ describe("Homepage", () => {
       "Your agent can read the edited Markdown file now.",
     );
     expect(storyboard.textContent).toContain("I read your comments.");
-    expect(
-      [...storyboard.querySelectorAll("button")].find((button) =>
-        button.textContent?.includes("Done Reviewing"),
-      ),
-    ).toBeUndefined();
+    const doneReviewingButton = [...storyboard.querySelectorAll("button")].find(
+      (button) => button.textContent?.includes("Done Reviewing"),
+    );
+    expect(doneReviewingButton).toBeDefined();
+    expect(doneReviewingButton?.getAttribute("data-slot")).toBe("button");
   });
 
   it("renders the Roughdraft flavored Markdown spec page", async () => {

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -330,6 +330,15 @@ describe("Homepage", () => {
       "Let's make the homepage more persuasive. Write a plan first.",
     );
     expect(storyboard.textContent).toContain(
+      "I'll inspect the current homepage, draft a Markdown plan, and open it in Roughdraft for review before I code.",
+    );
+    expect(storyboard.textContent).toContain(
+      'rg "It\'s just Markdown" packages/app/src',
+    );
+    expect(storyboard.textContent).toContain(
+      "sed -n '1,220p' packages/app/src/App.tsx",
+    );
+    expect(storyboard.textContent).toContain(
       "write .context/homepage-conversion-plan.md",
     );
     expect(storyboard.textContent).toContain("Homepage Conversion Plan");
@@ -337,16 +346,31 @@ describe("Homepage", () => {
       'Move the workflow story above "It\'s just Markdown."',
     );
     expect(storyboard.textContent).toContain(
+      "Show the agent pause, the review window, and the resume signal.",
+    );
+    expect(storyboard.textContent).toContain(
+      "Keep the format section as proof that the review data is portable Markdown.",
+    );
+    expect(storyboard.textContent).toContain(
       'This should go above "It\'s just Markdown."',
+    );
+    expect(storyboard.textContent).toContain(
+      "Can we make the example about homepage conversion?",
     );
     expect(storyboard.textContent).toContain(
       "Review an agent's plan before it starts coding.",
     );
+    expect(storyboard.textContent).toContain("Done Reviewing");
     expect(storyboard.textContent).toContain("Review complete");
     expect(storyboard.textContent).toContain(
       "Your agent can read the edited Markdown file now.",
     );
     expect(storyboard.textContent).toContain("I read your comments.");
+    expect(
+      [...storyboard.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Done Reviewing"),
+      ),
+    ).toBeUndefined();
   });
 
   it("renders the Roughdraft flavored Markdown spec page", async () => {

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -337,7 +337,7 @@ describe("Homepage", () => {
       'Move the workflow story above "It\'s just Markdown."',
     );
     expect(storyboard.textContent).toContain(
-      "This should go above \"It's just Markdown.\"",
+      'This should go above "It\'s just Markdown."',
     );
     expect(storyboard.textContent).toContain(
       "Review an agent's plan before it starts coding.",

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -277,7 +277,7 @@ describe("Homepage", () => {
     expect(document.body.textContent).toContain("Copied");
   });
 
-  it("explains the plan-review workflow with scrolling steps and a fixed visual", async () => {
+  it("explains the plan-review workflow with scrolling steps and a sticky visual", async () => {
     await renderHomepage(root);
 
     const text = container.textContent ?? "";
@@ -355,6 +355,18 @@ describe("Homepage", () => {
     ).toBe("true");
     expect(APP_STYLES).toMatch(
       /\.homepage-workflow-sticky-visual \{[^}]*position:\s*sticky;[^}]*top:\s*2rem;/s,
+    );
+    expect(APP_STYLES).toMatch(
+      /@media \(max-width:\s*899px\) \{[\s\S]*\.homepage-workflow-sticky-visual \{[^}]*position:\s*sticky;[^}]*top:\s*calc\([^}]*100svh[^}]*var\(--homepage-workflow-dock-height\)[^}]*var\(--homepage-workflow-dock-bottom\)[^}]*\);[^}]*bottom:\s*var\(--homepage-workflow-dock-bottom\);/s,
+    );
+    expect(APP_STYLES).toMatch(
+      /@media \(max-width:\s*899px\) \{[\s\S]*\.homepage-workflow-scene-list \{[^}]*padding-bottom:\s*calc\([^}]*var\(--homepage-workflow-dock-height\)[^}]*var\(--homepage-workflow-dock-bottom\)[^}]*\+\s*2rem[^}]*\);/s,
+    );
+    expect(APP_STYLES).toMatch(
+      /@media \(max-width:\s*899px\) \{[\s\S]*\.homepage-workflow-popup \{[^}]*--homepage-workflow-popup-overhang:\s*0rem;[^}]*right:\s*0\.5rem;[^}]*left:\s*0\.5rem;/s,
+    );
+    expect(APP_STYLES).toMatch(
+      /@media \(max-width:\s*899px\) \{[\s\S]*\.homepage-workflow-document-workspace \{[^}]*--homepage-workflow-document-offset-y:\s*clamp\(7rem,\s*15svh,\s*8rem\);/s,
     );
     expect(APP_STYLES).toMatch(
       /\.homepage-workflow-popup \{[^}]*position:\s*absolute;[^}]*bottom:\s*1rem;/s,


### PR DESCRIPTION
## Summary
Homepage visitors now get a guided "How it works" storyboard that shows the agent planning, opening Roughdraft, receiving review feedback, and resuming work before the Markdown format section. Mobile now keeps the mock workflow docked at the bottom of the storyboard without covering step copy or clipping the Roughdraft preview, while desktop keeps the two-column sticky layout. The branch also adds planning docs, browser coverage for desktop/mobile storyboard behavior, unit coverage for the CSS contract, and preserves the latest README CriticMarkup feedback.

## Test Plan
- `pnpm check`
- `pnpm test:e2e -- homepage-storyboard.spec.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
