### PR TITLE
feat: refine homepage review storyboard

### DIFF
--- a/packages/app/e2e/homepage-storyboard.spec.ts
+++ b/packages/app/e2e/homepage-storyboard.spec.ts
@@ -61,11 +61,22 @@ test.describe("homepage workflow storyboard", () => {
       pointerEvents: "none",
     });
 
+    const getDesktopActivationOffset = async () =>
+      storyboard
+        .getByTestId("homepage-workflow-terminal")
+        .evaluate((element) => element.getBoundingClientRect().top);
+
     await scenes.nth(1).evaluate((element) => {
       window.scrollTo({
-        top: element.getBoundingClientRect().top + window.scrollY - 1,
+        top: element.getBoundingClientRect().top + window.scrollY,
       });
     });
+    await page.evaluate(
+      (activationOffset) => {
+        window.scrollBy(0, -activationOffset - 1);
+      },
+      await getDesktopActivationOffset(),
+    );
     await expect(agentWorkTranscript).toHaveAttribute(
       "data-agent-work-visible",
       "false",
@@ -76,6 +87,12 @@ test.describe("homepage workflow storyboard", () => {
         top: element.getBoundingClientRect().top + window.scrollY,
       });
     });
+    await page.evaluate(
+      (activationOffset) => {
+        window.scrollBy(0, -activationOffset);
+      },
+      await getDesktopActivationOffset(),
+    );
     await expect(agentWorkTranscript).toHaveAttribute(
       "data-agent-work-visible",
       "true",
@@ -85,7 +102,10 @@ test.describe("homepage workflow storyboard", () => {
     );
     await expect(
       storyboard.getByTestId("homepage-workflow-terminal-tools"),
-    ).toContainText("Tool calls");
+    ).toContainText("Explored");
+    await expect(
+      storyboard.getByTestId("homepage-workflow-terminal-tools"),
+    ).toContainText('Search rg "It\'s just Markdown" packages/app/src');
     await expect(roughdraftPopup).toHaveAttribute(
       "data-popup-visible",
       "false",
@@ -157,6 +177,48 @@ test.describe("homepage workflow storyboard", () => {
     await expect(
       roughdraftPopup.getByTestId("homepage-workflow-review-comment"),
     ).toBeVisible();
+    await expect(
+      roughdraftPopup.getByTestId("homepage-workflow-review-rail"),
+    ).toContainText("Nora");
+    await expect(
+      roughdraftPopup.getByTestId("homepage-workflow-review-rail"),
+    ).not.toContainText("AI");
+    await expect(
+      roughdraftPopup.getByTestId("homepage-workflow-review-rail"),
+    ).toContainText('Replace: "agent\'s plan" with "homepage plan"');
+    await expect
+      .poll(async () =>
+        storyboard.evaluate((element) => {
+          const highlight = element.querySelector(
+            '[data-testid="homepage-workflow-comment-highlight"]',
+          );
+          const suggestion = element.querySelector(
+            '[data-testid="homepage-workflow-suggestion-old"]',
+          );
+          const threads = element.querySelectorAll(
+            ".homepage-workflow-review-thread",
+          );
+
+          if (!highlight || !suggestion || threads.length < 2) {
+            throw new Error("Expected review anchors and Nora review threads");
+          }
+
+          return Math.max(
+            Math.abs(
+              threads[0].getBoundingClientRect().top -
+                highlight.getBoundingClientRect().top,
+            ),
+            Math.abs(
+              threads[1].getBoundingClientRect().top -
+                suggestion.getBoundingClientRect().top,
+            ),
+          );
+        }),
+      )
+      .toBeLessThanOrEqual(8);
+    await expect(
+      storyboard.getByTestId("homepage-workflow-agent-resume"),
+    ).toHaveAttribute("data-terminal-line-visible", "false");
     const commentsLayout = await storyboard.evaluate((element) => {
       const popup = element.querySelector(
         '[data-testid="homepage-workflow-popup"]',
@@ -220,6 +282,33 @@ test.describe("homepage workflow storyboard", () => {
     expect(stickyLayout.stickyLeft).toBeGreaterThan(
       stickyLayout.sceneListRight,
     );
+
+    await scenes.nth(5).evaluate((element) => {
+      window.scrollTo({
+        top: element.getBoundingClientRect().top + window.scrollY,
+      });
+    });
+    await expect(
+      storyboard.getByTestId("homepage-workflow-handoff-button"),
+    ).toHaveCount(0);
+    await expect(
+      storyboard.getByTestId("homepage-workflow-agent-resume"),
+    ).toHaveAttribute("data-terminal-line-visible", "true");
+    await expect(storyboard).toContainText(
+      "I accepted your wording suggestion and moved the workflow story above the Markdown section.",
+    );
+    await expect(storyboard).toContainText(
+      "Review a homepage plan before it starts coding.",
+    );
+    await expect(
+      roughdraftPopup.getByTestId("homepage-workflow-review-comment"),
+    ).toBeVisible();
+    await expect(
+      roughdraftPopup.getByTestId("homepage-workflow-review-rail"),
+    ).toContainText('This should go above "It\'s just Markdown."');
+    await expect(
+      roughdraftPopup.getByTestId("homepage-workflow-review-rail"),
+    ).toContainText("Sounds good. I'll move it above that section.");
 
     const sceneLayout = await scenes.evaluateAll((elements) =>
       elements.map((element) => {
@@ -332,6 +421,11 @@ test.describe("homepage workflow storyboard", () => {
         sceneListPaddingBottom: Number.parseFloat(
           sceneListStyles.paddingBottom,
         ),
+        stickyMobileVisible: sticky.getAttribute(
+          "data-mobile-workflow-visible",
+        ),
+        stickyOpacity: stickyStyles.opacity,
+        stickyPointerEvents: stickyStyles.pointerEvents,
         stickyBottomGap: window.innerHeight - stickyRect.bottom,
         stickyHeight: stickyRect.height,
         stickyTop: stickyRect.top,
@@ -343,6 +437,9 @@ test.describe("homepage workflow storyboard", () => {
     });
 
     expect(layoutAtStart.position).toBe("sticky");
+    expect(layoutAtStart.stickyMobileVisible).toBe("false");
+    expect(layoutAtStart.stickyOpacity).toBe("0");
+    expect(layoutAtStart.stickyPointerEvents).toBe("none");
     expect(layoutAtStart.stickyBottomGap).toBeGreaterThanOrEqual(8);
     expect(layoutAtStart.stickyBottomGap).toBeLessThan(40);
     expect(layoutAtStart.stickyHeight).toBeGreaterThan(200);
@@ -358,8 +455,11 @@ test.describe("homepage workflow storyboard", () => {
     const stageLayouts: Array<{
       copyBottom: number;
       copyTop: number;
+      documentSurfaceGap: number | null;
       documentTitleBottom: number | null;
       documentTitleTop: number | null;
+      popupHeaderIsPaintedAboveDock: boolean | null;
+      popupHeaderTop: number | null;
       stage: number;
       stickyBottom: number;
       stickyTop: number;
@@ -394,6 +494,10 @@ test.describe("homepage workflow storyboard", () => {
       await expect(
         storyboard.getByTestId("homepage-workflow-terminal"),
       ).toHaveAttribute("data-homepage-workflow-terminal-stage", targetStage);
+      await expect(stickyVisual).toHaveAttribute(
+        "data-mobile-workflow-visible",
+        "true",
+      );
 
       stageLayouts.push(
         await scenes.nth(index).evaluate((element, stage) => {
@@ -406,20 +510,55 @@ test.describe("homepage workflow storyboard", () => {
           const documentTitle = document.querySelector(
             '[data-testid="homepage-workflow-document-title"]',
           );
-          if (!sticky || !sceneCopy || !documentTitle) {
+          const documentScale = document.querySelector(
+            '[data-testid="homepage-workflow-document-scale"]',
+          );
+          const documentWorkspace = document.querySelector(
+            '[data-testid="homepage-workflow-document-workspace"]',
+          );
+          const popupHeader = document.querySelector(
+            ".homepage-workflow-popup .homepage-workflow-panel-header",
+          );
+          if (
+            !sticky ||
+            !sceneCopy ||
+            !documentTitle ||
+            !documentScale ||
+            !documentWorkspace
+          ) {
             throw new Error(
-              "Expected sticky visual, scene copy, and document title",
+              "Expected sticky visual, scene copy, and document preview",
             );
           }
 
           const stickyRect = sticky.getBoundingClientRect();
           const copyRect = sceneCopy.getBoundingClientRect();
+          const scaleRect = documentScale.getBoundingClientRect();
           const titleRect = documentTitle.getBoundingClientRect();
+          const workspaceRect = documentWorkspace.getBoundingClientRect();
+          const popupHeaderRect = popupHeader?.getBoundingClientRect() ?? null;
+          const headerHitTarget = popupHeaderRect
+            ? document.elementFromPoint(
+                popupHeaderRect.left + popupHeaderRect.width / 2,
+                popupHeaderRect.top + popupHeaderRect.height / 2,
+              )
+            : null;
           return {
             copyBottom: copyRect.bottom,
             copyTop: copyRect.top,
+            documentSurfaceGap:
+              stage >= 3 ? scaleRect.top - workspaceRect.top : null,
             documentTitleBottom: stage >= 3 ? titleRect.bottom : null,
             documentTitleTop: stage >= 3 ? titleRect.top : null,
+            popupHeaderIsPaintedAboveDock:
+              stage >= 3 && popupHeaderRect
+                ? popupHeaderRect.top < stickyRect.top &&
+                  headerHitTarget?.closest(
+                    ".homepage-workflow-popup .homepage-workflow-panel-header",
+                  ) !== null
+                : null,
+            popupHeaderTop:
+              stage >= 3 && popupHeaderRect ? popupHeaderRect.top : null,
             stage,
             stickyBottom: stickyRect.bottom,
             stickyTop: stickyRect.top,
@@ -440,14 +579,15 @@ test.describe("homepage workflow storyboard", () => {
       if (
         stageLayout.stage >= 3 &&
         stageLayout.documentTitleTop !== null &&
-        stageLayout.documentTitleBottom !== null
+        stageLayout.documentTitleBottom !== null &&
+        stageLayout.documentSurfaceGap !== null
       ) {
-        expect(stageLayout.documentTitleTop).toBeGreaterThanOrEqual(
-          stageLayout.stickyTop + 8,
-        );
         expect(stageLayout.documentTitleBottom).toBeLessThanOrEqual(
           stageLayout.stickyBottom - 8,
         );
+        expect(stageLayout.documentSurfaceGap).toBeLessThanOrEqual(72);
+        expect(stageLayout.popupHeaderTop).toBeLessThan(stageLayout.stickyTop);
+        expect(stageLayout.popupHeaderIsPaintedAboveDock).toBe(true);
       }
     }
 

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -2,7 +2,6 @@ import {
   ArrowLeft,
   Braces,
   Check,
-  Code2,
   CodeXml,
   Copy,
   Eye,
@@ -12,7 +11,15 @@ import {
   PencilLine,
   Terminal,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  type Ref,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   buildLocationForDocumentEditorViewMode,
   type DocumentEditorViewMode,
@@ -36,6 +43,12 @@ import {
   DialogTrigger,
 } from "./components/ui/dialog";
 import { DocumentWorkspace } from "./DocumentWorkspace";
+import {
+  getCommentAnchorMeasurements,
+  groupCommentAnchorMeasurements,
+  normalizeCommentMeasurement,
+  resolveAnchoredRailLayouts,
+} from "./document-comments";
 import { detectBackend } from "./detect-backend";
 import type { DocumentSaveState } from "./PageCard";
 import { PreviewBackend } from "./preview-backend";
@@ -124,7 +137,7 @@ const HOMEPAGE_WORKFLOW_SCENES = [
     step: "06",
     title: "The agent resumes",
     description:
-      "The next agent turn reads the same Markdown file, sees your comments, and continues with the corrected plan.",
+      "The next agent turn reads the same Markdown file, sees your comments and suggestions, and continues with the corrected plan.",
   },
 ] as const;
 const ROUGHDRAFT_MARKDOWN_SYNTAX = [
@@ -219,6 +232,42 @@ const ROUGHDRAFT_MARKDOWN_EXTENSION_DETAILS = [
     body: "CriticMarkup inside inline code and fenced code blocks is preserved as example text instead of becoming live review feedback.",
   },
 ] as const;
+const HOMEPAGE_WORKFLOW_REVIEW_ITEMS = [
+  {
+    key: "nora-comment",
+    commentIds: ["nora-comment"],
+    author: "Nora",
+    body: 'This should go above "It\'s just Markdown."',
+    kind: "comment",
+    replies: [
+      {
+        author: "AI",
+        body: "Sounds good. I'll move it above that section.",
+      },
+    ],
+  },
+  {
+    key: "nora-suggestion",
+    commentIds: ["nora-suggestion"],
+    author: "Nora",
+    body: 'Replace: "agent\'s plan" with "homepage plan"',
+    kind: "suggestion",
+    replies: [],
+  },
+] as const;
+
+function getHomepageWorkflowDocumentScale(element: HTMLElement | null) {
+  const scaleElement = element?.closest<HTMLElement>(
+    ".homepage-workflow-document-scale",
+  );
+  const scaleTransform = scaleElement
+    ? window.getComputedStyle(scaleElement).transform
+    : "none";
+  const matrix =
+    scaleTransform === "none" ? null : new DOMMatrixReadOnly(scaleTransform);
+
+  return matrix?.a || 1;
+}
 
 export function Homepage({
   message,
@@ -231,8 +280,12 @@ export function Homepage({
     "idle",
   );
   const workflowStepRefs = useRef<Record<string, HTMLLIElement | null>>({});
+  const workflowIntroRef = useRef<HTMLDivElement | null>(null);
   const workflowStickyVisualRef = useRef<HTMLDivElement | null>(null);
+  const workflowTerminalRef = useRef<HTMLDivElement | null>(null);
   const [homepageWorkflowStage, setHomepageWorkflowStage] = useState(1);
+  const [mobileWorkflowVisualVisible, setMobileWorkflowVisualVisible] =
+    useState(false);
 
   const handleCopySetupPrompt = useCallback(async () => {
     try {
@@ -246,22 +299,35 @@ export function Homepage({
 
   useEffect(() => {
     const updateHomepageWorkflowStage = () => {
+      const isMobileStoryboard =
+        typeof window.matchMedia === "function" &&
+        window.matchMedia("(max-width: 899px)").matches;
+      const workflowIntroRect =
+        workflowIntroRef.current?.getBoundingClientRect();
+      const nextMobileWorkflowVisualVisible =
+        !isMobileStoryboard ||
+        (workflowIntroRect ? workflowIntroRect.bottom <= 0 : false);
+
+      setMobileWorkflowVisualVisible((current) =>
+        current === nextMobileWorkflowVisualVisible
+          ? current
+          : nextMobileWorkflowVisualVisible,
+      );
+
       const pageCanScroll =
         document.documentElement.scrollHeight > window.innerHeight + 1;
       if (!pageCanScroll) return;
 
       const stickyVisualRect =
         workflowStickyVisualRef.current?.getBoundingClientRect();
-      const isMobileStoryboard =
-        typeof window.matchMedia === "function" &&
-        window.matchMedia("(max-width: 899px)").matches;
+      const terminalRect = workflowTerminalRef.current?.getBoundingClientRect();
       const mobileReadableOffset = stickyVisualRect
         ? Math.min(stickyVisualRect.height + 32, window.innerHeight * 0.35)
         : 0;
       const activationLine =
         isMobileStoryboard && stickyVisualRect
           ? Math.max(0, Math.ceil(stickyVisualRect.top - mobileReadableOffset))
-          : 0;
+          : (terminalRect?.top ?? 0);
 
       let nextStage = 1;
       for (const [step, element] of Object.entries(workflowStepRefs.current)) {
@@ -417,7 +483,7 @@ export function Homepage({
           data-homepage-workflow-storyboard=""
           data-testid="homepage-workflow-storyboard"
         >
-          <div className="homepage-workflow-intro">
+          <div className="homepage-workflow-intro" ref={workflowIntroRef}>
             <h2
               className="text-center text-4xl leading-tight font-semibold text-balance text-slate-950 dark:text-slate-50 sm:text-5xl"
               id="homepage-workflow-heading"
@@ -431,11 +497,15 @@ export function Homepage({
             <div
               className="homepage-workflow-sticky-visual"
               data-homepage-workflow-sticky-visual=""
+              data-mobile-workflow-visible={
+                mobileWorkflowVisualVisible ? "true" : "false"
+              }
               data-testid="homepage-workflow-sticky-visual"
               ref={workflowStickyVisualRef}
             >
               <HomepageWorkflowComposite
                 workflowStage={homepageWorkflowStage}
+                terminalRef={workflowTerminalRef}
               />
             </div>
 
@@ -496,19 +566,27 @@ function HomepageWorkflowScene({
 }
 
 function HomepageWorkflowComposite({
+  terminalRef,
   workflowStage,
 }: {
+  terminalRef?: Ref<HTMLDivElement>;
   workflowStage: number;
 }) {
   return (
     <div className="homepage-workflow-composite">
-      <AgentChatMock workflowStage={workflowStage} />
+      <AgentChatMock terminalRef={terminalRef} workflowStage={workflowStage} />
       <RoughdraftPopupMock workflowStage={workflowStage} />
     </div>
   );
 }
 
-function AgentChatMock({ workflowStage }: { workflowStage: number }) {
+function AgentChatMock({
+  terminalRef,
+  workflowStage,
+}: {
+  terminalRef?: Ref<HTMLDivElement>;
+  workflowStage: number;
+}) {
   const showAgentWork = workflowStage >= 2;
   const showRoughdraftCommand = workflowStage >= 3;
   const showAgentResume = workflowStage >= 6;
@@ -518,6 +596,7 @@ function AgentChatMock({ workflowStage }: { workflowStage: number }) {
       className="homepage-workflow-terminal homepage-workflow-chat"
       data-homepage-workflow-terminal-stage={workflowStage}
       data-testid="homepage-workflow-terminal"
+      ref={terminalRef}
     >
       <div className="homepage-workflow-terminal-titlebar">
         <div className="flex items-center gap-1.5" aria-hidden="true">
@@ -562,13 +641,50 @@ function AgentChatMock({ workflowStage }: { workflowStage: number }) {
             className="homepage-workflow-terminal-tools homepage-workflow-stream-item homepage-workflow-stream-item-delay-long"
             data-testid="homepage-workflow-terminal-tools"
           >
-            <div className="mb-2 flex items-center gap-1.5 font-medium text-slate-200">
-              <Code2 className="size-3.5" aria-hidden="true" />
-              Tool calls
+            <div className="homepage-workflow-terminal-tools-heading">
+              <span aria-hidden="true">•</span>
+              <span>Explored</span>
             </div>
-            <div>rg "It's just Markdown" packages/app/src</div>
-            <div>sed -n '1,220p' packages/app/src/App.tsx</div>
-            <div>write .context/homepage-conversion-plan.md</div>
+            <div className="homepage-workflow-terminal-tool-list">
+              <div className="homepage-workflow-terminal-tool-row">
+                <span
+                  className="homepage-workflow-terminal-tool-branch"
+                  aria-hidden="true"
+                >
+                  └
+                </span>
+                <span>
+                  <span className="homepage-workflow-terminal-tool-action">
+                    Search
+                  </span>{" "}
+                  rg "It's just Markdown" packages/app/src
+                </span>
+              </div>
+              <div className="homepage-workflow-terminal-tool-row">
+                <span
+                  className="homepage-workflow-terminal-tool-branch"
+                  aria-hidden="true"
+                />
+                <span>
+                  <span className="homepage-workflow-terminal-tool-action">
+                    Read
+                  </span>{" "}
+                  sed -n '1,220p' packages/app/src/App.tsx
+                </span>
+              </div>
+              <div className="homepage-workflow-terminal-tool-row">
+                <span
+                  className="homepage-workflow-terminal-tool-branch"
+                  aria-hidden="true"
+                />
+                <span>
+                  <span className="homepage-workflow-terminal-tool-action">
+                    Write
+                  </span>{" "}
+                  .context/homepage-conversion-plan.md
+                </span>
+              </div>
+            </div>
           </div>
         </div>
 
@@ -590,8 +706,8 @@ function AgentChatMock({ workflowStage }: { workflowStage: number }) {
         >
           <span className="mt-1 size-2 shrink-0 rounded-full bg-emerald-300" />
           <span>
-            I read your comments. I'll move the workflow storyboard above the
-            Markdown section and use the homepage conversion example.
+            I read your comments. I accepted your wording suggestion and moved
+            the workflow story above the Markdown section.
           </span>
         </div>
 
@@ -614,8 +730,175 @@ function AgentChatMock({ workflowStage }: { workflowStage: number }) {
 
 function RoughdraftPopupMock({ workflowStage }: { workflowStage: number }) {
   const visible = workflowStage >= 3;
-  const showReviewMarkup = workflowStage >= 4;
-  const showDoneButton = workflowStage >= 5;
+  const showUserFeedback = workflowStage >= 4;
+  const showAgentReply = workflowStage >= 6;
+  const showIncorporatedPlan = workflowStage >= 6;
+  const showDoneButton = workflowStage >= 5 && workflowStage < 6;
+  const documentShellRef = useRef<HTMLDivElement | null>(null);
+  const documentPageRef = useRef<HTMLDivElement | null>(null);
+  const reviewRailRef = useRef<HTMLDivElement | null>(null);
+  const threadRefs = useRef(new Map<string, HTMLDivElement>());
+  const [commentAnchorGroups, setCommentAnchorGroups] = useState<
+    Array<{
+      key: string;
+      commentIds: string[];
+      anchorTop: number;
+      anchorBottom: number;
+    }>
+  >([]);
+  const [threadHeights, setThreadHeights] = useState<Record<string, number>>(
+    {},
+  );
+
+  const measureHomepageReviewLayout = useCallback(() => {
+    const shellElement = documentShellRef.current;
+    const pageElement = documentPageRef.current;
+    const railElement = reviewRailRef.current;
+
+    if (!showUserFeedback || !shellElement || !pageElement || !railElement) {
+      setCommentAnchorGroups([]);
+      return;
+    }
+
+    const railRect = railElement.getBoundingClientRect();
+    const measurementScale = getHomepageWorkflowDocumentScale(shellElement);
+    const anchorElements =
+      pageElement.querySelectorAll<HTMLElement>("[data-comment-ids]");
+
+    setCommentAnchorGroups(
+      groupCommentAnchorMeasurements(
+        getCommentAnchorMeasurements(
+          anchorElements,
+          railRect.top,
+          measurementScale,
+        ),
+      ),
+    );
+  }, [showUserFeedback]);
+
+  useLayoutEffect(() => {
+    measureHomepageReviewLayout();
+
+    if (!showUserFeedback) return;
+
+    const shellElement = documentShellRef.current;
+    const pageElement = documentPageRef.current;
+    const railElement = reviewRailRef.current;
+    if (!shellElement || !pageElement || !railElement) return;
+
+    const resizeObserver = new ResizeObserver(() => {
+      measureHomepageReviewLayout();
+    });
+
+    resizeObserver.observe(shellElement);
+    resizeObserver.observe(pageElement);
+    resizeObserver.observe(railElement);
+    window.addEventListener("resize", measureHomepageReviewLayout);
+
+    if (document.fonts) {
+      void document.fonts.ready.then(measureHomepageReviewLayout);
+    }
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener("resize", measureHomepageReviewLayout);
+    };
+  }, [measureHomepageReviewLayout, showUserFeedback]);
+
+  const setThreadRef = useCallback(
+    (key: string, node: HTMLDivElement | null) => {
+      if (node) {
+        threadRefs.current.set(key, node);
+      } else {
+        threadRefs.current.delete(key);
+      }
+    },
+    [],
+  );
+
+  useLayoutEffect(() => {
+    if (!showUserFeedback) {
+      setThreadHeights({});
+      return;
+    }
+
+    const updateThreadHeights = () => {
+      const measurementScale = getHomepageWorkflowDocumentScale(
+        documentShellRef.current,
+      );
+
+      setThreadHeights((current) => {
+        const next: Record<string, number> = {};
+        let changed = false;
+
+        for (const item of HOMEPAGE_WORKFLOW_REVIEW_ITEMS) {
+          const element = threadRefs.current.get(item.key);
+          const measuredHeight = Math.ceil(
+            element?.getBoundingClientRect().height ?? 0,
+          );
+          const height =
+            measuredHeight > 0
+              ? Math.ceil(
+                  normalizeCommentMeasurement(measuredHeight, measurementScale),
+                )
+              : (current[item.key] ?? 0);
+          next[item.key] = height;
+          changed ||= current[item.key] !== height;
+        }
+
+        if (
+          !changed &&
+          Object.keys(current).length === Object.keys(next).length
+        ) {
+          return current;
+        }
+
+        return next;
+      });
+    };
+
+    updateThreadHeights();
+
+    const resizeObserver = new ResizeObserver(() => {
+      updateThreadHeights();
+    });
+
+    for (const item of HOMEPAGE_WORKFLOW_REVIEW_ITEMS) {
+      const element = threadRefs.current.get(item.key);
+      if (element) resizeObserver.observe(element);
+    }
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [showUserFeedback]);
+
+  const reviewLayouts = useMemo(() => {
+    const railItems = HOMEPAGE_WORKFLOW_REVIEW_ITEMS.map((item) => {
+      const anchorGroup = commentAnchorGroups.find((group) =>
+        item.commentIds.every((commentId) =>
+          group.commentIds.includes(commentId),
+        ),
+      );
+
+      if (!anchorGroup) return null;
+
+      return {
+        ...item,
+        anchorTop: anchorGroup.anchorTop,
+        anchorBottom: anchorGroup.anchorBottom,
+      };
+    }).filter(
+      (
+        item,
+      ): item is (typeof HOMEPAGE_WORKFLOW_REVIEW_ITEMS)[number] & {
+        anchorTop: number;
+        anchorBottom: number;
+      } => Boolean(item),
+    );
+
+    return resolveAnchoredRailLayouts(railItems, threadHeights, null, 14, 72);
+  }, [commentAnchorGroups, threadHeights]);
 
   return (
     <div
@@ -632,7 +915,7 @@ function RoughdraftPopupMock({ workflowStage }: { workflowStage: number }) {
       <div
         className="homepage-workflow-document-workspace"
         data-homepage-workflow-review-visible={
-          showReviewMarkup ? "true" : "false"
+          showUserFeedback ? "true" : "false"
         }
         data-testid="homepage-workflow-document-workspace"
       >
@@ -653,15 +936,16 @@ function RoughdraftPopupMock({ workflowStage }: { workflowStage: number }) {
           ) : null}
           <div
             className={`homepage-workflow-document-shell ${
-              showReviewMarkup
+              showUserFeedback
                 ? "homepage-workflow-document-shell-with-comments"
                 : "homepage-workflow-document-shell-no-comments"
             }`}
             data-testid={
-              showReviewMarkup
+              showUserFeedback
                 ? "homepage-workflow-document-shell-with-comments"
                 : "homepage-workflow-document-shell-no-comments"
             }
+            ref={documentShellRef}
           >
             <div className="homepage-workflow-document-main">
               <div className="homepage-workflow-document-toolbar">
@@ -685,16 +969,20 @@ function RoughdraftPopupMock({ workflowStage }: { workflowStage: number }) {
                   editing
                 </span>
               </div>
-              <div className="homepage-workflow-document-page">
+              <div
+                className="homepage-workflow-document-page"
+                ref={documentPageRef}
+              >
                 <p className="homepage-workflow-doc-kicker">Roughdraft</p>
                 <h3 data-testid="homepage-workflow-document-title">
                   Homepage Conversion Plan
                 </h3>
                 <p>
                   Move the workflow story above{" "}
-                  {showReviewMarkup ? (
+                  {showUserFeedback ? (
                     <span
                       className="homepage-workflow-comment-highlight"
+                      data-comment-ids='["nora-comment"]'
                       data-testid="homepage-workflow-comment-highlight"
                     >
                       "It's just Markdown."
@@ -711,52 +999,91 @@ function RoughdraftPopupMock({ workflowStage }: { workflowStage: number }) {
                   Keep the format section as proof that the review data is
                   portable Markdown.
                 </p>
-                {showReviewMarkup ? (
+                {showUserFeedback ? (
                   <p>
                     <span
                       className="homepage-workflow-suggestion-old"
+                      data-comment-ids='["nora-suggestion"]'
                       data-testid="homepage-workflow-suggestion-old"
                     >
                       Review an agent's plan
                     </span>{" "}
                     <span
                       className="homepage-workflow-suggestion-new"
+                      data-comment-ids='["nora-suggestion"]'
                       data-testid="homepage-workflow-suggestion-new"
                     >
                       Review a homepage plan
                     </span>{" "}
                     before it starts coding.
                   </p>
+                ) : showIncorporatedPlan ? (
+                  <p>Review a homepage plan before it starts coding.</p>
                 ) : (
                   <p>Review an agent's plan before it starts coding.</p>
                 )}
               </div>
             </div>
-            {showReviewMarkup ? (
+            {showUserFeedback ? (
               <div
                 className="homepage-workflow-review-rail"
                 data-testid="homepage-workflow-review-rail"
+                ref={reviewRailRef}
               >
-                <div className="homepage-workflow-review-thread">
-                  <div className="homepage-workflow-review-avatar">N</div>
-                  <div>
-                    <div className="homepage-workflow-review-author">Nora</div>
-                    <p data-testid="homepage-workflow-review-comment">
-                      This should go above "It's just Markdown."
-                    </p>
-                  </div>
-                </div>
-                <div className="homepage-workflow-review-thread homepage-workflow-review-thread-ai">
-                  <div className="homepage-workflow-review-avatar">AI</div>
-                  <div>
-                    <div className="homepage-workflow-review-author">AI</div>
-                    <p>Replace: "agent's plan" with "homepage plan"</p>
-                    <div className="homepage-workflow-review-actions">
-                      <Check className="size-3.5" aria-hidden="true" />
-                      <span aria-hidden="true">×</span>
+                {HOMEPAGE_WORKFLOW_REVIEW_ITEMS.map((item) => {
+                  const layout = reviewLayouts.find(
+                    (reviewLayout) => reviewLayout.key === item.key,
+                  );
+
+                  return (
+                    <div
+                      className="homepage-workflow-review-thread"
+                      key={item.key}
+                      ref={(node) => setThreadRef(item.key, node)}
+                      style={layout ? { top: layout.railTop } : undefined}
+                    >
+                      <div className="homepage-workflow-review-avatar">N</div>
+                      <div>
+                        <div className="homepage-workflow-review-author">
+                          {item.author}
+                        </div>
+                        <p
+                          data-testid={
+                            item.kind === "comment"
+                              ? "homepage-workflow-review-comment"
+                              : undefined
+                          }
+                        >
+                          {item.body}
+                        </p>
+                        {showAgentReply
+                          ? item.replies?.map((reply) => (
+                              <div
+                                className="homepage-workflow-review-reply homepage-workflow-review-thread-ai"
+                                key={`${item.key}-${reply.author}`}
+                              >
+                                <div className="homepage-workflow-review-avatar">
+                                  {reply.author}
+                                </div>
+                                <div>
+                                  <div className="homepage-workflow-review-author">
+                                    {reply.author}
+                                  </div>
+                                  <p>{reply.body}</p>
+                                </div>
+                              </div>
+                            ))
+                          : null}
+                        {item.kind === "suggestion" ? (
+                          <div className="homepage-workflow-review-actions">
+                            <Check className="size-3.5" aria-hidden="true" />
+                            <span aria-hidden="true">×</span>
+                          </div>
+                        ) : null}
+                      </div>
                     </div>
-                  </div>
-                </div>
+                  );
+                })}
               </div>
             ) : null}
           </div>

--- a/packages/app/src/RoughdraftFormatDemo.tsx
+++ b/packages/app/src/RoughdraftFormatDemo.tsx
@@ -13,16 +13,16 @@ interface FormatExample {
 
 const FORMAT_EXAMPLES: FormatExample[] = [
   {
+    id: "plan-review",
+    label: "Review a plan",
+    markdown:
+      '# Homepage Conversion Plan\nGoal: make the homepage workflow story and Markdown proof feel like one continuous example.\n\nMove the workflow story above {=="It\'s just Markdown."==}{>>This should go above "It\'s just Markdown."<<}{id="c1" by="Nora" at="2026-04-28T12:10:00.000Z"}{>>Sounds good. I\'ll move it above that section.<<}{id="c2" by="AI" at="2026-04-28T12:11:00.000Z" re="c1"}\n\n{~~Review an agent\'s plan~>Review a homepage plan~~}{id="s1" by="Nora" at="2026-04-28T12:12:00.000Z"} before it starts coding.\n\nKeep the format section as proof that the review data is portable Markdown.\n',
+  },
+  {
     id: "spec-review",
     label: "Review a spec",
     markdown:
       '# Checkout Spec Review\nGoal: reduce trial checkout abandonment by 8%. Scope: ship {==guest checkout for returning teams==}{>>PM: confirm whether this excludes SSO-only workspaces.<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z"} in the first beta.\n\nMetric: replace {~~activation~>first successful team purchase~~}{id="s1" by="user" at="2026-04-28T12:03:00.000Z"} before engineering sizing.\n',
-  },
-  {
-    id: "plan-review",
-    label: "Review a plan",
-    markdown:
-      '# Agent Plan Review\nPlan: scaffold the settings page, wire save/load through `settings.ts`, then {==run the full suite after styling==}{>>Can we add the failing state test before implementation so the agent has a guardrail?<<}{id="c1" by="user" at="2026-04-28T12:10:00.000Z"}.\n\nAdd {++a rollback note for the migration step++}{id="s1" by="user" at="2026-04-28T12:12:00.000Z"}{>>I want to keep this easy to undo if the vibe pass gets messy.<<}{id="c2" by="user" at="2026-04-28T12:13:00.000Z" re="s1"} before implementation starts.\n',
   },
   {
     id: "writing-edit",

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -770,16 +770,56 @@
   .homepage-workflow-terminal-tools,
   .homepage-workflow-terminal-command {
     margin: 0 1rem;
-    border: 1px solid rgb(148 163 184 / 20%);
-    border-radius: 0.5rem;
-    background-color: rgb(15 23 42 / 32%);
-    padding: 0.75rem;
     color: rgb(203 213 225);
     font-size: 0.75rem;
     line-height: 1.55;
   }
 
+  .homepage-workflow-terminal-tools {
+    display: grid;
+    gap: 0.25rem;
+  }
+
+  .homepage-workflow-terminal-tools-heading {
+    display: flex;
+    gap: 0.75rem;
+    color: rgb(248 250 252);
+    font-weight: 700;
+  }
+
+  .homepage-workflow-terminal-tool-list {
+    display: grid;
+    gap: 0.125rem;
+    padding-left: 1.55rem;
+    padding-right: 0.25rem;
+  }
+
+  .homepage-workflow-terminal-tool-row {
+    display: grid;
+    grid-template-columns: 0.8rem minmax(0, 1fr);
+    column-gap: 0.35rem;
+    color: rgb(248 250 252);
+    overflow-wrap: anywhere;
+  }
+
+  .homepage-workflow-terminal-tool-row > span:last-child {
+    min-width: 0;
+  }
+
+  .homepage-workflow-terminal-tool-branch {
+    color: rgb(156 163 175);
+    font-weight: 700;
+  }
+
+  .homepage-workflow-terminal-tool-action {
+    color: rgb(125 211 208);
+  }
+
   .homepage-workflow-terminal-command {
+    border: 1px solid rgb(148 163 184 / 20%);
+    border-radius: 0.5rem;
+    background-color: rgb(15 23 42 / 32%);
+    padding: 0.75rem;
     color: rgb(248 250 252);
   }
 
@@ -1081,17 +1121,21 @@
   }
 
   .homepage-workflow-review-rail {
-    display: grid;
-    gap: 1.25rem;
+    position: relative;
     min-width: 0;
+    min-height: 25rem;
     color: rgb(51 65 85);
   }
 
   .homepage-workflow-review-thread {
+    position: absolute;
+    right: 0;
+    left: 0;
     display: grid;
     grid-template-columns: 2rem minmax(0, 1fr);
     gap: 0.75rem;
     align-items: start;
+    transition: top 180ms ease;
   }
 
   .homepage-workflow-review-avatar {
@@ -1126,6 +1170,26 @@
     color: rgb(51 65 85);
     font-size: 0.8rem;
     line-height: 1.65;
+  }
+
+  .homepage-workflow-review-reply {
+    display: grid;
+    grid-template-columns: 1.65rem minmax(0, 1fr);
+    gap: 0.6rem;
+    margin-top: 0.8rem;
+    padding-top: 0.8rem;
+    border-top: 1px solid rgb(231 229 228);
+  }
+
+  .homepage-workflow-review-reply .homepage-workflow-review-avatar {
+    height: 1.65rem;
+    width: 1.65rem;
+    font-size: 0.62rem;
+  }
+
+  .homepage-workflow-review-reply .homepage-workflow-review-author {
+    margin-bottom: 0.15rem;
+    font-size: 0.76rem;
   }
 
   .homepage-workflow-review-actions {
@@ -1265,9 +1329,16 @@
       height: var(--homepage-workflow-dock-height);
       min-height: 0;
       align-items: flex-end;
-      overflow: hidden;
+      overflow: visible;
       border-radius: 0.65rem;
       box-shadow: 0 18px 48px rgb(15 23 42 / 16%);
+      opacity: 1;
+      transition: opacity 180ms ease;
+    }
+
+    .homepage-workflow-sticky-visual[data-mobile-workflow-visible="false"] {
+      pointer-events: none;
+      opacity: 0;
     }
 
     .homepage-workflow-sticky-visual .homepage-workflow-composite {
@@ -1331,8 +1402,15 @@
     .homepage-workflow-terminal-command {
       margin-left: 0.75rem;
       margin-right: 0.75rem;
-      padding: 0.5rem;
       font-size: 0.66rem;
+    }
+
+    .homepage-workflow-terminal-command {
+      padding: 0.5rem;
+    }
+
+    .homepage-workflow-terminal-tool-list {
+      padding-left: 1.35rem;
     }
 
     .homepage-workflow-popup {
@@ -1345,7 +1423,7 @@
 
     .homepage-workflow-document-workspace {
       --homepage-workflow-document-scale: 0.66;
-      --homepage-workflow-document-offset-y: clamp(7rem, 15svh, 8rem);
+      --homepage-workflow-document-offset-y: clamp(1rem, 5svh, 2.75rem);
 
       min-height: 14.5rem;
       padding: 0.625rem;
@@ -1384,7 +1462,7 @@
 
     .homepage-workflow-document-workspace {
       --homepage-workflow-document-scale: 0.6;
-      --homepage-workflow-document-offset-y: clamp(7rem, 15svh, 8rem);
+      --homepage-workflow-document-offset-y: clamp(1rem, 5svh, 2.75rem);
 
       padding: 0.75rem;
     }
@@ -1426,31 +1504,78 @@
   }
 
   .rfm-source-page {
+    position: relative;
+    display: flex;
+    flex-direction: column;
     overflow: hidden;
     margin: 1rem;
     min-height: calc(70vh + 7rem);
-    border: 1px solid #e9e9e8;
-    border-radius: 0.75rem;
-    background-color: #fff;
-    box-shadow: 0 18px 44px rgb(57 47 38 / 8%);
+    border: 1px solid rgb(15 23 42 / 72%);
+    border-radius: 0.5rem;
+    background-color: rgb(31 35 43);
+    box-shadow: 0 20px 48px rgb(15 23 42 / 16%);
+    color: rgb(248 250 252);
+  }
+
+  .rfm-source-page::before {
+    content: "markdown source";
+    display: flex;
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    min-height: 2.5rem;
+    align-items: center;
+    border-bottom: 1px solid rgb(148 163 184 / 20%);
+    padding: 0 0.875rem 0 4.5rem;
+    color: rgb(203 213 225);
+    font-family:
+      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+      "Courier New", monospace;
+    font-size: 0.75rem;
+    font-weight: 700;
+  }
+
+  .rfm-source-page::after {
+    content: "";
+    position: absolute;
+    top: 0.925rem;
+    left: 0.875rem;
+    height: 0.65rem;
+    width: 0.65rem;
+    border-radius: 999px;
+    background-color: rgb(244 63 94);
+    box-shadow:
+      1rem 0 0 rgb(251 191 36),
+      2rem 0 0 rgb(16 185 129);
+  }
+
+  .rfm-source-page:focus-within {
+    box-shadow:
+      0 20px 48px rgb(15 23 42 / 16%),
+      0 0 0 2px rgb(56 189 248 / 18%);
   }
 
   .dark .rfm-source-page {
-    border-color: rgb(51 65 85);
-    background-color: var(--card);
+    border-color: rgb(15 23 42 / 72%);
+    background-color: rgb(31 35 43);
     box-shadow: 0 18px 44px rgb(0 0 0 / 35%);
   }
 
   .rfm-source-editor {
-    color: rgb(15 23 42);
+    flex: 1;
+    min-height: 0;
+    padding-top: 2.5rem;
+    color: rgb(226 232 240);
+    --cm-selection-bg: rgb(30 58 138 / 0.45);
   }
 
   .rfm-source-editor .cm-editor {
-    min-height: calc(70vh + 7rem);
+    min-height: calc(70vh + 4.5rem);
   }
 
   .rfm-source-editor .cm-scroller {
-    max-height: 30rem;
+    min-height: calc(70vh + 4.5rem);
   }
 
   .rfm-source-editor .cm-content {
@@ -1462,7 +1587,21 @@
     padding: 0;
   }
 
-  .dark .rfm-source-editor {
+  .rfm-source-editor .cm-content,
+  .rfm-source-editor .cm-line {
+    caret-color: rgb(226 232 240);
+  }
+
+  .rfm-source-editor .cm-cursor,
+  .rfm-source-editor .cm-dropCursor {
+    border-left-color: rgb(226 232 240);
+  }
+
+  .rfm-source-editor .cm-gutters {
+    color: rgb(148 163 184);
+  }
+
+  .rfm-source-editor .cm-activeLineGutter {
     color: rgb(226 232 240);
   }
 

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -142,6 +142,7 @@ describe("Homepage", () => {
     });
     container.remove();
     document.body.innerHTML = "";
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -169,11 +170,11 @@ describe("Homepage", () => {
     expect(container.textContent).toContain(
       "working with other major Markdown apps to rally support",
     );
-    expect(container.textContent).toContain("# Checkout Spec Review");
+    expect(container.textContent).toContain("# Homepage Conversion Plan");
     expect(container.textContent).toContain(
-      "PM: confirm whether this excludes SSO-only workspaces.",
+      'This should go above "It\'s just Markdown."',
     );
-    expect(container.textContent).toContain("first successful team purchase");
+    expect(container.textContent).toContain("Review a homepage plan");
     expect(container.textContent).toContain("Review a spec");
     expect(container.textContent).toContain("Review a plan");
     expect(container.textContent).toContain("Edit writing");
@@ -204,7 +205,13 @@ describe("Homepage", () => {
       /\.rfm-source-pane \.rfm-demo-pane-header \{[^}]*justify-content:\s*flex-end;/s,
     );
     expect(APP_STYLES).toMatch(
-      /\.rfm-source-page \{[^}]*margin:\s*1rem;[^}]*min-height:\s*calc\(70vh \+ 7rem\);[^}]*border:\s*1px solid #e9e9e8;[^}]*border-radius:\s*0\.75rem;[^}]*background-color:\s*#fff;[^}]*box-shadow:\s*0 18px 44px rgb\(57 47 38 \/ 8%\);/s,
+      /\.rfm-source-page \{[^}]*margin:\s*1rem;[^}]*min-height:\s*calc\(70vh \+ 7rem\);[^}]*border:\s*1px solid rgb\(15 23 42 \/ 72%\);[^}]*border-radius:\s*0\.5rem;[^}]*background-color:\s*rgb\(31 35 43\);[^}]*box-shadow:\s*0 20px 48px rgb\(15 23 42 \/ 16%\);[^}]*color:\s*rgb\(248 250 252\);/s,
+    );
+    expect(APP_STYLES).toMatch(
+      /\.rfm-source-page::before \{[^}]*content:\s*"markdown source";[^}]*min-height:\s*2\.5rem;[^}]*border-bottom:\s*1px solid rgb\(148 163 184 \/ 20%\);/s,
+    );
+    expect(APP_STYLES).toMatch(
+      /\.rfm-source-editor \{[^}]*padding-top:\s*2\.5rem;[^}]*color:\s*rgb\(226 232 240\);[^}]*--cm-selection-bg:\s*rgb\(30 58 138 \/ 0\.45\);/s,
     );
     const resultDocumentCard = getByTestId(
       container,
@@ -253,11 +260,13 @@ describe("Homepage", () => {
 
     await click(planReviewButton);
 
-    expect(container.textContent).toContain("Agent Plan Review");
+    expect(container.textContent).toContain("Homepage Conversion Plan");
     expect(container.textContent).toContain(
-      "rollback note for the migration step",
+      "Keep the format section as proof that the review data is portable Markdown.",
     );
-    expect(container.textContent).toContain('re="s1"');
+    expect(container.textContent).toContain(
+      "Sounds good. I'll move it above that section.",
+    );
 
     await click(cta);
 
@@ -316,6 +325,9 @@ describe("Homepage", () => {
       "homepage-workflow-sticky-visual",
     );
     expect(stickyVisual).not.toBeNull();
+    expect(stickyVisual.getAttribute("data-mobile-workflow-visible")).toBe(
+      "true",
+    );
     expect(
       storyboard.querySelectorAll('[data-testid="homepage-workflow-terminal"]'),
     ).toHaveLength(1);
@@ -360,13 +372,16 @@ describe("Homepage", () => {
       /@media \(max-width:\s*899px\) \{[\s\S]*\.homepage-workflow-sticky-visual \{[^}]*position:\s*sticky;[^}]*top:\s*calc\([^}]*100svh[^}]*var\(--homepage-workflow-dock-height\)[^}]*var\(--homepage-workflow-dock-bottom\)[^}]*\);[^}]*bottom:\s*var\(--homepage-workflow-dock-bottom\);/s,
     );
     expect(APP_STYLES).toMatch(
+      /@media \(max-width:\s*899px\) \{[\s\S]*\.homepage-workflow-sticky-visual \{[^}]*opacity:\s*1;[^}]*transition:\s*opacity 180ms ease;[^}]*\}[\s\S]*\.homepage-workflow-sticky-visual\[data-mobile-workflow-visible="false"\] \{[^}]*pointer-events:\s*none;[^}]*opacity:\s*0;/s,
+    );
+    expect(APP_STYLES).toMatch(
       /@media \(max-width:\s*899px\) \{[\s\S]*\.homepage-workflow-scene-list \{[^}]*padding-bottom:\s*calc\([^}]*var\(--homepage-workflow-dock-height\)[^}]*var\(--homepage-workflow-dock-bottom\)[^}]*\+\s*2rem[^}]*\);/s,
     );
     expect(APP_STYLES).toMatch(
       /@media \(max-width:\s*899px\) \{[\s\S]*\.homepage-workflow-popup \{[^}]*--homepage-workflow-popup-overhang:\s*0rem;[^}]*right:\s*0\.5rem;[^}]*left:\s*0\.5rem;/s,
     );
     expect(APP_STYLES).toMatch(
-      /@media \(max-width:\s*899px\) \{[\s\S]*\.homepage-workflow-document-workspace \{[^}]*--homepage-workflow-document-offset-y:\s*clamp\(7rem,\s*15svh,\s*8rem\);/s,
+      /@media \(max-width:\s*899px\) \{[\s\S]*\.homepage-workflow-document-workspace \{[^}]*--homepage-workflow-document-offset-y:\s*clamp\(1rem,\s*5svh,\s*2\.75rem\);/s,
     );
     expect(APP_STYLES).toMatch(
       /\.homepage-workflow-popup \{[^}]*position:\s*absolute;[^}]*bottom:\s*1rem;/s,
@@ -376,6 +391,12 @@ describe("Homepage", () => {
     );
     expect(APP_STYLES).toMatch(
       /\.homepage-workflow-terminal-reveal-stack\[data-agent-work-visible="false"\] \{[^}]*max-height:\s*0;[^}]*opacity:\s*0;/s,
+    );
+    expect(APP_STYLES).toMatch(
+      /\.homepage-workflow-terminal-tools-heading \{[^}]*display:\s*flex;[^}]*font-weight:\s*700;/s,
+    );
+    expect(APP_STYLES).toMatch(
+      /\.homepage-workflow-terminal-tool-action \{[^}]*color:\s*rgb\(125 211 208\);/s,
     );
     expect(APP_STYLES).toMatch(
       /\.homepage-workflow-document-shell-no-comments \{[^}]*max-width:\s*39rem;/s,
@@ -394,14 +415,18 @@ describe("Homepage", () => {
     expect(storyboard.textContent).toContain(
       "I'll inspect the current homepage, draft a Markdown plan, and open it in Roughdraft for review before I code.",
     );
+    expect(storyboard.textContent).toContain("Explored");
+    expect(storyboard.textContent).toContain("Search");
     expect(storyboard.textContent).toContain(
       'rg "It\'s just Markdown" packages/app/src',
     );
+    expect(storyboard.textContent).toContain("Read");
     expect(storyboard.textContent).toContain(
       "sed -n '1,220p' packages/app/src/App.tsx",
     );
+    expect(storyboard.textContent).toContain("Write");
     expect(storyboard.textContent).toContain(
-      "write .context/homepage-conversion-plan.md",
+      ".context/homepage-conversion-plan.md",
     );
     expect(storyboard.textContent).toContain("Homepage Conversion Plan");
     expect(storyboard.textContent).toContain(
@@ -422,6 +447,210 @@ describe("Homepage", () => {
     expect(storyboard.textContent).not.toContain("Review complete");
     expect(storyboard.textContent).toContain("I read your comments.");
     expect(storyboard.textContent).toContain("Waiting for I'm done...");
+  });
+
+  it("shows user-authored review feedback before the agent responds after handoff", async () => {
+    Object.defineProperty(document.documentElement, "scrollHeight", {
+      configurable: true,
+      value: 2200,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 800,
+    });
+
+    let activeStage = 4;
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function getWorkflowStageRect() {
+        if (this.classList.contains("homepage-workflow-sticky-visual")) {
+          return createDomRect({ top: 120, height: 360 });
+        }
+
+        if (this.classList.contains("homepage-workflow-intro")) {
+          return createDomRect({ top: -120, height: 80 });
+        }
+
+        if (this.classList.contains("homepage-workflow-scene")) {
+          const scenes = [
+            ...document.querySelectorAll(
+              '[data-testid="homepage-workflow-scene"]',
+            ),
+          ];
+          const sceneIndex = scenes.indexOf(this);
+          return createDomRect({
+            top: sceneIndex < activeStage ? -12 : 320,
+            height: 180,
+          });
+        }
+
+        return createDomRect({ width: 640, height: 480 });
+      },
+    );
+
+    await renderHomepage(root);
+
+    const storyboard = getByTestId(container, "homepage-workflow-storyboard");
+    expect(
+      getByTestId(storyboard, "homepage-workflow-terminal").getAttribute(
+        "data-homepage-workflow-terminal-stage",
+      ),
+    ).toBe("4");
+    expect(storyboard.textContent).toContain(
+      'This should go above "It\'s just Markdown."',
+    );
+    expect(storyboard.textContent).toContain("Nora");
+    expect(storyboard.textContent).toContain(
+      'Replace: "agent\'s plan" with "homepage plan"',
+    );
+    expect(
+      getByTestId(storyboard, "homepage-workflow-review-rail").textContent,
+    ).not.toContain("AI");
+    expect(
+      getByTestId(storyboard, "homepage-workflow-agent-resume").getAttribute(
+        "data-terminal-line-visible",
+      ),
+    ).toBe("false");
+
+    activeStage = 6;
+    await act(async () => {
+      window.dispatchEvent(new Event("scroll"));
+      await Promise.resolve();
+    });
+
+    expect(
+      getByTestId(storyboard, "homepage-workflow-terminal").getAttribute(
+        "data-homepage-workflow-terminal-stage",
+      ),
+    ).toBe("6");
+    expect(storyboard.textContent).toContain("I read your comments.");
+    expect(
+      getByTestId(storyboard, "homepage-workflow-agent-resume").getAttribute(
+        "data-terminal-line-visible",
+      ),
+    ).toBe("true");
+    expect(storyboard.textContent).toContain(
+      "I accepted your wording suggestion and moved the workflow story above the Markdown section.",
+    );
+  });
+
+  it("advances the desktop workflow stage when a scene reaches the terminal top", async () => {
+    Object.defineProperty(document.documentElement, "scrollHeight", {
+      configurable: true,
+      value: 2200,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 800,
+    });
+
+    let secondSceneTop = 141;
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function getWorkflowStageRect() {
+        if (this.classList.contains("homepage-workflow-terminal")) {
+          return createDomRect({ top: 140, height: 360 });
+        }
+
+        if (this.classList.contains("homepage-workflow-intro")) {
+          return createDomRect({ top: -120, height: 80 });
+        }
+
+        if (this.classList.contains("homepage-workflow-scene")) {
+          const scenes = [
+            ...document.querySelectorAll(
+              '[data-testid="homepage-workflow-scene"]',
+            ),
+          ];
+          const sceneIndex = scenes.indexOf(this);
+
+          return createDomRect({
+            top: sceneIndex === 1 ? secondSceneTop : 320,
+            height: 180,
+          });
+        }
+
+        return createDomRect({ width: 640, height: 480 });
+      },
+    );
+
+    await renderHomepage(root);
+
+    const storyboard = getByTestId(container, "homepage-workflow-storyboard");
+    expect(
+      getByTestId(storyboard, "homepage-workflow-terminal").getAttribute(
+        "data-homepage-workflow-terminal-stage",
+      ),
+    ).toBe("1");
+
+    secondSceneTop = 140;
+    await act(async () => {
+      window.dispatchEvent(new Event("scroll"));
+      await Promise.resolve();
+    });
+
+    expect(
+      getByTestId(storyboard, "homepage-workflow-terminal").getAttribute(
+        "data-homepage-workflow-terminal-stage",
+      ),
+    ).toBe("2");
+  });
+
+  it("keeps the mobile workflow visual hidden until the heading has scrolled past", async () => {
+    Object.defineProperty(document.documentElement, "scrollHeight", {
+      configurable: true,
+      value: 2000,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 800,
+    });
+    vi.stubGlobal("matchMedia", () => ({
+      matches: true,
+      media: "(max-width: 899px)",
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    let workflowIntroBottom = 120;
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function getWorkflowRect() {
+        if (this.classList.contains("homepage-workflow-intro")) {
+          return createDomRect({
+            top: workflowIntroBottom - 80,
+            height: 80,
+          });
+        }
+
+        if (this.classList.contains("homepage-workflow-sticky-visual")) {
+          return createDomRect({ top: 520, height: 240 });
+        }
+
+        return createDomRect({ width: 640, height: 480 });
+      },
+    );
+
+    await renderHomepage(root);
+
+    const stickyVisual = getByTestId(
+      container,
+      "homepage-workflow-sticky-visual",
+    );
+    expect(stickyVisual.getAttribute("data-mobile-workflow-visible")).toBe(
+      "false",
+    );
+
+    workflowIntroBottom = 0;
+    await act(async () => {
+      window.dispatchEvent(new Event("scroll"));
+      await Promise.resolve();
+    });
+
+    expect(stickyVisual.getAttribute("data-mobile-workflow-visible")).toBe(
+      "true",
+    );
   });
 
   it("renders the Roughdraft flavored Markdown spec page", async () => {


### PR DESCRIPTION
Homepage storyboarding now presents a single review scenario from the agent chat through the Markdown proof, so the fake examples no longer drift between sections.

The storyboard also now shows user-authored comments, suggestions, agent replies, and mobile/desktop timing more accurately, including anchored review rail layout and hidden mobile dock before the section enters view. The Markdown source pane uses a terminal-style treatment and defaults to the same Homepage Conversion Plan example. Verified with `pnpm check`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
