### PR TITLE
Add voice + pointer-guided review feedback workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Copy this file to .env and edit values for local development.
+# .env.local is also supported and overrides .env when both exist.
+
+# --- Voice intent inference (required for AI classification) ---
+ROUGHDRAFT_OPENROUTER_API_KEY=
+ROUGHDRAFT_LLM_MODEL=openai/gpt-4o-mini
+
+# --- Local transcription ---
+# Defaults to VoiceInk model directory if unset.
+ROUGHDRAFT_VOICE_MODEL_DIR="$HOME/Library/Application Support/com.prakashjoshipax.VoiceInk/WhisperModels"
+
+# Required for local transcription. Replace whisper-cli with your installed command.
+# Supported placeholders: {audio}, {output}, {model}
+ROUGHDRAFT_VOICE_TRANSCRIBE_COMMAND='whisper-cli -m {model} -f {audio} -otxt -of {output}'
+
+# Optional: override where background server logs are written.
+# Defaults to "<state-dir>/server.log".
+# ROUGHDRAFT_LOG_FILE=/absolute/path/to/roughdraft-server.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules
+.env
+.env.local
 dist
 coverage
 playwright-report

--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ The MCP server exposes tools to read the review index, list pending feedback, wa
 ./scripts/run.sh
 ```
 
+Create local env config before starting the CLI/server:
+
+```bash
+cp .env.example .env
+# edit .env and set required values (for example ROUGHDRAFT_OPENROUTER_API_KEY)
+```
+
 `./scripts/setup.sh` installs workspace dependencies and builds the app and server. `./scripts/run.sh` serves the built app at `http://localhost:7373`.
 
 The two scripts coordinate through a lock file, so it's safe to start `./scripts/run.sh` while `./scripts/setup.sh` is still in progress. `run` will wait for setup to finish, or trigger setup itself if nothing has been built yet.
@@ -218,6 +225,8 @@ roughdraft doctor ./draft.md --json
 
 Usage errors return exit code `2`. Runtime failures return exit code `1`. `roughdraft status --json` returns exit code `0` even when the JSON says `"running": false`.
 
+Roughdraft automatically loads environment variables from `.env` in the current working directory. If `.env.local` exists, it is loaded after `.env` and overrides duplicate keys.
+
 Supported environment variables:
 
 ```text
@@ -235,6 +244,24 @@ ROUGHDRAFT_STATE_FILE
 
 ROUGHDRAFT_STATE_DIR
   Directory containing server.json.
+
+ROUGHDRAFT_LOG_FILE
+  Optional absolute path for background server logs. Defaults to
+  `<state-dir>/server.log`.
+
+ROUGHDRAFT_OPENROUTER_API_KEY
+  API key used by /api/voice/process to infer comment vs suggestion actions.
+
+ROUGHDRAFT_LLM_MODEL
+  Optional OpenRouter model override for voice-action inference.
+
+ROUGHDRAFT_VOICE_TRANSCRIBE_COMMAND
+  Local transcription command template used by `/api/voice/session/stop`.
+  Supported placeholders: `{audio}`, `{output}`, `{model}`.
+
+ROUGHDRAFT_VOICE_MODEL_DIR
+  Optional model directory used to resolve `{model}`. Defaults to
+  `~/Library/Application Support/com.prakashjoshipax.VoiceInk/WhisperModels`.
 ```
 
 Development-only environment variables:

--- a/docs/spec/ui-state-screenshot-guide.md
+++ b/docs/spec/ui-state-screenshot-guide.md
@@ -90,6 +90,10 @@ Paragraph with **bold**, [link](https://example.com), `inline code`.
 | Document | Editing mode | Open mode menu and choose Editing | `document-mode-trigger` | Normal edit behavior. |
 | Document | Suggesting mode | Open mode menu and choose Suggesting | `document-mode-trigger` | Selection actions should create suggestions instead of direct edits. |
 | Document | Viewing mode | Open mode menu and choose Viewing | `document-mode-trigger` | Editing controls should look non-editable. |
+| Document | Voice status: recording | Select text in rich editor while mic permission is granted | `voice-review-status` | Badge should show `Voice: recording`. |
+| Document | Voice status: processing | Speak an utterance while selection is active | `voice-review-status` | Badge should show `Voice: processing` while inference runs. |
+| Document | Voice status: paused | Clear selection after recording starts | `voice-review-status` | Badge should show `Voice: paused` after debounce window. |
+| Document | Voice status: error | Deny mic permission or run unsupported browser | `voice-review-status` | Badge should show `Voice: error` with a message. |
 | Document | Save status: saved | Any clean document after autosave | `document-save-status` | Label should be `Saved`. |
 | Document | Save status: unsaved | Type in a local document before save completes | `document-save-status` | Transient; often easier with save throttling or network mocking. |
 | Document | Save status: saving | Type and capture during autosave | `document-save-status` | Transient; easiest with mocked delayed save. |

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   ],
   "dependencies": {
     "@roughdraft/rfm": "file:packages/rfm",
+    "dotenv": "17.4.2",
     "express": "^5.1.0"
   },
   "devDependencies": {

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -349,6 +349,11 @@ export function DocumentWorkspace({
 
     setReviewHandoffState("notifying");
     try {
+      window.dispatchEvent(
+        new CustomEvent("roughdraft:review-handoff", {
+          detail: { path: activeDocumentPath },
+        }),
+      );
       const result = await onCompleteReview();
       if (result.delivered) {
         setReviewWatcherCount(0);

--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -4,7 +4,7 @@ import { TextSelection } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
 import { EditorContent, useEditor, useEditorState } from "@tiptap/react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-
+import { buildLocationForLinkedMarkdownDocument } from "./app-navigation";
 import { CommentEditorList } from "./CommentEditorList";
 import {
   type CriticChangeAttrs,
@@ -30,9 +30,13 @@ import {
 } from "./editor-extensions";
 import { cn } from "./lib/utils";
 import { MarkdownCodeEditor } from "./MarkdownCodeEditor";
-import { buildLocationForLinkedMarkdownDocument } from "./app-navigation";
 import { toHtml } from "./markdown";
-import type { Page, StorageBackend } from "./storage";
+import type {
+  Page,
+  StorageBackend,
+  VoiceActionResult,
+  VoiceSelectionSnapshot,
+} from "./storage";
 import { useCommentAnchorLayout } from "./useCommentAnchorLayout";
 
 export type DocumentSaveState = "saved" | "unsaved" | "saving" | "error";
@@ -48,6 +52,12 @@ export interface DocumentSaveController {
 
 type EditorViewMode = "rich-text" | "code";
 export type DocumentInteractionMode = "viewing" | "suggesting" | "editing";
+type VoiceProgressStage =
+  | "transcribing"
+  | "processing"
+  | "editing"
+  | "done"
+  | "error";
 
 interface PageCardProps {
   page: Page;
@@ -103,12 +113,112 @@ interface RichTextEditorSurfaceProps {
   onCommentRailPresenceChange?: (hasCommentRailSpace: boolean) => void;
 }
 
+interface VoiceCaptureContext {
+  runId: number;
+  selection: VoiceSelectionSnapshot | null;
+  chunks: Blob[];
+  startedAtMs: number;
+  shouldTranscribe: boolean;
+}
+
 interface CodeEditorSurfaceProps {
   markdown: string;
   hasCommentRailSpace: boolean;
   interactionMode: DocumentInteractionMode;
   layout: "default" | "embedded-demo";
   onMarkdownChange: (markdown: string) => void;
+}
+
+function audioBufferToWavBlob(audioBuffer: AudioBuffer): Blob {
+  const channels = audioBuffer.numberOfChannels;
+  const sampleRate = audioBuffer.sampleRate;
+  const length = audioBuffer.length;
+  const bytesPerSample = 2;
+  const blockAlign = channels * bytesPerSample;
+  const dataSize = length * blockAlign;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+
+  const writeString = (offset: number, text: string) => {
+    for (let index = 0; index < text.length; index += 1) {
+      view.setUint8(offset + index, text.charCodeAt(index));
+    }
+  };
+
+  writeString(0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeString(8, "WAVE");
+  writeString(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, channels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * blockAlign, true);
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, 16, true);
+  writeString(36, "data");
+  view.setUint32(40, dataSize, true);
+
+  let offset = 44;
+  for (let frame = 0; frame < length; frame += 1) {
+    for (let channel = 0; channel < channels; channel += 1) {
+      const sample = audioBuffer.getChannelData(channel)[frame] ?? 0;
+      const clamped = Math.max(-1, Math.min(1, sample));
+      const int16 = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff;
+      view.setInt16(offset, int16, true);
+      offset += 2;
+    }
+  }
+
+  return new Blob([buffer], { type: "audio/wav" });
+}
+
+function audioBufferRms(audioBuffer: AudioBuffer): number {
+  let sumSquares = 0;
+  let sampleCount = 0;
+  for (let channel = 0; channel < audioBuffer.numberOfChannels; channel += 1) {
+    const data = audioBuffer.getChannelData(channel);
+    for (let index = 0; index < data.length; index += 1) {
+      const sample = data[index] ?? 0;
+      sumSquares += sample * sample;
+      sampleCount += 1;
+    }
+  }
+  if (sampleCount === 0) return 0;
+  return Math.sqrt(sumSquares / sampleCount);
+}
+
+function shouldIgnoreUtterance(utterance: string): boolean {
+  const normalized = utterance
+    .toLowerCase()
+    .replace(/[^\w\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!normalized) return true;
+
+  const fillerPhrases = new Set([
+    "thank you",
+    "thanks",
+    "okay",
+    "ok",
+    "all right",
+    "alright",
+    "oh my god",
+    "wow",
+    "hmm",
+    "um",
+    "uh",
+  ]);
+  if (fillerPhrases.has(normalized)) return true;
+
+  const hasEditIntent =
+    /\b(delete|remove|replace|rewrite|reword|change|add|insert|move|cut|shorten|expand|merge|split|fix)\b/.test(
+      normalized,
+    );
+  const words = normalized.split(" ").filter(Boolean);
+  if (!hasEditIntent && words.length <= 2) return true;
+
+  return false;
 }
 
 export interface DraftSuggestionState {
@@ -623,6 +733,28 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
   const [pendingFocusCommentId, setPendingFocusCommentId] = useState<
     string | null
   >(null);
+  const [voiceStatus, setVoiceStatus] = useState<
+    "idle" | "recording" | "processing" | "paused" | "error"
+  >("idle");
+  const [voiceStatusMessage, setVoiceStatusMessage] = useState<string>("");
+  const [voiceProgress, setVoiceProgress] = useState<{
+    runId: number;
+    stage: VoiceProgressStage;
+    message: string;
+  } | null>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const voiceSelectionRef = useRef<VoiceSelectionSnapshot | null>(null);
+  const voicePinnedSelectionRef = useRef<VoiceSelectionSnapshot | null>(null);
+  const shouldRecordVoiceRef = useRef(false);
+  const voiceAppendTargetBySelectionRef = useRef<Map<string, string>>(
+    new Map(),
+  );
+  const voiceProgressRunRef = useRef(0);
+  const voiceCaptureContextRef = useRef<VoiceCaptureContext | null>(null);
+  const applyVoiceActionRef = useRef<
+    (selection: VoiceSelectionSnapshot, action: VoiceActionResult) => void
+  >(() => {});
 
   const resolveFileUrl = useCallback(
     (path: string) => backend.resolveFileUrl(path),
@@ -713,6 +845,23 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
     },
     [backend, resolveFileUrl, resolveLinkUrl],
   );
+
+  const getSelectionSnapshot = useCallback(
+    (currentEditor: Editor): VoiceSelectionSnapshot | null => {
+      const { from, to, empty } = currentEditor.state.selection;
+      if (empty || from === to) return null;
+      const selectedText = currentEditor.state.doc
+        .textBetween(from, to, "\n")
+        .trim();
+      if (!selectedText) return null;
+      return { from, to, selectedText };
+    },
+    [],
+  );
+
+  const selectionKey = useCallback((selection: VoiceSelectionSnapshot) => {
+    return `${selection.from}:${selection.to}:${selection.selectedText}`;
+  }, []);
 
   const refreshCriticChanges = useCallback(() => {
     if (criticChangeFrameRef.current != null) {
@@ -1228,9 +1377,432 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
   selectedCommentIdRef.current = selectedCommentId;
   selectedChangeIdRef.current = selectedChangeId;
 
+  const processVoiceUtterance = useCallback(
+    async (
+      utterance: string,
+      runId: number,
+      targetSelection: VoiceSelectionSnapshot | null,
+    ) => {
+      const normalizedUtterance = utterance.trim();
+      if (shouldIgnoreUtterance(normalizedUtterance)) {
+        setVoiceProgress({
+          runId,
+          stage: "done",
+          message: "No actionable feedback detected.",
+        });
+        window.setTimeout(() => {
+          setVoiceProgress((current) =>
+            current?.runId === runId ? null : current,
+          );
+        }, 900);
+        return;
+      }
+      if (
+        !backend.processVoiceUtterance ||
+        !activeDocumentPath ||
+        !targetSelection ||
+        normalizedUtterance.length === 0
+      ) {
+        return;
+      }
+
+      setVoiceStatus("processing");
+      setVoiceProgress({
+        runId,
+        stage: "processing",
+        message: "Processing feedback...",
+      });
+      try {
+        const action = await backend.processVoiceUtterance(
+          activeDocumentPath,
+          normalizedUtterance,
+          targetSelection,
+        );
+        setVoiceProgress({
+          runId,
+          stage: "editing",
+          message: "Applying comment or suggestion...",
+        });
+        applyVoiceActionRef.current(targetSelection, action);
+        setVoiceStatus(shouldRecordVoiceRef.current ? "recording" : "paused");
+        setVoiceProgress({
+          runId,
+          stage: "done",
+          message: "Feedback added.",
+        });
+        window.setTimeout(() => {
+          setVoiceProgress((current) =>
+            current?.runId === runId ? null : current,
+          );
+        }, 1400);
+      } catch (error) {
+        setVoiceStatus("error");
+        const message =
+          error instanceof Error ? error.message : "Voice processing failed";
+        setVoiceStatusMessage(message);
+        setVoiceProgress({
+          runId,
+          stage: "error",
+          message: `Voice feedback failed: ${message}`,
+        });
+      }
+    },
+    [activeDocumentPath, backend],
+  );
+
+  const flushRecordedAudio = useCallback(
+    async (
+      chunks: Blob[],
+      runId: number,
+      targetSelection: VoiceSelectionSnapshot | null,
+    ) => {
+    if (chunks.length === 0) return;
+    setVoiceProgress({
+      runId,
+      stage: "transcribing",
+      message: "Transcribing audio...",
+    });
+
+    const originalBlob = new Blob(chunks, {
+      type: chunks[0]?.type || "audio/webm",
+    });
+    let uploadBlob = originalBlob;
+    try {
+      const context = new AudioContext();
+      const decoded = await context.decodeAudioData(
+        await originalBlob.arrayBuffer(),
+      );
+      const rms = audioBufferRms(decoded);
+      if (rms < 0.0035) {
+        await context.close();
+        setVoiceProgress({
+          runId,
+          stage: "done",
+          message: "No speech detected.",
+        });
+        window.setTimeout(() => {
+          setVoiceProgress((current) =>
+            current?.runId === runId ? null : current,
+          );
+        }, 900);
+        return;
+      }
+      uploadBlob = audioBufferToWavBlob(decoded);
+      await context.close();
+    } catch {
+      uploadBlob = originalBlob;
+    }
+
+    const buffer = await uploadBlob.arrayBuffer();
+    const bytes = new Uint8Array(buffer);
+    let binary = "";
+    for (let index = 0; index < bytes.length; index += 1) {
+      const byte = bytes[index];
+      if (byte !== undefined) {
+        binary += String.fromCharCode(byte);
+      }
+    }
+
+    const startResponse = await fetch("/api/voice/session/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    if (!startResponse.ok) {
+      setVoiceProgress({
+        runId,
+        stage: "error",
+        message: "Voice feedback failed: unable to start transcription.",
+      });
+      return;
+    }
+    const startPayload = (await startResponse.json()) as { sessionId?: string };
+    const sessionId = startPayload.sessionId;
+    if (!sessionId) {
+      setVoiceProgress({
+        runId,
+        stage: "error",
+        message: "Voice feedback failed: missing transcription session.",
+      });
+      return;
+    }
+
+    const chunkResponse = await fetch("/api/voice/session/chunk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sessionId,
+        mimeType: uploadBlob.type || "audio/webm",
+        audioBase64: btoa(binary),
+      }),
+    });
+    if (!chunkResponse.ok) {
+      setVoiceProgress({
+        runId,
+        stage: "error",
+        message: "Voice feedback failed: upload error.",
+      });
+      return;
+    }
+
+    const stopResponse = await fetch("/api/voice/session/stop", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sessionId }),
+    });
+    if (!stopResponse.ok) {
+      setVoiceProgress({
+        runId,
+        stage: "error",
+        message: "Voice feedback failed: transcription stop error.",
+      });
+      return;
+    }
+    const stopPayload = (await stopResponse.json()) as { transcript?: string };
+    const transcript = stopPayload.transcript?.trim() ?? "";
+    if (transcript.length > 0) {
+      await processVoiceUtterance(transcript, runId, targetSelection);
+    } else {
+      setVoiceProgress({
+        runId,
+        stage: "done",
+        message: "No speech detected.",
+      });
+      window.setTimeout(() => {
+        setVoiceProgress((current) =>
+          current?.runId === runId ? null : current,
+        );
+      }, 1400);
+    }
+    },
+    [processVoiceUtterance],
+  );
+
+  const stopVoiceCapture = useCallback((cancel = false) => {
+    shouldRecordVoiceRef.current = false;
+    const recorder = mediaRecorderRef.current;
+    const captureContext = voiceCaptureContextRef.current;
+    if (recorder && recorder.state !== "inactive") {
+      if (cancel && captureContext) {
+        captureContext.shouldTranscribe = false;
+      }
+      const runId = captureContext?.runId ?? ++voiceProgressRunRef.current;
+      if (captureContext && !cancel) {
+        const elapsedMs = Date.now() - captureContext.startedAtMs;
+        if (elapsedMs < 450) {
+          captureContext.shouldTranscribe = false;
+          setVoiceProgress({
+            runId,
+            stage: "done",
+            message: "No speech detected.",
+          });
+          window.setTimeout(() => {
+            setVoiceProgress((current) =>
+              current?.runId === runId ? null : current,
+            );
+          }, 900);
+        } else {
+          setVoiceProgress({
+            runId,
+            stage: "transcribing",
+            message: "Transcribing audio...",
+          });
+        }
+      }
+      if (cancel) {
+        setVoiceProgress(null);
+      }
+      recorder.requestData();
+      recorder.stop();
+    }
+    mediaRecorderRef.current = null;
+    voiceCaptureContextRef.current = null;
+    if (mediaStreamRef.current) {
+      for (const track of mediaStreamRef.current.getTracks()) {
+        track.stop();
+      }
+      mediaStreamRef.current = null;
+    }
+    voicePinnedSelectionRef.current = null;
+    setVoiceStatus("idle");
+  }, [flushRecordedAudio]);
+
+  const ensureVoiceCapture = useCallback(() => {
+    if (mediaRecorderRef.current || !shouldRecordVoiceRef.current) return;
+    if (
+      typeof navigator === "undefined" ||
+      !navigator.mediaDevices?.getUserMedia ||
+      typeof MediaRecorder === "undefined"
+    ) {
+      setVoiceStatus("error");
+      setVoiceStatusMessage(
+        "Local audio capture is unavailable in this browser.",
+      );
+      return;
+    }
+    void navigator.mediaDevices
+      .getUserMedia({ audio: true })
+      .then((stream) => {
+        if (!shouldRecordVoiceRef.current) {
+          for (const track of stream.getTracks()) {
+            track.stop();
+          }
+          return;
+        }
+        mediaStreamRef.current = stream;
+        const recorder = new MediaRecorder(stream);
+        const recorderChunks: Blob[] = [];
+        const recordingSelection = voicePinnedSelectionRef.current;
+        const runId = ++voiceProgressRunRef.current;
+        const captureContext: VoiceCaptureContext = {
+          runId,
+          selection: recordingSelection,
+          chunks: recorderChunks,
+          startedAtMs: Date.now(),
+          shouldTranscribe: true,
+        };
+        voiceCaptureContextRef.current = captureContext;
+        recorder.ondataavailable = (event) => {
+          if (event.data.size > 0) {
+            recorderChunks.push(event.data);
+          }
+        };
+        recorder.onerror = () => {
+          setVoiceStatus("error");
+          setVoiceStatusMessage("Microphone recording error.");
+        };
+        recorder.onstop = () => {
+          if (!captureContext.shouldTranscribe) return;
+          void flushRecordedAudio(
+            captureContext.chunks,
+            captureContext.runId,
+            captureContext.selection,
+          );
+        };
+        mediaRecorderRef.current = recorder;
+        recorder.start();
+        setVoiceStatus("recording");
+      })
+      .catch((error: unknown) => {
+        setVoiceStatus("error");
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Microphone permission denied.";
+        setVoiceStatusMessage(message);
+      });
+  }, [flushRecordedAudio]);
+
   useEffect(() => {
     editor?.setEditable(interactionMode !== "viewing", false);
   }, [editor, interactionMode]);
+
+  useEffect(() => {
+    if (!editor || interactionMode === "viewing") {
+      stopVoiceCapture();
+      voiceSelectionRef.current = null;
+      return;
+    }
+
+    const handleSelectionChange = () => {
+      const currentEditor = editorRef.current;
+      if (!currentEditor) return;
+      const snapshot = getSelectionSnapshot(currentEditor);
+      if (!snapshot) {
+        voiceSelectionRef.current = null;
+        shouldRecordVoiceRef.current = false;
+        setVoiceStatus("paused");
+        const captureContext = voiceCaptureContextRef.current;
+        if (captureContext) {
+          const elapsedMs = Date.now() - captureContext.startedAtMs;
+          if (elapsedMs < 450) {
+            captureContext.shouldTranscribe = false;
+            setVoiceProgress({
+              runId: captureContext.runId,
+              stage: "done",
+              message: "No speech detected.",
+            });
+            window.setTimeout(() => {
+              setVoiceProgress((current) =>
+                current?.runId === captureContext.runId ? null : current,
+              );
+            }, 900);
+          } else {
+            setVoiceProgress({
+              runId: captureContext.runId,
+              stage: "transcribing",
+              message: "Transcribing audio...",
+            });
+          }
+        }
+        const recorder = mediaRecorderRef.current;
+        if (recorder && recorder.state !== "inactive") {
+          recorder.requestData();
+          recorder.stop();
+        }
+        mediaRecorderRef.current = null;
+        voiceCaptureContextRef.current = null;
+        if (mediaStreamRef.current) {
+          for (const track of mediaStreamRef.current.getTracks()) {
+            track.stop();
+          }
+          mediaStreamRef.current = null;
+        }
+        return;
+      }
+
+      voiceSelectionRef.current = snapshot;
+      voicePinnedSelectionRef.current = snapshot;
+      if (voiceCaptureContextRef.current) {
+        voiceCaptureContextRef.current.selection = snapshot;
+      }
+      shouldRecordVoiceRef.current = true;
+      ensureVoiceCapture();
+      setVoiceStatusMessage("");
+    };
+
+    editor.on("selectionUpdate", handleSelectionChange);
+    handleSelectionChange();
+
+    return () => {
+      editor.off("selectionUpdate", handleSelectionChange);
+    };
+  }, [
+    editor,
+    ensureVoiceCapture,
+    getSelectionSnapshot,
+    interactionMode,
+    stopVoiceCapture,
+  ]);
+
+  useEffect(() => {
+    const handleHandoff = () => {
+      stopVoiceCapture();
+    };
+    window.addEventListener("roughdraft:review-handoff", handleHandoff);
+    return () => {
+      window.removeEventListener("roughdraft:review-handoff", handleHandoff);
+    };
+  }, [stopVoiceCapture]);
+
+  useEffect(() => {
+    if (!editor || interactionMode === "viewing") return;
+
+    const handleEscapeToCancelVoice = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      const currentEditor = editorRef.current;
+      if (!currentEditor) return;
+
+      stopVoiceCapture(true);
+      const { to } = currentEditor.state.selection;
+      currentEditor.chain().setTextSelection({ from: to, to }).run();
+    };
+
+    window.addEventListener("keydown", handleEscapeToCancelVoice);
+    return () => {
+      window.removeEventListener("keydown", handleEscapeToCancelVoice);
+    };
+  }, [editor, interactionMode, stopVoiceCapture]);
 
   const activeCommentIds =
     useEditorState({
@@ -1257,6 +1829,12 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
       onEditorReady?.(null);
     };
   }, [editor, onEditorReady]);
+
+  useEffect(() => {
+    return () => {
+      stopVoiceCapture();
+    };
+  }, [stopVoiceCapture]);
 
   useEffect(() => {
     setSelectedCommentId((current) =>
@@ -1490,6 +2068,139 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
       measureLayout();
     });
   }, [measureLayout]);
+
+  const applyVoiceAction = useCallback(
+    (selection: VoiceSelectionSnapshot, action: VoiceActionResult) => {
+      const currentEditor = editorRef.current;
+      if (!currentEditor) return;
+      const tr = currentEditor.state.tr;
+
+      const key = selectionKey(selection);
+      const existingTarget = voiceAppendTargetBySelectionRef.current.get(key);
+
+      if (action.action === "comment" || action.uncertain) {
+        if (existingTarget) {
+          const existingComment = commentsRef.current.get(existingTarget);
+          if (existingComment) {
+            const nextComments = new Map(commentsRef.current);
+            nextComments.set(existingTarget, {
+              ...existingComment,
+              content: `${existingComment.content}\n${action.content}`.trim(),
+            });
+            commentsRef.current = nextComments;
+            setComments(nextComments);
+            emitMarkdownChange(currentEditor.getJSON(), nextComments);
+          }
+          return;
+        }
+
+        const comment = createCriticComment(
+          {
+            authorType: "user",
+            authorId: "user",
+            content: action.uncertain
+              ? `[uncertain] ${action.content}`
+              : action.content,
+          },
+          {
+            existingComments: commentsRef.current.values(),
+          },
+        );
+        const nextComments = new Map(commentsRef.current);
+        nextComments.set(comment.id, comment);
+        commentsRef.current = nextComments;
+        setComments(nextComments);
+
+        suppressNextMarkdownUpdateRef.current = true;
+        const commentMarkType = currentEditor.state.schema.marks.commentRef;
+        if (!commentMarkType) return;
+        tr.addMark(
+          selection.from,
+          selection.to,
+          commentMarkType.create({ commentIds: [comment.id] }),
+        );
+        currentEditor.view.dispatch(tr);
+        if (suppressNextMarkdownUpdateRef.current) {
+          suppressNextMarkdownUpdateRef.current = false;
+        }
+        voiceAppendTargetBySelectionRef.current.set(key, comment.id);
+        emitMarkdownChange(currentEditor.getJSON(), nextComments);
+        return;
+      }
+
+      if (action.action === "suggestion_addition") {
+        const change = createCriticChange(
+          "addition",
+          { authorType: "user", authorId: "user" },
+          {
+            existingChanges: getDocumentCriticChanges(currentEditor),
+          },
+        );
+        const criticMarkType = currentEditor.state.schema.marks.criticChange;
+        if (!criticMarkType) return;
+        tr.insertText(action.content, selection.to);
+        tr.addMark(
+          selection.to,
+          selection.to + action.content.length,
+          criticMarkType.create(change),
+        );
+        currentEditor.view.dispatch(tr);
+        emitMarkdownChange(currentEditor.getJSON());
+        refreshCriticChanges();
+        return;
+      }
+
+      if (action.action === "suggestion_deletion") {
+        const change = createCriticChange(
+          "deletion",
+          { authorType: "user", authorId: "user" },
+          {
+            existingChanges: getDocumentCriticChanges(currentEditor),
+          },
+        );
+        const criticMarkType = currentEditor.state.schema.marks.criticChange;
+        if (!criticMarkType) return;
+        tr.addMark(selection.from, selection.to, criticMarkType.create(change));
+        currentEditor.view.dispatch(tr);
+        emitMarkdownChange(currentEditor.getJSON());
+        refreshCriticChanges();
+        return;
+      }
+
+      const replacementText =
+        action.replacementText && action.replacementText.trim().length > 0
+          ? action.replacementText
+          : action.content;
+      const change = createCriticChange(
+        "substitution-old",
+        { authorType: "user", authorId: "user" },
+        {
+          existingChanges: getDocumentCriticChanges(currentEditor),
+        },
+      );
+      const replacementChange: CriticChangeAttrs = {
+        ...change,
+        kind: "substitution-new",
+      };
+      const criticMarkType = currentEditor.state.schema.marks.criticChange;
+      if (!criticMarkType) return;
+      tr.addMark(selection.from, selection.to, criticMarkType.create(change));
+      tr.insertText(replacementText, selection.to);
+      tr.addMark(
+        selection.to,
+        selection.to + replacementText.length,
+        criticMarkType.create(replacementChange),
+      );
+      currentEditor.view.dispatch(tr);
+      emitMarkdownChange(currentEditor.getJSON());
+      refreshCriticChanges();
+    },
+    [emitMarkdownChange, refreshCriticChanges, selectionKey],
+  );
+
+  useEffect(() => {
+    applyVoiceActionRef.current = applyVoiceAction;
+  }, [applyVoiceAction]);
 
   const handleSuggestDeletion = useCallback(() => {
     const currentEditor = editorRef.current;
@@ -1923,6 +2634,36 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
               data-testid="document-content-card"
               className={cn(contentCardClass, "px-10 py-10 sm:px-14 sm:py-14")}
             >
+              {interactionMode !== "viewing" && voiceStatus === "recording" ? (
+                <div
+                  data-testid="voice-review-status"
+                  className="pointer-events-none fixed bottom-6 left-1/2 z-50 inline-flex -translate-x-1/2 items-center gap-2 rounded-full border border-stone-300 bg-stone-50/95 px-4 py-2 text-xs text-stone-700 shadow-md backdrop-blur dark:border-slate-600 dark:bg-slate-800/95 dark:text-slate-200"
+                >
+                  <span
+                    className={cn(
+                      "size-2 rounded-full bg-stone-400",
+                      voiceStatus === "recording" && "bg-red-500",
+                    )}
+                  />
+                  <span className="font-medium">
+                    Voice: {voiceStatus}
+                    {voiceStatusMessage ? ` (${voiceStatusMessage})` : ""}
+                  </span>
+                </div>
+              ) : null}
+              {voiceProgress ? (
+                <div
+                  role="status"
+                  aria-live="polite"
+                  data-testid="voice-review-progress-toast"
+                  className="pointer-events-none fixed bottom-6 right-6 z-50 max-w-sm rounded-lg border border-stone-300 bg-white/95 px-4 py-3 text-sm text-stone-900 shadow-lg backdrop-blur dark:border-slate-600 dark:bg-slate-900/95 dark:text-slate-100"
+                >
+                  <div className="font-medium">{voiceProgress.message}</div>
+                  <div className="mt-1 text-xs uppercase tracking-wide text-stone-500 dark:text-slate-400">
+                    {voiceProgress.stage}
+                  </div>
+                </div>
+              ) : null}
               <EditorContextMenu
                 editor={editor}
                 backend={backend}

--- a/packages/app/src/api-backend.ts
+++ b/packages/app/src/api-backend.ts
@@ -7,6 +7,8 @@ import {
   type ReviewWatchStatus,
   type StorageBackend,
   type StoredAsset,
+  type VoiceActionResult,
+  type VoiceSelectionSnapshot,
 } from "./storage";
 
 export class ApiBackend implements StorageBackend {
@@ -153,6 +155,31 @@ export class ApiBackend implements StorageBackend {
       watcherCount:
         typeof payload.watcherCount === "number" ? payload.watcherCount : 0,
     };
+  }
+
+  async processVoiceUtterance(
+    relativePath: string,
+    utterance: string,
+    selection: VoiceSelectionSnapshot,
+  ): Promise<VoiceActionResult> {
+    const res = await fetch(this.buildUrl("/api/voice/process"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        projectPath: this.info.projectPath,
+        path: relativePath,
+        utterance,
+        selection,
+      }),
+    });
+
+    if (!res.ok) {
+      throw new Error(
+        `Failed to process voice utterance for ${relativePath}: ${res.status}`,
+      );
+    }
+
+    return res.json();
   }
 
   async saveAsset(file: File): Promise<StoredAsset> {

--- a/packages/app/src/local-storage-backend.ts
+++ b/packages/app/src/local-storage-backend.ts
@@ -1,4 +1,11 @@
-import type { BackendInfo, Page, StorageBackend, StoredAsset } from "./storage";
+import type {
+  BackendInfo,
+  Page,
+  StorageBackend,
+  StoredAsset,
+  VoiceActionResult,
+  VoiceSelectionSnapshot,
+} from "./storage";
 
 const PAGES_KEY = "roughdraft:pages";
 const ASSETS_KEY = "roughdraft:assets";
@@ -115,6 +122,19 @@ export class LocalStorageBackend implements StorageBackend {
 
   async completeReview(_relativePath: string): Promise<{ delivered: boolean }> {
     return { delivered: false };
+  }
+
+  async processVoiceUtterance(
+    _relativePath: string,
+    utterance: string,
+    _selection: VoiceSelectionSnapshot,
+  ): Promise<VoiceActionResult> {
+    return {
+      action: "comment",
+      content: utterance.trim(),
+      confidence: 0.3,
+      uncertain: true,
+    };
   }
 
   async saveAsset(file: File): Promise<StoredAsset> {

--- a/packages/app/src/preview-backend.ts
+++ b/packages/app/src/preview-backend.ts
@@ -1,4 +1,11 @@
-import type { BackendInfo, Page, StorageBackend, StoredAsset } from "./storage";
+import type {
+  BackendInfo,
+  Page,
+  StorageBackend,
+  StoredAsset,
+  VoiceActionResult,
+  VoiceSelectionSnapshot,
+} from "./storage";
 
 function titleFromContent(content: string, fallback: string) {
   const firstLine = content.split("\n")[0] || "";
@@ -64,6 +71,19 @@ export class PreviewBackend implements StorageBackend {
 
   async completeReview(_relativePath: string): Promise<{ delivered: boolean }> {
     return { delivered: false };
+  }
+
+  async processVoiceUtterance(
+    _relativePath: string,
+    utterance: string,
+    _selection: VoiceSelectionSnapshot,
+  ): Promise<VoiceActionResult> {
+    return {
+      action: "comment",
+      content: utterance.trim(),
+      confidence: 0.3,
+      uncertain: true,
+    };
   }
 
   async saveAsset(file: File): Promise<StoredAsset> {

--- a/packages/app/src/remote-backend.ts
+++ b/packages/app/src/remote-backend.ts
@@ -5,6 +5,8 @@ import {
   type Page,
   type StorageBackend,
   type StoredAsset,
+  type VoiceActionResult,
+  type VoiceSelectionSnapshot,
 } from "./storage";
 
 interface RemoteDocumentPayload {
@@ -228,6 +230,19 @@ export class RemoteBackend implements StorageBackend {
     throw new Error(
       "Remote document sessions do not support asset uploads in this version.",
     );
+  }
+
+  async processVoiceUtterance(
+    _relativePath: string,
+    utterance: string,
+    _selection: VoiceSelectionSnapshot,
+  ): Promise<VoiceActionResult> {
+    return {
+      action: "comment",
+      content: utterance.trim(),
+      confidence: 0.3,
+      uncertain: true,
+    };
   }
 
   resolveFileUrl(_path: string): string | null {

--- a/packages/app/src/storage.ts
+++ b/packages/app/src/storage.ts
@@ -36,6 +36,26 @@ export interface ReviewWatchStatus {
   watcherCount: number;
 }
 
+export interface VoiceSelectionSnapshot {
+  from: number;
+  to: number;
+  selectedText: string;
+}
+
+export type VoiceActionType =
+  | "comment"
+  | "suggestion_addition"
+  | "suggestion_deletion"
+  | "suggestion_substitution";
+
+export interface VoiceActionResult {
+  action: VoiceActionType;
+  content: string;
+  replacementText?: string;
+  confidence: number;
+  uncertain?: boolean;
+}
+
 export interface BackendInfo {
   kind: "local-files" | "local-storage" | "remote";
   label: string;
@@ -60,6 +80,11 @@ export interface StorageBackend {
   ): () => void;
   completeReview?(relativePath: string): Promise<CompleteReviewResult>;
   getReviewWatchStatus?(relativePath: string): Promise<ReviewWatchStatus>;
+  processVoiceUtterance?(
+    relativePath: string,
+    utterance: string,
+    selection: VoiceSelectionSnapshot,
+  ): Promise<VoiceActionResult>;
   saveAsset(file: File): Promise<StoredAsset>;
   resolveFileUrl(path: string): string | null;
   openProject(path: string): Promise<void>;

--- a/packages/server/bin/roughdraft.mjs
+++ b/packages/server/bin/roughdraft.mjs
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 
+import path from "node:path";
+import dotenv from "dotenv";
 import { runCli } from "../dist/cli.js";
+
+const cwd = process.cwd();
+dotenv.config({ path: path.join(cwd, ".env"), override: false });
+dotenv.config({ path: path.join(cwd, ".env.local"), override: true });
 
 const exitCode = await runCli(process.argv.slice(2));
 process.exit(exitCode);

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -8,6 +8,7 @@ import { createApp } from "./index";
 import {
   createCliDependencies,
   ensureServerRunning,
+  getServerLogFilePath,
   getServerStateFilePath,
   runCli,
 } from "./cli";
@@ -756,12 +757,14 @@ describe("cli", () => {
     const payload = parseOnlyJsonLog<{
       running: boolean;
       stateFile: string;
+      logFile: string;
     }>(test.logs);
 
     expect(exitCode).toBe(0);
     expect(payload).toEqual({
       running: false,
       stateFile: getServerStateFilePath(test.deps.env),
+      logFile: getServerLogFilePath(test.deps.env),
     });
   });
 
@@ -777,6 +780,7 @@ describe("cli", () => {
       pid: number;
       startedAt: string;
       stateFile: string;
+      logFile: string;
       managed: boolean;
     }>(test.logs);
 
@@ -788,6 +792,7 @@ describe("cli", () => {
       pid: result.server.pid,
       startedAt: result.server.startedAt,
       stateFile: getServerStateFilePath(test.deps.env),
+      logFile: getServerLogFilePath(test.deps.env),
       managed: true,
     });
   });

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,10 +1,10 @@
+import { spawn, spawnSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { spawn, spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
 import { setTimeout as sleep } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
 import {
   type RfmDiagnostic,
   validateRoughdraftMarkdown,
@@ -47,6 +47,7 @@ export interface RoughdraftServerState {
   pid: number;
   startedAt: string;
   url: string;
+  logFile?: string;
 }
 
 interface StatusPayload {
@@ -84,6 +85,7 @@ export interface CliDependencies {
   spawnServerProcess: (options: {
     port: number;
     projectDir: string;
+    logFilePath: string;
   }) => Promise<SpawnedServer> | SpawnedServer;
   isProcessRunning: (pid: number) => boolean;
   stopProcess: (pid: number) => Promise<void>;
@@ -693,7 +695,10 @@ async function defaultStopProcess(pid: number): Promise<void> {
 function defaultSpawnServerProcess(options: {
   port: number;
   projectDir: string;
+  logFilePath: string;
 }): SpawnedServer {
+  fs.mkdirSync(path.dirname(options.logFilePath), { recursive: true });
+  const logFd = fs.openSync(options.logFilePath, "a");
   const serverEntryPath = fileURLToPath(new URL("./child.js", import.meta.url));
   const child = spawn(
     process.execPath,
@@ -707,12 +712,13 @@ function defaultSpawnServerProcess(options: {
     {
       cwd: options.projectDir,
       detached: true,
-      stdio: "ignore",
+      stdio: ["ignore", logFd, logFd],
       windowsHide: true,
       env: process.env,
     },
   );
 
+  fs.closeSync(logFd);
   child.unref();
 
   if (!child.pid) {
@@ -1389,6 +1395,17 @@ export function getServerStateFilePath(
   return path.join(os.homedir(), ".roughdraft", "server.json");
 }
 
+export function getServerLogFilePath(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const explicitFile = env.ROUGHDRAFT_LOG_FILE?.trim();
+  if (explicitFile) {
+    return path.resolve(explicitFile);
+  }
+
+  return path.join(path.dirname(getServerStateFilePath(env)), "server.log");
+}
+
 function isValidServerState(value: unknown): value is RoughdraftServerState {
   if (!value || typeof value !== "object") return false;
 
@@ -1401,7 +1418,9 @@ function isValidServerState(value: unknown): value is RoughdraftServerState {
     typeof candidate.startedAt === "string" &&
     candidate.startedAt.length > 0 &&
     typeof candidate.url === "string" &&
-    candidate.url.length > 0
+    candidate.url.length > 0 &&
+    (candidate.logFile === undefined ||
+      (typeof candidate.logFile === "string" && candidate.logFile.length > 0))
   );
 }
 
@@ -1604,10 +1623,16 @@ async function resolveLiveDevFrontendBaseUrl(
 async function normalizeTrackedState(
   persistedState: RoughdraftServerState,
   stateFilePath: string,
+  env: NodeJS.ProcessEnv,
 ): Promise<RoughdraftServerState> {
   const normalizedState = {
     ...persistedState,
     url: buildPublicBaseUrl(persistedState.port),
+    logFile:
+      typeof persistedState.logFile === "string" &&
+      persistedState.logFile.trim().length > 0
+        ? path.resolve(persistedState.logFile)
+        : getServerLogFilePath(env),
   };
 
   if (normalizedState.url !== persistedState.url) {
@@ -1641,6 +1666,7 @@ async function findReusableServer(
       const normalizedState = await normalizeTrackedState(
         persistedState,
         stateFilePath,
+        deps.env,
       );
       return {
         port: normalizedState.port,
@@ -1714,9 +1740,11 @@ export async function ensureServerRunning(
   const preferredPort = getPreferredPort(deps.env);
   const port = await deps.findAvailablePortImpl(preferredPort);
   const projectDir = path.resolve(options.projectDir ?? deps.cwd);
+  const logFilePath = getServerLogFilePath(deps.env);
   const spawned = await deps.spawnServerProcess({
     port,
     projectDir,
+    logFilePath,
   });
 
   try {
@@ -1731,6 +1759,7 @@ export async function ensureServerRunning(
     pid: spawned.pid,
     startedAt: new Date().toISOString(),
     url: buildPublicBaseUrl(port),
+    logFile: logFilePath,
   };
   writeServerStateToDisk(getServerStateFilePath(deps.env), state);
 
@@ -1750,11 +1779,13 @@ export async function ensureServerRunning(
 function buildServerStatusJson(
   server: ReusableServer | null,
   stateFilePath: string,
+  env: NodeJS.ProcessEnv,
 ) {
   if (!server) {
     return {
       running: false,
       stateFile: stateFilePath,
+      logFile: getServerLogFilePath(env),
     };
   }
 
@@ -1765,6 +1796,7 @@ function buildServerStatusJson(
     pid: server.pid,
     startedAt: server.startedAt,
     stateFile: stateFilePath,
+    logFile: getServerLogFilePath(env),
     managed: server.tracked,
   };
 }
@@ -2232,6 +2264,7 @@ export async function runCli(
           ...buildServerStatusJson(
             result.server,
             getServerStateFilePath(deps.env),
+            deps.env,
           ),
           reused: result.reused,
           portChanged: result.portChanged,
@@ -2287,7 +2320,11 @@ export async function runCli(
         if (json) {
           emitJson(
             deps.log,
-            buildServerStatusJson(null, getServerStateFilePath(deps.env)),
+            buildServerStatusJson(
+              null,
+              getServerStateFilePath(deps.env),
+              deps.env,
+            ),
           );
           return 0;
         }
@@ -2301,7 +2338,11 @@ export async function runCli(
       if (json) {
         emitJson(
           deps.log,
-          buildServerStatusJson(server, getServerStateFilePath(deps.env)),
+          buildServerStatusJson(
+            server,
+            getServerStateFilePath(deps.env),
+            deps.env,
+          ),
         );
         return 0;
       }
@@ -2311,6 +2352,7 @@ export async function runCli(
         deps.log(`PID: ${server.pid}`);
         deps.log(`Started: ${server.startedAt}`);
         deps.log(`State file: ${getServerStateFilePath(deps.env)}`);
+        deps.log(`Log file: ${getServerLogFilePath(deps.env)}`);
       } else {
         deps.log(
           `This server is not managed by ${getServerStateFilePath(deps.env)}.`,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,15 +1,17 @@
-import express, { type Express, type Request, type Response } from "express";
+import { execFile } from "node:child_process";
 import crypto from "node:crypto";
-import os from "node:os";
-import { createServer as createHttpServer } from "node:http";
-import { fileURLToPath } from "node:url";
-import path from "node:path";
 import fs from "node:fs";
+import { createServer as createHttpServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { extractRoughdraftReviewIndex } from "@roughdraft/rfm";
+import express, { type Express, type Request, type Response } from "express";
 import {
+  hasNonLoopbackHost,
   ROUGHDRAFT_DEFAULT_PORT,
   ROUGHDRAFT_PUBLIC_HOST,
-  hasNonLoopbackHost,
   resolveBindHosts,
 } from "./network.js";
 import { ReviewEventQueue } from "./review-events.js";
@@ -103,11 +105,112 @@ interface RemoteDocumentSavePayload {
   expectedVersion?: string;
 }
 
+interface VoiceSelectionPayload {
+  from?: number;
+  to?: number;
+  selectedText?: string;
+}
+
+interface VoiceProcessPayload {
+  path?: string;
+  projectPath?: string;
+  utterance?: string;
+  selection?: VoiceSelectionPayload;
+}
+
+type VoiceActionType =
+  | "comment"
+  | "suggestion_addition"
+  | "suggestion_deletion"
+  | "suggestion_substitution";
+
+interface VoiceActionResult {
+  action: VoiceActionType;
+  content: string;
+  replacementText?: string;
+  confidence: number;
+  uncertain?: boolean;
+}
+
+function hasExplicitEditIntent(utterance: string): boolean {
+  const normalized = utterance.toLowerCase();
+  return /\b(delete|remove|replace|rewrite|reword|change|add|insert|move|cut|shorten|expand|merge|split|fix)\b/.test(
+    normalized,
+  );
+}
+
+function shouldForceComment(utterance: string): boolean {
+  const normalized = utterance.toLowerCase();
+  if (normalized.includes("?")) return true;
+  if (
+    /^(what|why|how|where|when|who|can|could|would|should|is|are|do|does|did)\b/.test(
+      normalized,
+    )
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function coerceVoiceActionResult(
+  utterance: string,
+  result: VoiceActionResult,
+): VoiceActionResult {
+  if (result.action === "comment") return result;
+  if (hasExplicitEditIntent(utterance) && !shouldForceComment(utterance)) {
+    return result;
+  }
+  return {
+    action: "comment",
+    content: utterance,
+    confidence: Math.min(result.confidence, 0.85),
+    uncertain: result.uncertain ?? false,
+  };
+}
+
 const REMOTE_SESSION_TTL_MS = 5 * 60 * 1000;
 const REMOTE_SESSION_SWEEP_INTERVAL_MS = 60 * 1000;
 const REMOTE_SESSION_KEEPALIVE_MS = 15 * 1000;
 
 let nextOpenRequestClientId = 1;
+
+const ROUGHDRAFT_OPENROUTER_API_KEY_ENV = "ROUGHDRAFT_OPENROUTER_API_KEY";
+const ROUGHDRAFT_LLM_MODEL_ENV = "ROUGHDRAFT_LLM_MODEL";
+const DEFAULT_VOICE_MODEL = "openai/gpt-4o-mini";
+const ROUGHDRAFT_VOICE_MODEL_DIR_ENV = "ROUGHDRAFT_VOICE_MODEL_DIR";
+const ROUGHDRAFT_VOICE_TRANSCRIBE_COMMAND_ENV =
+  "ROUGHDRAFT_VOICE_TRANSCRIBE_COMMAND";
+const execFileAsync = promisify(execFile);
+
+interface VoiceTranscriptionSession {
+  id: string;
+  chunks: Buffer[];
+  mimeType: string;
+  createdAt: number;
+}
+
+function logVoice(event: string, data: Record<string, unknown> = {}): void {
+  const payload = {
+    ts: new Date().toISOString(),
+    event,
+    ...data,
+  };
+  console.log(`[voice] ${JSON.stringify(payload)}`);
+}
+
+function summarizeApiKey(
+  value: string | undefined,
+): { present: boolean; prefix: string | null; length: number } {
+  const trimmed = value?.trim() ?? "";
+  if (trimmed.length === 0) {
+    return { present: false, prefix: null, length: 0 };
+  }
+  return {
+    present: true,
+    prefix: trimmed.slice(0, 12),
+    length: trimmed.length,
+  };
+}
 
 function remoteSessionVersion(content: string): string {
   const hash = crypto.createHash("sha256").update(content).digest("hex");
@@ -382,6 +485,285 @@ function listProjectTree(projectDir: string): ProjectTreeListing {
   return { paths };
 }
 
+function normalizeVoiceActionCandidate(value: unknown): VoiceActionType | null {
+  if (
+    value === "comment" ||
+    value === "suggestion_addition" ||
+    value === "suggestion_deletion" ||
+    value === "suggestion_substitution"
+  ) {
+    return value;
+  }
+
+  return null;
+}
+
+function parseVoiceActionResult(payload: unknown): VoiceActionResult | null {
+  if (!payload || typeof payload !== "object") return null;
+  const data = payload as {
+    action?: unknown;
+    content?: unknown;
+    replacementText?: unknown;
+    confidence?: unknown;
+    uncertain?: unknown;
+  };
+  const action = normalizeVoiceActionCandidate(data.action);
+  const content =
+    typeof data.content === "string" ? data.content.trim() : undefined;
+
+  if (!action || !content) return null;
+
+  return {
+    action,
+    content,
+    replacementText:
+      typeof data.replacementText === "string" &&
+      data.replacementText.trim().length > 0
+        ? data.replacementText.trim()
+        : undefined,
+    confidence:
+      typeof data.confidence === "number"
+        ? Math.min(1, Math.max(0, data.confidence))
+        : 0.5,
+    uncertain: data.uncertain === true,
+  };
+}
+
+async function inferVoiceActionWithOpenRouter(
+  utterance: string,
+  selectedText: string,
+  fetchImpl: typeof fetch,
+): Promise<VoiceActionResult> {
+  const apiKey = process.env[ROUGHDRAFT_OPENROUTER_API_KEY_ENV];
+  const model =
+    process.env[ROUGHDRAFT_LLM_MODEL_ENV]?.trim() || DEFAULT_VOICE_MODEL;
+  const keySummary = summarizeApiKey(apiKey);
+  logVoice("inference.config", {
+    apiKeyPresent: keySummary.present,
+    apiKeyPrefix: keySummary.prefix,
+    apiKeyLength: keySummary.length,
+    model,
+    utteranceChars: utterance.length,
+    selectedTextChars: selectedText.length,
+  });
+  if (!apiKey || apiKey.trim().length === 0) {
+    logVoice("inference.fallback.no_api_key", {
+      envKey: ROUGHDRAFT_OPENROUTER_API_KEY_ENV,
+    });
+    return {
+      action: "comment",
+      content: utterance,
+      confidence: 0.2,
+      uncertain: true,
+    };
+  }
+
+  const response = await fetchImpl(
+    "https://openrouter.ai/api/v1/chat/completions",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        response_format: { type: "json_object" },
+        messages: [
+          {
+            role: "system",
+            content:
+              "You convert dictated review feedback into a single JSON object with keys: action, content, replacementText, confidence, uncertain. action must be one of comment|suggestion_addition|suggestion_deletion|suggestion_substitution. Default to action=comment unless the utterance is an explicit edit instruction (delete/remove/replace/add/rewrite/etc). Questions, reactions, uncertainty, or discussion should be comment.",
+          },
+          {
+            role: "user",
+            content: `Selected text:\n${selectedText}\n\nUtterance:\n${utterance}\n\nReturn only JSON.`,
+          },
+        ],
+      }),
+    },
+  );
+
+  logVoice("inference.http.response", {
+    status: response.status,
+    ok: response.ok,
+  });
+  if (!response.ok) {
+    let errorBody = "";
+    try {
+      errorBody = await response.text();
+    } catch {
+      errorBody = "";
+    }
+    logVoice("inference.fallback.http_error", {
+      status: response.status,
+      bodyPreview: errorBody.slice(0, 500),
+    });
+    return {
+      action: "comment",
+      content: utterance,
+      confidence: 0.2,
+      uncertain: true,
+    };
+  }
+
+  const payload = (await response.json()) as {
+    choices?: Array<{ message?: { content?: string | null } }>;
+  };
+  const content = payload.choices?.[0]?.message?.content;
+  if (typeof content !== "string" || content.trim().length === 0) {
+    logVoice("inference.fallback.empty_content", {
+      hasChoices: Array.isArray(payload.choices),
+    });
+    return {
+      action: "comment",
+      content: utterance,
+      confidence: 0.2,
+      uncertain: true,
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(content);
+    const parsedResult = parseVoiceActionResult(parsed);
+    if (!parsedResult) {
+      logVoice("inference.fallback.schema_mismatch", {
+        contentPreview: content.slice(0, 500),
+      });
+    } else {
+      logVoice("inference.result", {
+        action: parsedResult.action,
+        confidence: parsedResult.confidence,
+        uncertain: parsedResult.uncertain === true,
+      });
+    }
+    const resolved =
+      parsedResult ?? {
+        action: "comment",
+        content: utterance,
+        confidence: 0.2,
+        uncertain: true,
+      };
+    const coerced = coerceVoiceActionResult(utterance, resolved);
+    if (coerced.action !== resolved.action) {
+      logVoice("inference.coerce_to_comment", {
+        utterancePreview: utterance.slice(0, 120),
+        originalAction: resolved.action,
+        coercedAction: coerced.action,
+      });
+    }
+    return coerced;
+  } catch {
+    logVoice("inference.fallback.json_parse_error", {
+      contentPreview: content.slice(0, 500),
+    });
+    return {
+      action: "comment",
+      content: utterance,
+      confidence: 0.2,
+      uncertain: true,
+    };
+  }
+}
+
+function resolveVoiceModelPath(): string {
+  const modelDir =
+    process.env[ROUGHDRAFT_VOICE_MODEL_DIR_ENV]?.trim() ||
+    path.join(
+      os.homedir(),
+      "Library/Application Support/com.prakashjoshipax.VoiceInk/WhisperModels",
+    );
+  return path.join(modelDir, "ggml-large-v3-turbo.bin");
+}
+
+function parseCommandTemplate(template: string): {
+  command: string;
+  args: string[];
+} {
+  const parts = template
+    .split(" ")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  const command = parts.shift();
+  if (!command) {
+    throw new Error("voice transcribe command is empty");
+  }
+  return { command, args: parts };
+}
+
+async function transcribeLocalAudioFromBuffer(
+  audioBuffer: Buffer,
+): Promise<string> {
+  const commandTemplate = process.env[ROUGHDRAFT_VOICE_TRANSCRIBE_COMMAND_ENV];
+  if (!commandTemplate || commandTemplate.trim().length === 0) {
+    logVoice("transcribe.skip.no_command", {
+      envKey: ROUGHDRAFT_VOICE_TRANSCRIBE_COMMAND_ENV,
+    });
+    return "";
+  }
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "roughdraft-voice-"));
+  const audioPath = path.join(tempDir, "audio.webm");
+  const outputPath = path.join(tempDir, "transcript");
+  fs.writeFileSync(audioPath, audioBuffer);
+
+  const { command, args } = parseCommandTemplate(commandTemplate);
+  const modelPath = resolveVoiceModelPath();
+  const resolvedArgs = args.map((arg) =>
+    arg
+      .replaceAll("{audio}", audioPath)
+      .replaceAll("{output}", outputPath)
+      .replaceAll("{model}", modelPath),
+  );
+  logVoice("transcribe.exec.start", {
+    command,
+    resolvedArgs,
+    modelPath,
+    audioBytes: audioBuffer.length,
+    audioPath,
+    outputPath,
+  });
+
+  try {
+    const { stdout, stderr } = await execFileAsync(command, resolvedArgs, {
+      timeout: 120_000,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    logVoice("transcribe.exec.done", {
+      stdoutChars: stdout.length,
+      stderrChars: stderr.length,
+      stderrPreview: stderr.slice(0, 500),
+    });
+    if (fs.existsSync(outputPath)) {
+      const transcript = fs.readFileSync(outputPath, "utf-8").trim();
+      logVoice("transcribe.output.direct", {
+        transcriptChars: transcript.length,
+      });
+      return transcript;
+    }
+    if (fs.existsSync(`${outputPath}.txt`)) {
+      const transcript = fs.readFileSync(`${outputPath}.txt`, "utf-8").trim();
+      logVoice("transcribe.output.txt", {
+        transcriptChars: transcript.length,
+      });
+      return transcript;
+    }
+    const transcript = stdout.trim();
+    logVoice("transcribe.output.stdout", {
+      transcriptChars: transcript.length,
+    });
+    return transcript;
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "unknown transcription error";
+    logVoice("transcribe.exec.error", { message });
+    throw error;
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    logVoice("transcribe.cleanup", { tempDirRemoved: tempDir });
+  }
+}
+
 export function createApp(options: CreateAppOptions = {}): CreateAppResult {
   const port = options.port ?? ROUGHDRAFT_DEFAULT_PORT;
   const homeDir = options.homeDir ?? os.homedir();
@@ -397,6 +779,7 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
   const openRequestClients = new Set<OpenRequestClient>();
   const reviewEvents = new ReviewEventQueue();
   const remoteSessions = new Map<string, RemoteSession>();
+  const voiceSessions = new Map<string, VoiceTranscriptionSession>();
 
   function isAuthorizedRemoteDocumentRequest(req: Request): boolean {
     if (!remoteDocumentToken) return true;
@@ -684,6 +1067,184 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
       watching: watcherCount > 0,
       watcherCount,
     });
+  });
+
+  app.post("/api/voice/session/start", (_req, res) => {
+    const id = crypto.randomUUID();
+    voiceSessions.set(id, {
+      id,
+      chunks: [],
+      mimeType: "audio/webm",
+      createdAt: Date.now(),
+    });
+    logVoice("session.start", { sessionId: id });
+    res.status(201).json({ sessionId: id });
+  });
+
+  app.post("/api/voice/session/chunk", (req, res) => {
+    const sessionId =
+      typeof req.body?.sessionId === "string" ? req.body.sessionId : "";
+    const audioBase64 =
+      typeof req.body?.audioBase64 === "string" ? req.body.audioBase64 : "";
+    const mimeType =
+      typeof req.body?.mimeType === "string" ? req.body.mimeType : "audio/webm";
+
+    const session = voiceSessions.get(sessionId);
+    if (!session) {
+      logVoice("session.chunk.missing", { sessionId });
+      res.status(404).json({ error: "voice session not found" });
+      return;
+    }
+
+    if (!audioBase64) {
+      logVoice("session.chunk.empty", { sessionId });
+      res.status(400).json({ error: "audioBase64 is required" });
+      return;
+    }
+
+    session.mimeType = mimeType;
+    const chunk = Buffer.from(audioBase64, "base64");
+    session.chunks.push(chunk);
+    logVoice("session.chunk", {
+      sessionId,
+      mimeType,
+      chunkBytes: chunk.length,
+      totalChunks: session.chunks.length,
+    });
+    res.json({ ok: true });
+  });
+
+  app.post("/api/voice/session/stop", async (req, res) => {
+    const sessionId =
+      typeof req.body?.sessionId === "string" ? req.body.sessionId : "";
+    const session = voiceSessions.get(sessionId);
+    if (!session) {
+      logVoice("session.stop.missing", { sessionId });
+      res.status(404).json({ error: "voice session not found" });
+      return;
+    }
+
+    voiceSessions.delete(sessionId);
+    const buffer = Buffer.concat(session.chunks);
+    logVoice("session.stop", {
+      sessionId,
+      chunks: session.chunks.length,
+      totalBytes: buffer.length,
+      mimeType: session.mimeType,
+      ageMs: Date.now() - session.createdAt,
+    });
+    if (buffer.length === 0) {
+      logVoice("session.stop.empty_audio", { sessionId });
+      res.json({ transcript: "" });
+      return;
+    }
+
+    try {
+      const transcript = await transcribeLocalAudioFromBuffer(buffer);
+      logVoice("session.stop.transcript", {
+        sessionId,
+        transcriptChars: transcript.length,
+        transcriptPreview: transcript.slice(0, 200),
+      });
+      res.json({ transcript });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "voice transcription failed";
+      logVoice("session.stop.error", {
+        sessionId,
+        message,
+      });
+      res.status(500).json({ error: message });
+    }
+  });
+
+  app.post("/api/voice/process", async (req, res) => {
+    logVoice("process.request.received", {
+      method: req.method,
+      hasBody: Boolean(req.body),
+      queryPath:
+        typeof req.query.path === "string" ? req.query.path : undefined,
+      bodyPath: typeof req.body?.path === "string" ? req.body.path : undefined,
+      bodyProjectPath:
+        typeof req.body?.projectPath === "string"
+          ? req.body.projectPath
+          : undefined,
+    });
+    const target = markdownPathFromRequest(req, res);
+    if (!target) {
+      logVoice("process.request.rejected.invalid_target", {
+        reason: "markdownPathFromRequest returned null",
+      });
+      return;
+    }
+    logVoice("process.request.target", {
+      relativePath: target.relativePath,
+      projectDir: target.projectDir,
+      absolutePath: target.absolutePath,
+    });
+
+    const payload = req.body as VoiceProcessPayload;
+    const utterance =
+      typeof payload.utterance === "string" ? payload.utterance.trim() : "";
+    const selection = payload.selection;
+    const selectedText =
+      typeof selection?.selectedText === "string"
+        ? selection.selectedText.trim()
+        : "";
+
+    if (!utterance) {
+      logVoice("process.request.rejected.empty_utterance", {
+        utteranceType: typeof payload.utterance,
+      });
+      res.status(400).json({ error: "utterance is required" });
+      return;
+    }
+
+    if (!selectedText) {
+      logVoice("process.request.rejected.empty_selection", {
+        selectionType: typeof selection,
+        selectedTextType: typeof selection?.selectedText,
+      });
+      res.status(400).json({ error: "selection.selectedText is required" });
+      return;
+    }
+
+    logVoice("process.request.validated", {
+      utteranceChars: utterance.length,
+      utterancePreview: utterance.slice(0, 200),
+      selectionChars: selectedText.length,
+      selectionPreview: selectedText.slice(0, 200),
+      selectionFrom:
+        typeof selection?.from === "number" ? selection.from : undefined,
+      selectionTo: typeof selection?.to === "number" ? selection.to : undefined,
+    });
+
+    try {
+      const startedAt = Date.now();
+      const action = await inferVoiceActionWithOpenRouter(
+        utterance,
+        selectedText,
+        fetchImpl,
+      );
+      logVoice("process.response.success", {
+        durationMs: Date.now() - startedAt,
+        action: action.action,
+        confidence: action.confidence,
+        uncertain: action.uncertain === true,
+        contentChars: action.content.length,
+        contentPreview: action.content.slice(0, 200),
+        replacementChars: action.replacementText?.length ?? 0,
+        replacementPreview: action.replacementText?.slice(0, 200),
+      });
+      res.json(action);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "voice processing failed";
+      logVoice("process.response.error", {
+        message,
+      });
+      res.status(500).json({ error: message });
+    }
   });
 
   app.put("/api/pages/:id", (req, res) => {
@@ -1231,6 +1792,21 @@ export async function createServer(
     projectDir,
     remoteDocumentToken:
       remoteDocumentToken.length > 0 ? remoteDocumentToken : undefined,
+  });
+  const startupKeySummary = summarizeApiKey(
+    process.env[ROUGHDRAFT_OPENROUTER_API_KEY_ENV],
+  );
+  logVoice("server.env.voice", {
+    cwd: process.cwd(),
+    envModelRaw: process.env[ROUGHDRAFT_LLM_MODEL_ENV] ?? null,
+    envModelEffective:
+      process.env[ROUGHDRAFT_LLM_MODEL_ENV]?.trim() || DEFAULT_VOICE_MODEL,
+    envApiKeyPresent: startupKeySummary.present,
+    envApiKeyPrefix: startupKeySummary.prefix,
+    envApiKeyLength: startupKeySummary.length,
+    envVoiceModelDir: process.env[ROUGHDRAFT_VOICE_MODEL_DIR_ENV] ?? null,
+    envVoiceTranscribeCommand:
+      process.env[ROUGHDRAFT_VOICE_TRANSCRIBE_COMMAND_ENV] ?? null,
   });
   const listeningHosts: string[] = [];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@roughdraft/rfm':
         specifier: file:packages/rfm
         version: link:packages/rfm
+      dotenv:
+        specifier: 17.4.2
+        version: 17.4.2
       express:
         specifier: ^5.1.0
         version: 5.2.1
@@ -421,28 +424,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.12':
     resolution: {integrity: sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.12':
     resolution: {integrity: sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.12':
     resolution: {integrity: sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.12':
     resolution: {integrity: sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig==}
@@ -1083,56 +1082,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
     resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
     resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
@@ -1205,49 +1196,41 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
@@ -1319,79 +1302,66 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -1471,28 +1441,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -2671,28 +2637,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
it's still very "rough" (pun-intended) and ideally shouldn't use openrouter but a local model using ollama or LM studio. and I also want to explore removing even more friction by just hovering on text and saying my feedback (kind of like clicky captures the screen when you point at something).

* * *

## Summary
This PR adds a hands-free review workflow for Markdown drafts:

- select text,
- speak feedback,
- Roughdraft transcribes locally,
- Roughdraft classifies feedback as a `comment` or `suggestion`,
- feedback is applied without hijacking user selection.

It also improves operability with dotenv-based env loading and persistent server logs for background mode.

## How It Works

<details>
<summary>Mermaid flow diagram</summary>

```mermaid
flowchart TD
  A[Open Roughdraft] --> B[Mic session initialized]
  B --> C{User selects text?}
  C -->|Yes| D[Start capturing audio chunks]
  C -->|No| C
  D --> E{Selection cleared or Send clicked}
  E -->|Selection cleared| F[Stop capture for this selection]
  E -->|Send clicked| G[Stop recording session]
  F --> H{Speech detected?}
  H -->|No| I[Skip processing]
  H -->|Yes| J["/api/voice/session/stop<br/>local transcription"]
  J --> K{Transcript actionable?}
  K -->|No| I
  K -->|Yes| L["/api/voice/process<br/>OpenRouter classification"]
  L --> M{Action}
  M -->|comment| N[Create anchored comment]
  M -->|suggestion_*| O[Create suggestion change]
  N --> P[Show completion toast]
  O --> P
```

</details>

## Implementation Notes

### Client (`packages/app`)
- `PageCard.tsx`
  - Implements the voice workflow end-to-end: capture on selection, immediate processing on unselect, staged progress toast, repeated-use stability, and escape-to-cancel.
  - Adds silence/filler guardrails.
  - Preserves user selection control during background apply.
  - Writes feedback as user-authored comments/suggestions.
- `storage` backends/interfaces: adds typed voice-processing contracts used by the UI flow.

### Server (`packages/server`)
- `index.ts`: adds `/api/voice/session/start`, `/chunk`, `/stop`, `/process`; runs local transcription via command template; classifies utterances with OpenRouter and fallback/coercion logic; emits verbose `[voice]` logs.
- `bin/roughdraft.mjs`, `cli.ts`: loads `.env` then `.env.local` and exposes background log-file status details.

## Environment Variables
Copy the tracked template and set your local values:

```bash
cp .env.example .env
# edit .env and set required values
```

Required:
- `ROUGHDRAFT_OPENROUTER_API_KEY`

Recommended for local transcription:
- `ROUGHDRAFT_VOICE_TRANSCRIBE_COMMAND`
- `ROUGHDRAFT_VOICE_MODEL_DIR` (optional if using default VoiceInk model dir)

Example transcription command (whisper.cpp CLI):

```bash
ROUGHDRAFT_VOICE_TRANSCRIBE_COMMAND="whisper-cli -m {model} -f {audio} -of {output}"
```

## Behavior Details
- Recording begins with app open, then capture is tied to active selection.
- Clearing selection triggers immediate processing (no extra buffer delay).
- Empty/silent captures are dropped without creating feedback.
- Non-edit utterances default to comments; explicit edit instructions become suggestions.

## Risks / Follow-ups
- Browser audio format differences can still affect transcription quality; WAV conversion fallback is in place.
- OpenRouter model policies/availability may vary by key/provider routing.
- Potential future work: optional local HTTP/stdio bridge process for tighter control over transcription backend.

## Tests Performed
- `pnpm --filter @roughdraft/app test`
- `pnpm --filter @roughdraft/server test`
- `pnpm --filter @roughdraft/app build`
- Manual end-to-end voice flows with log inspection (`~/.roughdraft/server.log`).
