### PR TITLE
chore: bump npm package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roughdraft",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A local markdown review app",
   "license": "MIT",
   "author": "Nathan Baschez",


### PR DESCRIPTION
Bumps the published `roughdraft` npm package to `0.1.8` so the next npm release can publish a new version.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
