### PR TITLE
feat: add HTML review MVP

### DIFF
--- a/.context/fixtures/html/commented-document.html
+++ b/.context/fixtures/html/commented-document.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Commented document</title>
+  </head>
+  <body>
+    <article>
+      <h1>The weather report</h1>
+
+      <p>
+        The
+        <mark data-rd-comment-ids="c-7uG2">sky</mark>
+        is blue today.
+      </p>
+
+      <p>
+        Rain is forecast for the
+        <mark data-rd-comment-ids="c-9aB1 c-3xY8">evening</mark>.
+      </p>
+
+      <p>
+        We expect a calm <mark>weekend</mark> overall.
+      </p>
+    </article>
+
+    <aside class="rd-review" hidden>
+      <rd-comment
+        id="c-7uG2"
+        data-rd-author="ananth@cradlewise.com"
+        data-rd-created-at="2026-05-23T10:14:11Z"
+        data-rd-anchor-ids="c-7uG2"
+        data-rd-status="open"
+      >Consider saying &ldquo;clear sky&rdquo; for accuracy.</rd-comment>
+
+      <rd-comment
+        id="c-9aB1"
+        data-rd-author="ananth@cradlewise.com"
+        data-rd-created-at="2026-05-23T10:15:02Z"
+        data-rd-anchor-ids="c-9aB1"
+        data-rd-status="open"
+      >Pin a specific time window.</rd-comment>
+
+      <rd-comment
+        id="c-3xY8"
+        data-rd-author="reviewer@example.com"
+        data-rd-created-at="2026-05-23T10:18:40Z"
+        data-rd-anchor-ids="c-3xY8"
+        data-rd-status="open"
+        data-rd-reply-to="c-9aB1"
+      >Agree &mdash; &ldquo;after 7pm&rdquo; would be clearer.</rd-comment>
+
+      <rd-comment
+        id="c-4r5T"
+        data-rd-author="ananth@cradlewise.com"
+        data-rd-created-at="2026-05-23T10:20:00Z"
+        data-rd-anchor-ids="c-9aB1"
+        data-rd-status="resolved"
+      >Resolved offline.</rd-comment>
+    </aside>
+  </body>
+</html>

--- a/.context/fixtures/html/literal-zones.html
+++ b/.context/fixtures/html/literal-zones.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Literal zones</title>
+    <style>
+      /* Author CSS must not be parsed as Roughdraft markup, even though it
+         mentions data-rd-comment-ids and rd-comment selectors below. */
+      mark[data-rd-comment-ids] { background: #fff3a3; }
+      rd-comment { display: none; }
+    </style>
+    <script>
+      // Author script must not be parsed as Roughdraft markup, even though
+      // the literal text below mentions <mark data-rd-comment-ids> and
+      // <rd-comment> tokens.
+      const example = "<mark data-rd-comment-ids=\"c-not-real\">x</mark>";
+      console.log(example);
+    </script>
+  </head>
+  <body>
+    <article>
+      <h1>HTML annotation examples</h1>
+
+      <p>
+        A real annotation lives in the body:
+        <mark data-rd-comment-ids="c-real-1">like this</mark>.
+      </p>
+
+      <h2>Code samples are literal</h2>
+
+      <p>The following <code>&lt;mark data-rd-comment-ids="c-code-1"&gt;literal&lt;/mark&gt;</code> must not become an anchor.</p>
+
+      <pre><code>&lt;mark data-rd-comment-ids="c-pre-1"&gt;example in pre&lt;/mark&gt;
+&lt;rd-comment id="c-pre-1"&gt;not a real comment&lt;/rd-comment&gt;
+&lt;ins data-rd-suggestion-id="s-pre-1"&gt;literal ins&lt;/ins&gt;
+</code></pre>
+
+      <h2>Explicit literal escape hatch</h2>
+
+      <div data-rd-literal>
+        Anything inside here is literal:
+        &lt;mark data-rd-comment-ids="c-literal-1"&gt;not parsed&lt;/mark&gt;
+        &lt;rd-comment id="c-literal-1"&gt;ignored&lt;/rd-comment&gt;
+      </div>
+    </article>
+
+    <aside class="rd-review" hidden>
+      <rd-comment
+        id="c-real-1"
+        data-rd-author="ananth@cradlewise.com"
+        data-rd-created-at="2026-05-23T13:00:00Z"
+        data-rd-anchor-ids="c-real-1"
+        data-rd-status="open"
+      >This is the only real comment in the file.</rd-comment>
+    </aside>
+  </body>
+</html>

--- a/.context/fixtures/html/mixed-review-document.html
+++ b/.context/fixtures/html/mixed-review-document.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Mixed review document</title>
+    <style>
+      mark[data-rd-comment-ids] { background: #fff3a3; }
+      aside.rd-review[hidden] { display: none; }
+      ins[data-rd-suggestion-id] { background: #d6f5d6; text-decoration: none; }
+      del[data-rd-suggestion-id] { background: #f9d5d5; }
+    </style>
+  </head>
+  <body>
+    <article>
+      <h1>Quarterly review</h1>
+
+      <p>
+        Revenue grew
+        <mark data-rd-comment-ids="c-rev-1">
+          <ins
+            data-rd-suggestion-id="s-rev-1"
+            data-rd-author="ananth@cradlewise.com"
+            data-rd-created-at="2026-05-23T12:00:00Z"
+          >12%</ins></mark>
+        quarter over quarter.
+      </p>
+
+      <p>
+        Churn was
+        <del
+          data-rd-suggestion-id="s-churn-1"
+          data-rd-author="reviewer@example.com"
+          data-rd-created-at="2026-05-23T12:01:00Z"
+        >high</del><ins
+          data-rd-suggestion-id="s-churn-1"
+          data-rd-author="reviewer@example.com"
+          data-rd-created-at="2026-05-23T12:01:00Z"
+        >elevated but stable</ins>
+        in the SMB segment.
+      </p>
+
+      <p>
+        We expanded the team in
+        <mark data-rd-comment-ids="c-team-1 c-team-2">Berlin and Bangalore</mark>.
+      </p>
+
+      <h2>Risks</h2>
+      <ul>
+        <li>
+          <mark data-rd-comment-ids="c-risk-1">Latency in the EU region.</mark>
+        </li>
+        <li>Long onboarding for enterprise customers.</li>
+      </ul>
+    </article>
+
+    <aside class="rd-review" hidden>
+      <rd-comment
+        id="c-rev-1"
+        data-rd-author="reviewer@example.com"
+        data-rd-created-at="2026-05-23T12:00:30Z"
+        data-rd-anchor-ids="c-rev-1"
+        data-rd-status="open"
+      >Cite the exact source row.</rd-comment>
+
+      <rd-comment
+        id="c-team-1"
+        data-rd-author="ananth@cradlewise.com"
+        data-rd-created-at="2026-05-23T12:02:00Z"
+        data-rd-anchor-ids="c-team-1"
+        data-rd-status="open"
+      >Mention headcount delta.</rd-comment>
+
+      <rd-comment
+        id="c-team-2"
+        data-rd-author="reviewer@example.com"
+        data-rd-created-at="2026-05-23T12:02:45Z"
+        data-rd-anchor-ids="c-team-1"
+        data-rd-status="open"
+        data-rd-reply-to="c-team-1"
+      >+1, and split by office.</rd-comment>
+
+      <rd-comment
+        id="c-risk-1"
+        data-rd-author="ananth@cradlewise.com"
+        data-rd-created-at="2026-05-23T12:03:30Z"
+        data-rd-anchor-ids="c-risk-1"
+        data-rd-status="resolved"
+      >Fixed in last release.</rd-comment>
+    </aside>
+  </body>
+</html>

--- a/.context/fixtures/html/plain-document.html
+++ b/.context/fixtures/html/plain-document.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Plain document</title>
+  </head>
+  <body>
+    <article>
+      <h1>The weather report</h1>
+      <p>The sky is blue today.</p>
+      <p>Rain is forecast for the evening.</p>
+      <ul>
+        <li>Morning: clear.</li>
+        <li>Afternoon: scattered clouds.</li>
+        <li>Evening: rain likely.</li>
+      </ul>
+    </article>
+  </body>
+</html>

--- a/.context/fixtures/html/suggestions-document.html
+++ b/.context/fixtures/html/suggestions-document.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Suggestions document</title>
+  </head>
+  <body>
+    <article>
+      <h1>Release notes</h1>
+
+      <p>
+        We shipped
+        <ins
+          data-rd-suggestion-id="s-1"
+          data-rd-author="ananth@cradlewise.com"
+          data-rd-created-at="2026-05-23T11:00:00Z"
+          data-rd-status="open"
+        >three new</ins>
+        features this week.
+      </p>
+
+      <p>
+        Performance is
+        <del
+          data-rd-suggestion-id="s-2"
+          data-rd-author="ananth@cradlewise.com"
+          data-rd-created-at="2026-05-23T11:01:10Z"
+          data-rd-status="open"
+        >slightly degraded</del>
+        on the home page.
+      </p>
+
+      <p>
+        We will replace
+        <del
+          data-rd-suggestion-id="s-3"
+          data-rd-author="ananth@cradlewise.com"
+          data-rd-created-at="2026-05-23T11:02:30Z"
+        >the legacy parser</del><ins
+          data-rd-suggestion-id="s-3"
+          data-rd-author="ananth@cradlewise.com"
+          data-rd-created-at="2026-05-23T11:02:30Z"
+        >the new streaming parser</ins>
+        next sprint.
+      </p>
+    </article>
+  </body>
+</html>

--- a/README.md
+++ b/README.md
@@ -161,6 +161,27 @@ my-essay/
 ```
 
 Roughdraft reads and writes the markdown file directly.
+
+### HTML files (MVP)
+
+Roughdraft also opens annotated HTML documents directly:
+
+```bash
+roughdraft open ./path/to/page.html
+```
+
+HTML review uses the annotation contract recorded in
+`docs/adr/0005-html-review-annotation-contract.md`:
+
+- Comment anchors are a single `<mark data-rd-comment-ids="…">…</mark>` with one or more space-separated ids.
+- Comment records live in an `<aside class="rd-review" hidden>` at the end of `<body>` as `<rd-comment id="…">…</rd-comment>` elements.
+- Suggestions are `<ins>` / `<del>` (or both with a shared `data-rd-suggestion-id`) for insertion, deletion, and substitution.
+- Protected zones — `<script>`, `<style>`, `<pre>`, `<code>`, and `data-rd-literal` — are never rewritten.
+
+MCP tools that operate on annotated HTML files: `roughdraft_read_html_document`,
+`roughdraft_add_comment`, `roughdraft_accept_suggestion`, `roughdraft_reject_suggestion`.
+A captured end-to-end transcript lives at `.context/mcp-evidence/G6.4-agent-flow.transcript.md`.
+
 ## Agent setup
 If you want your local agent to remember the Roughdraft workflow, ask it to read the live setup prompt:
 

--- a/docs/adr/0005-html-review-annotation-contract.md
+++ b/docs/adr/0005-html-review-annotation-contract.md
@@ -1,0 +1,168 @@
+# 0005: HTML Review Annotation Contract
+
+## Status
+
+Accepted (MVP scope). Supersedes the implicit assumption in ADR 0001–0004 that the on-disk review format is Markdown + CriticMarkup, *only for the HTML-native flow being introduced on this branch*. Markdown/CriticMarkup remain authoritative for `.md` files.
+
+**Shipped (2026-05-23):** Parser, serializer, sanitizer, file backend (read/write), browser review rail (read-only render + click-to-scroll sync), authoring flows (add comment, accept/reject suggestion, multi-id anchors), and MCP tools (`roughdraft_read_html_document`, `roughdraft_add_comment`, `roughdraft_accept_suggestion`, `roughdraft_reject_suggestion`) all implement this contract. End-to-end agent flow evidence: `.context/mcp-evidence/G6.4-agent-flow.transcript.md`. Performance budgets: `packages/rfm/src/html/__tests__/perf-mixed-review.test.ts` and `packages/app/src/editor/html/__tests__/perf-render.test.tsx`.
+
+## Context
+
+Roughdraft is gaining an HTML-native review mode. Documents live on disk as `.html` (or `.htm`) and must remain readable, diffable, and editable by humans, agents, and third-party tools without the Roughdraft app present. CriticMarkup is a Markdown convention and does not survive HTML rendering; we need an HTML-native annotation layer that:
+
+- Renders harmlessly in any modern browser without Roughdraft (graceful degradation: comment bodies are still visible text, anchors highlight as `<mark>`).
+- Is unambiguous to parse and round-trip with low diff churn.
+- Is safe to ingest: a malicious HTML document must not exfiltrate data or execute scripts when opened in Roughdraft.
+- Composes with existing HTML content, including code listings and literal HTML examples.
+
+## Decision
+
+### 1. Comment anchors
+
+A reviewed span of inline content is wrapped in a single `<mark>` element whose `data-rd-comment-ids` attribute lists one or more comment record ids in the order they were created.
+
+```html
+<p>The <mark data-rd-comment-ids="c-7uG2">sky</mark> is blue.</p>
+```
+
+Rules:
+
+- The attribute value is a space-separated list of stable, opaque ids. Ids are URL-safe `[A-Za-z0-9_-]+` and unique within the document.
+- A `<mark>` with no `data-rd-comment-ids` attribute is treated as plain author content and is not a comment anchor.
+- `<mark>` is the *only* element used as a comment anchor. Other elements may not carry `data-rd-comment-ids`.
+- Anchors may not span block boundaries. To comment on a multi-paragraph region, the author creates one anchor per block and the comment record lists those anchor ids (see `data-rd-anchor-ids` on the record).
+- Anchors may not nest. To represent multiple comments on the same span, list all ids in one `data-rd-comment-ids` attribute on a single `<mark>`.
+
+### 2. Comment records
+
+Each comment is a `<rd-comment>` custom element placed in document order, after the block where its primary anchor lives, inside a `<aside class="rd-review" hidden>` container at the end of `<body>`:
+
+```html
+<aside class="rd-review" hidden>
+  <rd-comment
+    id="c-7uG2"
+    data-rd-author="ananth@cradlewise.com"
+    data-rd-created-at="2026-05-23T10:14:11Z"
+    data-rd-anchor-ids="c-7uG2"
+    data-rd-status="open"
+  >The sky is also sometimes grey.</rd-comment>
+</aside>
+```
+
+Rules:
+
+- `<rd-comment>` is an [HTML custom element](https://html.spec.whatwg.org/multipage/custom-elements.html). Browsers without Roughdraft render its text body inline; Roughdraft hides the `<aside>` via the `hidden` attribute when rendering its own review rail.
+- Required attributes: `id`, `data-rd-author`, `data-rd-created-at` (ISO-8601 UTC), `data-rd-status` (`open` | `resolved`), `data-rd-anchor-ids`.
+- Optional attributes: `data-rd-reply-to` (id of parent comment for threads), `data-rd-updated-at`.
+- The text content is the comment body. HTML content inside a comment body is restricted to the sanitizer allowlist (see §6). Bodies must escape `<` as `&lt;` etc. per normal HTML rules.
+- The `id` of a comment record matches at least one entry in some anchor's `data-rd-comment-ids`. The reverse must also hold: every id referenced by an anchor must have a record.
+- Replies (threaded comments) reference their parent via `data-rd-reply-to=<parent-id>` and need not have their own anchor; they may have `data-rd-anchor-ids=""`.
+
+### 3. Suggestions (insertion / deletion / substitution)
+
+Suggestions use the standard HTML semantic elements `<ins>` and `<del>` with Roughdraft attributes:
+
+- **Insertion**: `<ins data-rd-suggestion-id="s-1" data-rd-author="..." data-rd-created-at="...">new text</ins>`
+- **Deletion**: `<del data-rd-suggestion-id="s-2" data-rd-author="..." data-rd-created-at="...">old text</del>`
+- **Substitution**: a `<del>` immediately followed by an `<ins>` that share the same `data-rd-suggestion-id`.
+
+Rules:
+
+- `data-rd-suggestion-id` is required and unique-per-document.
+- Substitutions must be expressed as exactly one `<del>` adjacent to exactly one `<ins>` with the same id, in that order, with no intervening characters other than zero or more whitespace text nodes.
+- Suggestions may be commented: a `<mark data-rd-comment-ids>` may wrap a `<del>`, `<ins>`, or substitution pair. The reverse (a suggestion wrapping a comment anchor) is not permitted in MVP.
+- Optional `data-rd-status` on `<ins>`/`<del>`: `open` (default), `accepted`, `rejected`. Accepted/rejected suggestions are normally serialized as their resolved form (plain text or removed) — see §7.
+
+### 4. Multiple comments on one span
+
+Multiple comments anchored on the same span are expressed by listing all comment ids on a single `<mark>`:
+
+```html
+<p>The <mark data-rd-comment-ids="c-7uG2 c-9aB1">sky</mark> is blue.</p>
+```
+
+The corresponding `<rd-comment>` records appear in the `<aside class="rd-review">` in the order they were created, each with `data-rd-anchor-ids` listing this anchor's id-set (typically just its own id; see §2).
+
+### 5. Literal and protected zones
+
+The parser must not interpret review markup inside protected zones. Protected zones are:
+
+- `<script>` and `<style>` element contents.
+- `<pre>` element contents (whether or not they contain `<code>`).
+- `<code>` element contents (inline or inside `<pre>`).
+- Any element with `data-rd-literal` (escape hatch for templated literal HTML examples in docs).
+
+Inside a protected zone:
+
+- `<mark data-rd-comment-ids>`, `<ins data-rd-suggestion-id>`, `<del data-rd-suggestion-id>`, and `<rd-comment>` are treated as plain literal text, not as Roughdraft annotations.
+- The serializer must not move, normalize, or rewrite the inner content of protected zones beyond preserving it byte-for-byte.
+
+This makes it safe to write technical documentation that *describes* Roughdraft's HTML annotation format without accidentally annotating the documentation itself.
+
+### 6. Sanitizer allowlist
+
+When ingesting an HTML document the sanitizer enforces an allowlist. Anything outside the allowlist is dropped (element removed, attribute removed) and the operation is logged in the parsed model's `warnings`.
+
+Allowed structural elements (non-exhaustive starter list, finalized in G3.1):
+
+- Block: `html`, `head`, `body`, `meta`, `title`, `link[rel=stylesheet][href]` (same-origin only at write time), `style`, `article`, `section`, `header`, `footer`, `nav`, `main`, `aside`, `div`, `p`, `h1`–`h6`, `ul`, `ol`, `li`, `dl`, `dt`, `dd`, `blockquote`, `figure`, `figcaption`, `hr`, `table`, `thead`, `tbody`, `tfoot`, `tr`, `th`, `td`, `pre`.
+- Inline: `a[href]`, `span`, `strong`, `em`, `b`, `i`, `u`, `s`, `code`, `kbd`, `samp`, `var`, `sub`, `sup`, `br`, `img[src][alt]`.
+- Review: `mark`, `ins`, `del`, `rd-comment`.
+
+Allowed attributes (global): `id`, `class`, `lang`, `title`, `dir`, `hidden`, plus the `data-rd-*` namespace.
+
+Disallowed by default:
+
+- `<script>` in author content (allowed only in head boot via explicit opt-in, deferred from MVP).
+- `on*` event handlers, `javascript:` and `data:` URLs (except `data:image/*` in `img[src]`).
+- `<iframe>`, `<object>`, `<embed>`, `<form>`, `<input>`, `<button>`, `<select>`, `<textarea>`, `<link rel=preload>` and similar.
+- Inline `style` attributes (use class+stylesheet).
+
+The sanitizer is applied on read and on write. A round-trip through Roughdraft normalizes the document to the allowlist; this is acceptable churn explicitly permitted by §7.
+
+### 7. Low-churn serialization
+
+The serializer is **not byte-perfect**. It promises:
+
+- Stable output for a stable model: serializing the same model twice yields identical bytes.
+- Bounded churn for a bounded edit: editing one comment, anchor, or suggestion changes only the bytes inside its element and any whitespace immediately adjacent to it, not unrelated regions.
+- Whitespace normalization is permitted between block elements; whitespace inside protected zones (§5) is preserved byte-for-byte.
+- Attribute order within an element is stable and deterministic (Roughdraft picks a canonical order — TBD in implementation, but stable per parser version).
+- Self-closing form: void elements use `<br>` (HTML, not XHTML `<br/>`).
+
+This is the contract referenced by ADR 0003 for Markdown, restated for HTML.
+
+### 8. Document boot and graceful degradation
+
+A Roughdraft-emitted HTML document includes a small `<style>` in `<head>` that:
+
+- Shows `<mark data-rd-comment-ids>` with a soft yellow highlight.
+- Hides `<aside class="rd-review">` from non-Roughdraft renderers via the `hidden` attribute *and* a CSS fallback.
+- Styles `<ins data-rd-suggestion-id>` and `<del data-rd-suggestion-id>` distinctly.
+
+A document without this boot block is still valid; Roughdraft injects it on the next write if missing.
+
+## Consequences
+
+- Round-trip and mutation contracts are part of the product. New HTML features must add fixture coverage before broad parser/serializer refactors.
+- The MCP server exposes only operations expressible through this contract; agent-authored markup outside the contract is rejected by the sanitizer.
+- Markdown remains the on-disk format for `.md` files and is unchanged by this ADR.
+
+## What This Explicitly Does Not Mean
+
+- Roughdraft does not promise to preserve every byte of arbitrary input HTML; the sanitizer may legitimately strip disallowed constructs.
+- The contract is not a sidecar database. It must remain a single self-contained `.html` file readable in any browser.
+- This ADR does not commit to a specific parser library; G1.1 picks one.
+- This ADR does not define how the UI renders comments — only how they live on disk.
+
+## Deferred edge cases (revisit in Goal 7)
+
+- Anchors spanning block boundaries (currently disallowed; may be re-enabled with `data-rd-anchor-group`).
+- Nested suggestions (a suggestion inside another suggestion).
+- Comments anchored to non-text features (an image, a table cell, a heading id).
+- Cross-document comment refs (a comment referencing an anchor in another file).
+- `<script>` in author content with a Roughdraft-managed allowlist.
+- Reactions / emoji on comments.
+- Suggestion conflicts (two suggestions overlapping the same span).
+- Author identity beyond a free-text string (verified identities, per-org namespaces).
+- Internationalized punctuation in attribute values (validated at sanitizer level; tests deferred).

--- a/docs/spec/ui-state-screenshot-guide.md
+++ b/docs/spec/ui-state-screenshot-guide.md
@@ -66,6 +66,14 @@ Paragraph with **bold**, [link](https://example.com), `inline code`.
 ```markdown
 # Fenced examples This page should not show a review rail just because examples appear inside code fences. ```text {==example==}{>>comment<<}{id="c1" by="user" at="2026-05-12T22:52:50.592Z"} {++inserted++} {--deleted--} {~~old~>new~~} ```
 ```
+
+### Annotated HTML Document
+
+The canonical HTML fixtures live in `.context/fixtures/html/`. Use
+`mixed-review-document.html` for any HTML review-rail screenshots; it
+exercises a multi-id anchor, a substitution suggestion, a reply thread, and
+a resolved comment in one file. See
+`docs/adr/0005-html-review-annotation-contract.md` for the full schema.
 ## Capture Matrix
 | Area | State | How to reach it | Useful selectors | Notes |
 | --- | --- | --- | --- | --- |
@@ -115,6 +123,9 @@ Paragraph with **bold**, [link](https://example.com), `inline code`.
 | Comment editor | Reply editing | Use a reply action | `comment-rail-child-editor` | Useful for nested thread spacing. |
 | Code mode | Review rail present | Open review fixture with `?editor=code` | `page-card-code`, `markdown-code-editor` | Confirms code editor and rail can coexist. |
 | Code mode | Review rail absent | Open fenced fixture with `?editor=code` | `page-card-code`, `markdown-code-editor` | Confirms fenced CriticMarkup alone does not create review rail. |
+| HTML document | Read-only render | Open URL with `?path=<absolute>/mixed-review-document.html` | `comment-anchor`, `html-review-rail` | Confirms marks render and rail lists comments + suggestions in document order. |
+| HTML document | Add comment composer | Select inline text in the HTML doc and choose `Add comment` | `html-add-comment-composer` | Captures the composer over the selected anchor span. |
+| HTML document | Accept/Reject suggestion | Open a fixture with a substitution; use rail actions | `html-suggestion-action-accept`, `html-suggestion-action-reject` | Verify the on-disk file is updated after each action. |
 | Error/home fallback | Non-Markdown path | Open URL with `?path=/tmp/file.txt` | homepage error message | Copy: `Roughdraft now opens one .md file at a time.` |
 | Error/home fallback | Missing/unloadable path | Open URL with invalid markdown path through local backend | homepage error message | Captures load-error homepage variant. |
 ## Playwright Capture Skeleton

--- a/packages/app/e2e/html-authoring.spec.ts
+++ b/packages/app/e2e/html-authoring.spec.ts
@@ -1,0 +1,261 @@
+import { expect, test, type Page } from "@playwright/test";
+import {
+  createMarkdownProject,
+  logE2eEvent,
+  readProjectFile,
+  removeMarkdownProject,
+  writeProjectFile,
+} from "./helpers";
+
+const BASE_HTML = `<!doctype html>
+<html lang="en">
+  <head><title>HTML authoring fixture</title></head>
+  <body>
+    <article>
+      <h1>Quarterly review</h1>
+      <p>We expanded the team in Berlin and Bangalore.</p>
+      <p>We shipped <ins data-rd-suggestion-id="s-ins" data-rd-author="reviewer@example.com" data-rd-created-at="2026-05-23T12:00:00Z" data-rd-status="open">three new</ins> features this week.</p>
+      <p>We will replace <del data-rd-suggestion-id="s-sub" data-rd-author="reviewer@example.com" data-rd-created-at="2026-05-23T12:01:00Z" data-rd-status="open">the legacy parser</del><ins data-rd-suggestion-id="s-sub" data-rd-author="reviewer@example.com" data-rd-created-at="2026-05-23T12:01:00Z" data-rd-status="open">the new streaming parser</ins> next sprint.</p>
+    </article>
+  </body>
+</html>`;
+
+const ANCHORED_HTML = `<!doctype html>
+<html lang="en">
+  <head><title>HTML multi comment fixture</title></head>
+  <body>
+    <article>
+      <h1>Quarterly review</h1>
+      <p>We expanded the team in <mark data-rd-comment-ids="c-existing">Berlin and Bangalore</mark>.</p>
+    </article>
+    <aside class="rd-review" hidden>
+      <rd-comment id="c-existing" data-rd-anchor-ids="c-existing" data-rd-status="open" data-rd-author="reviewer@example.com" data-rd-created-at="2026-05-23T12:00:00Z">Existing comment.</rd-comment>
+    </aside>
+  </body>
+</html>`;
+
+async function openHtmlFile(page: Page, absolutePath: string) {
+  await page.goto(
+    `/?${new URLSearchParams({ path: absolutePath }).toString()}`,
+  );
+  await expect(page.getByTestId("html-document-workspace")).toHaveAttribute(
+    "data-state",
+    "loaded",
+  );
+}
+
+async function selectHtmlText(page: Page, text: string) {
+  await page.evaluate((targetText) => {
+    const root = document.querySelector('[data-testid="html-readonly-view"]');
+    if (!root) throw new Error("Could not find HTML readonly view");
+
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    let node = walker.nextNode();
+    while (node) {
+      const index = node.textContent?.indexOf(targetText) ?? -1;
+      if (index >= 0) {
+        const range = document.createRange();
+        range.setStart(node, index);
+        range.setEnd(node, index + targetText.length);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+        document.dispatchEvent(new Event("selectionchange", { bubbles: true }));
+        return;
+      }
+      node = walker.nextNode();
+    }
+    throw new Error(`Could not find text "${targetText}"`);
+  }, text);
+}
+
+test.describe("html authoring", () => {
+  let projectDir: string;
+
+  test.beforeEach(() => {
+    projectDir = createMarkdownProject("html-authoring");
+  });
+
+  test.afterEach(() => {
+    removeMarkdownProject(projectDir);
+  });
+
+  test("html add comment persists anchor and record after reload @smoke", async ({
+    page,
+  }, testInfo) => {
+    const filePath = writeProjectFile(projectDir, "doc.html", BASE_HTML);
+    await openHtmlFile(page, filePath);
+
+    await selectHtmlText(page, "Berlin and Bangalore");
+    await page.getByTestId("html-add-comment-button").click();
+    await expect(page.getByTestId("add-comment-composer")).toBeVisible();
+    await testInfo.attach("G5.1-01-composer-open.png", {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: "image/png",
+    });
+
+    await page.getByTestId("add-comment-body").fill("Mention headcount delta.");
+    await page.getByTestId("add-comment-save").click();
+
+    await expect(page.getByTestId("add-comment-composer")).toHaveCount(0);
+    await expect(page.getByTestId("html-review-rail")).toContainText(
+      "Mention headcount delta.",
+    );
+
+    await page.reload();
+    await expect(page.getByTestId("html-document-workspace")).toHaveAttribute(
+      "data-state",
+      "loaded",
+    );
+    await expect(page.getByTestId("html-review-rail")).toContainText(
+      "Mention headcount delta.",
+    );
+    await expect(
+      page.locator('[data-testid="comment-anchor"]').filter({
+        hasText: "Berlin and Bangalore",
+      }),
+    ).toBeVisible();
+
+    const disk = readProjectFile(projectDir, "doc.html");
+    expect(disk).toContain("Mention headcount delta.");
+    expect(disk).toContain("<mark data-rd-comment-ids=");
+    expect(disk).toContain("<rd-comment");
+
+    await testInfo.attach("G5.1-02-after-save.png", {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: "image/png",
+    });
+    logE2eEvent("html-authoring.add-comment", { file: filePath });
+  });
+
+  test("html accept suggestion persists resolved inserted text after reload @smoke", async ({
+    page,
+  }, testInfo) => {
+    const filePath = writeProjectFile(projectDir, "doc.html", BASE_HTML);
+    await openHtmlFile(page, filePath);
+
+    await expect(page.getByTestId("html-review-rail")).toContainText(
+      "Insertion",
+    );
+    await testInfo.attach("G5.2-01-before-accept.png", {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: "image/png",
+    });
+
+    await page
+      .locator('[data-testid="suggestion-accept"][data-suggestion-id="s-ins"]')
+      .click();
+    await expect(
+      page.locator(
+        '[data-testid="suggestion-accept"][data-suggestion-id="s-ins"]',
+      ),
+    ).toHaveCount(0);
+    await expect(page.getByTestId("html-readonly-view")).toContainText(
+      "We shipped three new features this week.",
+    );
+
+    await page.reload();
+    await expect(page.getByTestId("html-document-workspace")).toHaveAttribute(
+      "data-state",
+      "loaded",
+    );
+    await expect(page.getByTestId("html-readonly-view")).toContainText(
+      "We shipped three new features this week.",
+    );
+
+    const disk = readProjectFile(projectDir, "doc.html");
+    expect(disk).toContain("three new");
+    expect(disk).not.toContain('data-rd-suggestion-id="s-ins"');
+
+    await testInfo.attach("G5.2-02-after-accept.png", {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: "image/png",
+    });
+    logE2eEvent("html-authoring.accept-suggestion", { file: filePath });
+  });
+
+  test("html reject suggestion restores deleted text after reload @smoke", async ({
+    page,
+  }, testInfo) => {
+    const filePath = writeProjectFile(projectDir, "doc.html", BASE_HTML);
+    await openHtmlFile(page, filePath);
+
+    await expect(page.getByTestId("html-review-rail")).toContainText(
+      "Substitution",
+    );
+    await testInfo.attach("G5.3-01-before-reject.png", {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: "image/png",
+    });
+
+    await page
+      .locator('[data-testid="suggestion-reject"][data-suggestion-id="s-sub"]')
+      .click();
+    await expect(
+      page.locator(
+        '[data-testid="suggestion-reject"][data-suggestion-id="s-sub"]',
+      ),
+    ).toHaveCount(0);
+    await expect(page.getByTestId("html-readonly-view")).toContainText(
+      "We will replace the legacy parser next sprint.",
+    );
+
+    await page.reload();
+    await expect(page.getByTestId("html-document-workspace")).toHaveAttribute(
+      "data-state",
+      "loaded",
+    );
+    await expect(page.getByTestId("html-readonly-view")).toContainText(
+      "We will replace the legacy parser next sprint.",
+    );
+
+    const disk = readProjectFile(projectDir, "doc.html");
+    expect(disk).toContain("the legacy parser");
+    expect(disk).not.toContain("the new streaming parser");
+    expect(disk).not.toContain('data-rd-suggestion-id="s-sub"');
+
+    await testInfo.attach("G5.3-02-after-reject.png", {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: "image/png",
+    });
+    logE2eEvent("html-authoring.reject-suggestion", { file: filePath });
+  });
+
+  test("html multi-comment span shows both comments on one anchor @smoke", async ({
+    page,
+  }, testInfo) => {
+    const filePath = writeProjectFile(projectDir, "doc.html", ANCHORED_HTML);
+    await openHtmlFile(page, filePath);
+
+    await selectHtmlText(page, "Berlin and Bangalore");
+    await page.getByTestId("html-add-comment-button").click();
+    await page.getByTestId("add-comment-body").fill("Second comment.");
+    await page.getByTestId("add-comment-save").click();
+
+    await expect(page.getByTestId("html-review-rail")).toContainText(
+      "Existing comment.",
+    );
+    await expect(page.getByTestId("html-review-rail")).toContainText(
+      "Second comment.",
+    );
+
+    const anchors = page.locator('[data-testid="comment-anchor"]');
+    await expect(anchors).toHaveCount(1);
+    await expect(anchors.first()).toHaveAttribute(
+      "data-rd-comment-ids",
+      /c-existing\s+c-/,
+    );
+
+    const disk = readProjectFile(projectDir, "doc.html");
+    const markCount = (disk.match(/<mark\b/g) ?? []).length;
+    expect(markCount).toBe(1);
+    expect(disk).toContain("c-existing");
+    expect(disk).toContain("Second comment.");
+
+    await testInfo.attach("G5.4-01-two-comments-one-span.png", {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: "image/png",
+    });
+    logE2eEvent("html-authoring.multi-comment-span", { file: filePath });
+  });
+});

--- a/packages/app/e2e/html-review-rail-sync.spec.ts
+++ b/packages/app/e2e/html-review-rail-sync.spec.ts
@@ -1,0 +1,119 @@
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import {
+  createMarkdownProject,
+  logE2eEvent,
+  removeMarkdownProject,
+  writeProjectFile,
+} from "./helpers";
+
+const HTML_FIXTURE = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>HTML review rail sync fixture</title>
+  </head>
+  <body>
+    <article>
+      <h1>Quarterly review</h1>
+      <p>
+        Revenue grew
+        <mark data-rd-comment-ids="c-rev-1">12%</mark>
+        quarter over quarter.
+      </p>
+      <p>
+        We expanded the team in
+        <mark data-rd-comment-ids="c-team-1">Berlin and Bangalore</mark>.
+      </p>
+    </article>
+    <aside class="rd-review" hidden>
+      <rd-comment id="c-rev-1" data-rd-anchor-ids="c-rev-1" data-rd-status="open"
+        data-rd-author="reviewer@example.com"
+        data-rd-created-at="2026-05-23T12:00:30Z"
+      >Cite the exact source row.</rd-comment>
+      <rd-comment id="c-team-1" data-rd-anchor-ids="c-team-1" data-rd-status="open"
+        data-rd-author="ananth@cradlewise.com"
+        data-rd-created-at="2026-05-23T12:02:00Z"
+      >Mention headcount delta.</rd-comment>
+    </aside>
+  </body>
+</html>`;
+
+test.describe("html review rail sync", () => {
+  let projectDir: string;
+
+  test.beforeEach(() => {
+    projectDir = createMarkdownProject("html-review-rail-sync");
+  });
+
+  test.afterEach(() => {
+    removeMarkdownProject(projectDir);
+  });
+
+  test("renders, syncs rail and anchor click activation @smoke", async ({
+    page,
+  }, testInfo) => {
+    const filePath = writeProjectFile(projectDir, "doc.html", HTML_FIXTURE);
+
+    await page.goto(`/?${new URLSearchParams({ path: filePath }).toString()}`);
+
+    const workspace = page.getByTestId("html-document-workspace");
+    await expect(workspace).toHaveAttribute("data-state", "loaded");
+    await expect(page.getByTestId("html-readonly-view")).toBeVisible();
+    await expect(page.getByTestId("html-review-rail")).toBeVisible();
+
+    await expect(page.getByTestId("html-readonly-view")).toContainText(
+      "Quarterly review",
+    );
+    await expect(page.getByTestId("html-readonly-view")).toContainText(
+      "Revenue grew",
+    );
+
+    const anchorRev = page.locator(
+      '[data-testid="comment-anchor"][data-rd-comment-ids="c-rev-1"]',
+    );
+    const anchorTeam = page.locator(
+      '[data-testid="comment-anchor"][data-rd-comment-ids="c-team-1"]',
+    );
+    await expect(anchorRev).toBeVisible();
+    await expect(anchorTeam).toBeVisible();
+
+    const reviewCards = page.getByTestId("html-review-card");
+    const cardRev = reviewCards.nth(0);
+    const cardTeam = reviewCards.nth(1);
+    await expect(cardRev).toBeVisible();
+    await expect(cardTeam).toBeVisible();
+
+    await testInfo.attach("01-loaded.png", {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: "image/png",
+    });
+
+    // Rail card → inline anchor sync
+    await cardRev.click();
+    await expect(cardRev).toHaveAttribute("data-active", "true");
+    await expect(anchorRev).toHaveAttribute("data-active", "true");
+    await expect(cardTeam).toHaveAttribute("data-active", "false");
+
+    await testInfo.attach("02-rail-click.png", {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: "image/png",
+    });
+
+    // Inline anchor → rail card sync
+    await anchorTeam.click();
+    await expect(anchorTeam).toHaveAttribute("data-active", "true");
+    await expect(cardTeam).toHaveAttribute("data-active", "true");
+    await expect(cardRev).toHaveAttribute("data-active", "false");
+
+    await testInfo.attach("03-anchor-click.png", {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: "image/png",
+    });
+
+    logE2eEvent("html-review-rail-sync.synced", {
+      projectDir,
+      file: path.basename(filePath),
+    });
+  });
+});

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -6,9 +6,9 @@ const appUrl = `http://127.0.0.1:${appPort}`;
 
 export default defineConfig({
   testDir: "./e2e",
-  timeout: 30_000,
+  timeout: 120_000,
   expect: {
-    timeout: 7_500,
+    timeout: 30_000,
   },
   fullyParallel: true,
   reporter: process.env.CI ? "github" : "list",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -44,6 +44,7 @@ import {
   DialogTrigger,
 } from "./components/ui/dialog";
 import { DocumentWorkspace } from "./DocumentWorkspace";
+import { HtmlDocumentWorkspace } from "./editor/html/HtmlDocumentWorkspace";
 import {
   getCommentAnchorMeasurements,
   groupCommentAnchorMeasurements,
@@ -1588,6 +1589,12 @@ export function App() {
 
         if (cancelled) return;
 
+        if (requestedPathState.documentKind === "html") {
+          setActiveDocumentPath(requestedPathState.documentPath);
+          setLoading(false);
+          return;
+        }
+
         await loadDocument(detectedBackend, requestedPathState.documentPath);
         if (cancelled) return;
 
@@ -1609,6 +1616,7 @@ export function App() {
     };
   }, [
     loadDocument,
+    requestedPathState.documentKind,
     requestedPathState.documentPath,
     requestedPathState.projectPath,
     requestedPathState.rawPath,
@@ -1795,6 +1803,7 @@ export function App() {
 
   useEffect(() => {
     if (!backend?.watchMarkdownFile || !activeDocumentPath) return;
+    if (requestedPathState.documentKind === "html") return;
 
     let disposed = false;
     const stopWatching = backend.watchMarkdownFile(
@@ -1843,7 +1852,13 @@ export function App() {
       disposed = true;
       stopWatching();
     };
-  }, [activeDocumentPath, applyDocumentPage, backend, documentDiskChangeState]);
+  }, [
+    activeDocumentPath,
+    applyDocumentPage,
+    backend,
+    documentDiskChangeState,
+    requestedPathState.documentKind,
+  ]);
 
   const handleDocumentEditorViewModeChange = useCallback(
     (nextMode: DocumentEditorViewMode) => {
@@ -1883,6 +1898,30 @@ export function App() {
         message={loadError ?? <HomepageSubtitle />}
         updateStatus={updateStatus}
       />
+    );
+  }
+
+  if (
+    requestedPathState.documentKind === "html" &&
+    requestedPathState.documentPath
+  ) {
+    return (
+      <main className="relative flex h-screen min-w-0 flex-col overflow-hidden bg-[#FCFCFC] dark:bg-background text-slate-950 dark:text-slate-50">
+        {updateStatus ? (
+          <div className="pointer-events-none absolute top-4 right-4 z-40 max-w-sm">
+            <div className="pointer-events-auto">
+              <UpdateNotice updateStatus={updateStatus} />
+            </div>
+          </div>
+        ) : null}
+        <HtmlDocumentWorkspace
+          documentPath={requestedPathState.documentPath}
+          projectPath={
+            backend?.info.projectPath ?? requestedPathState.projectPath
+          }
+          absolutePath={requestedPathState.rawPath}
+        />
+      </main>
     );
   }
 

--- a/packages/app/src/app-navigation.test.ts
+++ b/packages/app/src/app-navigation.test.ts
@@ -23,6 +23,7 @@ describe("app navigation", () => {
       rawPath: "/Users/me/.claude/plans/example.md",
       projectPath: "/Users/me/.claude/plans",
       documentPath: "example.md",
+      documentKind: "markdown",
     });
   });
 
@@ -44,6 +45,7 @@ describe("app navigation", () => {
       rawPath: null,
       projectPath: null,
       documentPath: null,
+      documentKind: null,
     });
 
     window.history.replaceState(null, "", PREVIEW_PATH);
@@ -52,6 +54,37 @@ describe("app navigation", () => {
       rawPath: null,
       projectPath: null,
       documentPath: null,
+      documentKind: null,
+    });
+  });
+
+  it("recognizes .html paths", () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/?path=%2FUsers%2Fme%2Fdocs%2Freport.html",
+    );
+
+    expect(getRequestedPathState()).toEqual({
+      rawPath: "/Users/me/docs/report.html",
+      projectPath: "/Users/me/docs",
+      documentPath: "report.html",
+      documentKind: "html",
+    });
+  });
+
+  it("recognizes .htm paths", () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/?path=%2FUsers%2Fme%2Fdocs%2Flegacy.htm",
+    );
+
+    expect(getRequestedPathState()).toEqual({
+      rawPath: "/Users/me/docs/legacy.htm",
+      projectPath: "/Users/me/docs",
+      documentPath: "legacy.htm",
+      documentKind: "html",
     });
   });
 

--- a/packages/app/src/app-navigation.ts
+++ b/packages/app/src/app-navigation.ts
@@ -1,7 +1,10 @@
+export type RequestedDocumentKind = "markdown" | "html";
+
 interface RequestedPathState {
   rawPath: string | null;
   projectPath: string | null;
   documentPath: string | null;
+  documentKind: RequestedDocumentKind | null;
 }
 
 export type DocumentEditorViewMode = "rich-text" | "code";
@@ -49,15 +52,36 @@ export function getDocumentEditorViewModeFromLocation(
   return fallbackMode;
 }
 
+function requestedDocumentKindFromPath(
+  normalizedPath: string,
+): RequestedDocumentKind | null {
+  const lower = normalizedPath.toLowerCase();
+  if (lower.endsWith(".md")) return "markdown";
+  if (lower.endsWith(".html") || lower.endsWith(".htm")) return "html";
+  return null;
+}
+
 export function getRequestedPathState(): RequestedPathState {
   const rawPath = getRawPathFromLocation();
   if (!rawPath) {
-    return { rawPath: null, projectPath: null, documentPath: null };
+    return {
+      rawPath: null,
+      projectPath: null,
+      documentPath: null,
+      documentKind: null,
+    };
   }
 
   const normalizedPath = normalizePathSeparators(rawPath);
-  if (!normalizedPath.toLowerCase().endsWith(".md")) {
-    return { rawPath, projectPath: rawPath, documentPath: null };
+  const documentKind = requestedDocumentKindFromPath(normalizedPath);
+
+  if (!documentKind) {
+    return {
+      rawPath,
+      projectPath: rawPath,
+      documentPath: null,
+      documentKind: null,
+    };
   }
 
   const lastSlashIndex = Math.max(
@@ -68,7 +92,7 @@ export function getRequestedPathState(): RequestedPathState {
     lastSlashIndex >= 0 ? rawPath.slice(0, lastSlashIndex) || "/" : ".";
   const documentPath = rawPath.slice(lastSlashIndex + 1);
 
-  return { rawPath, projectPath, documentPath };
+  return { rawPath, projectPath, documentPath, documentKind };
 }
 
 export function formatWorkspacePathForDisplay(path?: string | null) {

--- a/packages/app/src/authoring/AddCommentComposer.tsx
+++ b/packages/app/src/authoring/AddCommentComposer.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef, useState } from "react";
+
+export interface AddCommentSubmitInput {
+  body: string;
+}
+
+export interface AddCommentComposerProps {
+  open: boolean;
+  selectedText: string;
+  onSubmit: (input: AddCommentSubmitInput) => void;
+  onCancel: () => void;
+  busy?: boolean;
+  error?: string | null;
+}
+
+export function AddCommentComposer({
+  open,
+  selectedText,
+  onSubmit,
+  onCancel,
+  busy = false,
+  error = null,
+}: AddCommentComposerProps) {
+  const [body, setBody] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setBody("");
+      textareaRef.current?.focus();
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  const trimmed = body.trim();
+  const canSubmit = trimmed.length > 0 && !busy;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    onSubmit({ body: trimmed });
+  };
+
+  return (
+    <div
+      data-testid="add-comment-composer"
+      role="dialog"
+      aria-label="Add comment"
+      className="rd-html-add-comment-composer"
+    >
+      <header className="rd-html-add-comment-composer__header">
+        <span className="rd-html-add-comment-composer__label">Comment on</span>
+        <span
+          data-testid="add-comment-selected-text"
+          className="rd-html-add-comment-composer__selected"
+        >
+          {selectedText}
+        </span>
+      </header>
+      <textarea
+        ref={textareaRef}
+        data-testid="add-comment-body"
+        className="rd-html-add-comment-composer__body"
+        placeholder="Comment"
+        value={body}
+        onChange={(event) => {
+          setBody(event.target.value);
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            onCancel();
+          }
+        }}
+        rows={3}
+      />
+      {error ? (
+        <p
+          data-testid="add-comment-error"
+          role="alert"
+          className="rd-html-add-comment-composer__error"
+        >
+          {error}
+        </p>
+      ) : null}
+      <footer className="rd-html-add-comment-composer__actions">
+        <button
+          type="button"
+          data-testid="add-comment-cancel"
+          onClick={() => {
+            onCancel();
+          }}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          data-testid="add-comment-save"
+          disabled={!canSubmit}
+          onClick={handleSubmit}
+        >
+          {busy ? "Saving…" : "Save"}
+        </button>
+      </footer>
+    </div>
+  );
+}

--- a/packages/app/src/authoring/SuggestionActions.tsx
+++ b/packages/app/src/authoring/SuggestionActions.tsx
@@ -1,0 +1,55 @@
+export interface AcceptSuggestionProps {
+  suggestionId: string;
+  onAccept: (suggestionId: string) => void;
+  disabled?: boolean;
+}
+
+export function AcceptSuggestion({
+  suggestionId,
+  onAccept,
+  disabled = false,
+}: AcceptSuggestionProps) {
+  return (
+    <button
+      type="button"
+      data-testid="suggestion-accept"
+      data-suggestion-id={suggestionId}
+      disabled={disabled}
+      onClick={(event) => {
+        event.stopPropagation();
+        onAccept(suggestionId);
+      }}
+      className="rd-html-suggestion-action rd-html-suggestion-action--accept"
+    >
+      Accept
+    </button>
+  );
+}
+
+export interface RejectSuggestionProps {
+  suggestionId: string;
+  onReject: (suggestionId: string) => void;
+  disabled?: boolean;
+}
+
+export function RejectSuggestion({
+  suggestionId,
+  onReject,
+  disabled = false,
+}: RejectSuggestionProps) {
+  return (
+    <button
+      type="button"
+      data-testid="suggestion-reject"
+      data-suggestion-id={suggestionId}
+      disabled={disabled}
+      onClick={(event) => {
+        event.stopPropagation();
+        onReject(suggestionId);
+      }}
+      className="rd-html-suggestion-action rd-html-suggestion-action--reject"
+    >
+      Reject
+    </button>
+  );
+}

--- a/packages/app/src/authoring/__tests__/AcceptSuggestion.test.tsx
+++ b/packages/app/src/authoring/__tests__/AcceptSuggestion.test.tsx
@@ -1,0 +1,86 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { acceptHtmlSuggestion, parseAnnotatedHtml } from "@roughdraft/rfm";
+import { AcceptSuggestion } from "../SuggestionActions";
+
+const SUGGESTIONS_HTML = `<!doctype html>
+<html lang="en"><head><title>S</title></head>
+<body>
+  <article>
+    <p>
+      We shipped
+      <ins data-rd-suggestion-id="s-1" data-rd-author="a" data-rd-created-at="2026-05-23T11:00:00Z" data-rd-status="open">three new</ins>
+      features this week.
+    </p>
+    <p>
+      We will replace
+      <del data-rd-suggestion-id="s-3" data-rd-author="a" data-rd-created-at="2026-05-23T11:02:30Z">the legacy parser</del><ins data-rd-suggestion-id="s-3" data-rd-author="a" data-rd-created-at="2026-05-23T11:02:30Z">the new streaming parser</ins>
+      next sprint.
+    </p>
+  </article>
+</body></html>`;
+
+describe("AcceptSuggestion", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders an Accept button tied to the suggestion id", async () => {
+    await act(async () => {
+      root.render(<AcceptSuggestion suggestionId="s-1" onAccept={() => {}} />);
+    });
+    const button = container.querySelector(
+      '[data-testid="suggestion-accept"][data-suggestion-id="s-1"]',
+    ) as HTMLButtonElement | null;
+    expect(button).not.toBeNull();
+  });
+
+  it("calls onAccept with the suggestion id when clicked", async () => {
+    const onAccept = vi.fn();
+    await act(async () => {
+      root.render(<AcceptSuggestion suggestionId="s-1" onAccept={onAccept} />);
+    });
+
+    const button = container.querySelector(
+      '[data-testid="suggestion-accept"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      button.click();
+    });
+
+    expect(onAccept).toHaveBeenCalledWith("s-1");
+  });
+
+  it("accept standalone ins removes the ins wrapper and keeps the inserted text", () => {
+    const doc = parseAnnotatedHtml(SUGGESTIONS_HTML);
+    const next = acceptHtmlSuggestion(doc, { id: "s-1" });
+    expect(next.source).toContain("We shipped\n      three new\n");
+    expect(next.source).not.toContain('data-rd-suggestion-id="s-1"');
+    // The other suggestion is left alone.
+    expect(next.source).toContain('data-rd-suggestion-id="s-3"');
+  });
+
+  it("accept substitution replaces del+ins with the inserted text", () => {
+    const doc = parseAnnotatedHtml(SUGGESTIONS_HTML);
+    const next = acceptHtmlSuggestion(doc, { id: "s-3" });
+    expect(next.source).toContain("the new streaming parser");
+    expect(next.source).not.toContain("the legacy parser");
+    expect(next.source).not.toContain('data-rd-suggestion-id="s-3"');
+  });
+});

--- a/packages/app/src/authoring/__tests__/AddCommentComposer.test.tsx
+++ b/packages/app/src/authoring/__tests__/AddCommentComposer.test.tsx
@@ -1,0 +1,144 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AddCommentComposer } from "../AddCommentComposer";
+
+describe("AddCommentComposer", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders the selected anchor text", async () => {
+    await act(async () => {
+      root.render(
+        <AddCommentComposer
+          open
+          selectedText="Revenue grew"
+          onSubmit={() => {}}
+          onCancel={() => {}}
+        />,
+      );
+    });
+
+    expect(
+      container.querySelector('[data-testid="add-comment-composer"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="add-comment-selected-text"]')
+        ?.textContent,
+    ).toContain("Revenue grew");
+  });
+
+  it("renders nothing when not open", async () => {
+    await act(async () => {
+      root.render(
+        <AddCommentComposer
+          open={false}
+          selectedText="x"
+          onSubmit={() => {}}
+          onCancel={() => {}}
+        />,
+      );
+    });
+
+    expect(
+      container.querySelector('[data-testid="add-comment-composer"]'),
+    ).toBeNull();
+  });
+
+  it("disables Save when body is empty or whitespace", async () => {
+    await act(async () => {
+      root.render(
+        <AddCommentComposer
+          open
+          selectedText="x"
+          onSubmit={() => {}}
+          onCancel={() => {}}
+        />,
+      );
+    });
+
+    const save = container.querySelector(
+      '[data-testid="add-comment-save"]',
+    ) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+  });
+
+  it("submits the trimmed body via onSubmit", async () => {
+    const onSubmit = vi.fn();
+    await act(async () => {
+      root.render(
+        <AddCommentComposer
+          open
+          selectedText="anchor"
+          onSubmit={onSubmit}
+          onCancel={() => {}}
+        />,
+      );
+    });
+
+    const textarea = container.querySelector(
+      '[data-testid="add-comment-body"]',
+    ) as HTMLTextAreaElement;
+    expect(textarea).not.toBeNull();
+
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value",
+      )?.set;
+      setter?.call(textarea, "  Please cite source.  ");
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const save = container.querySelector(
+      '[data-testid="add-comment-save"]',
+    ) as HTMLButtonElement;
+    expect(save.disabled).toBe(false);
+
+    await act(async () => {
+      save.click();
+    });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({ body: "Please cite source." });
+  });
+
+  it("calls onCancel when Cancel is pressed", async () => {
+    const onCancel = vi.fn();
+    await act(async () => {
+      root.render(
+        <AddCommentComposer
+          open
+          selectedText="x"
+          onSubmit={() => {}}
+          onCancel={onCancel}
+        />,
+      );
+    });
+
+    const cancel = container.querySelector(
+      '[data-testid="add-comment-cancel"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      cancel.click();
+    });
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/src/authoring/__tests__/MultiCommentSpan.test.tsx
+++ b/packages/app/src/authoring/__tests__/MultiCommentSpan.test.tsx
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  addHtmlComment,
+  parseAnnotatedHtml,
+  removeHtmlComment,
+} from "@roughdraft/rfm";
+
+const PLAIN_HTML = `<!doctype html>
+<html lang="en">
+  <head><title>Multi-comment fixture</title></head>
+  <body>
+    <article>
+      <p>We expanded the team in Berlin and Bangalore.</p>
+    </article>
+  </body>
+</html>`;
+
+const ALREADY_ANCHORED_HTML = `<!doctype html>
+<html lang="en">
+  <head><title>Already anchored fixture</title></head>
+  <body>
+    <article>
+      <p>We expanded the team in <mark data-rd-comment-ids="c-1">Berlin and Bangalore</mark>.</p>
+    </article>
+    <aside class="rd-review" hidden>
+      <rd-comment id="c-1" data-rd-anchor-ids="c-1" data-rd-status="open" data-rd-author="a" data-rd-created-at="2026-05-23T12:00:00Z">First comment.</rd-comment>
+    </aside>
+  </body>
+</html>`;
+
+describe("MultiCommentSpan", () => {
+  it("adding a second comment to an already-anchored span keeps a single mark with two ids", () => {
+    const doc0 = parseAnnotatedHtml(ALREADY_ANCHORED_HTML);
+    const doc1 = addHtmlComment(doc0, {
+      id: "c-2",
+      anchor: { text: "Berlin and Bangalore" },
+      author: "b",
+      createdAt: "2026-05-23T12:05:00Z",
+      body: "Second comment.",
+    });
+
+    // Exactly one mark wrapping the anchored span (no nested or duplicated marks).
+    const markMatches = doc1.source.match(/<mark\b/g) ?? [];
+    expect(markMatches.length).toBe(1);
+
+    // The single mark holds both ids.
+    const idAttr = doc1.source.match(/data-rd-comment-ids="([^"]*)"/);
+    expect(idAttr).not.toBeNull();
+    const ids = (idAttr?.[1] ?? "").split(/\s+/).filter(Boolean);
+    expect(ids).toEqual(expect.arrayContaining(["c-1", "c-2"]));
+    expect(ids).toHaveLength(2);
+
+    // Both comments are in the model.
+    expect(doc1.comments.map((c) => c.id)).toEqual(
+      expect.arrayContaining(["c-1", "c-2"]),
+    );
+  });
+
+  it("removing one of N comments updates the mark to N-1 ids without nesting", () => {
+    const doc0 = parseAnnotatedHtml(ALREADY_ANCHORED_HTML);
+    const doc1 = addHtmlComment(doc0, {
+      id: "c-2",
+      anchor: { text: "Berlin and Bangalore" },
+      author: "b",
+      createdAt: "2026-05-23T12:05:00Z",
+      body: "Second comment.",
+    });
+
+    const doc2 = removeHtmlComment(doc1, { id: "c-1" });
+
+    const markMatches = doc2.source.match(/<mark\b/g) ?? [];
+    expect(markMatches.length).toBe(1);
+
+    const idAttr = doc2.source.match(/data-rd-comment-ids="([^"]*)"/);
+    const ids = (idAttr?.[1] ?? "").split(/\s+/).filter(Boolean);
+    expect(ids).toEqual(["c-2"]);
+
+    expect(doc2.comments.map((c) => c.id)).toEqual(["c-2"]);
+  });
+
+  it("adds a fresh anchor when the span is not previously wrapped", () => {
+    const doc0 = parseAnnotatedHtml(PLAIN_HTML);
+    const doc1 = addHtmlComment(doc0, {
+      id: "c-fresh",
+      anchor: { text: "Berlin and Bangalore" },
+      author: "a",
+      createdAt: "2026-05-23T12:00:00Z",
+      body: "First.",
+    });
+
+    expect(doc1.source).toContain(
+      '<mark data-rd-comment-ids="c-fresh">Berlin and Bangalore</mark>',
+    );
+    expect(doc1.comments.map((c) => c.id)).toEqual(["c-fresh"]);
+  });
+});

--- a/packages/app/src/authoring/__tests__/RejectSuggestion.test.tsx
+++ b/packages/app/src/authoring/__tests__/RejectSuggestion.test.tsx
@@ -1,0 +1,86 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseAnnotatedHtml, rejectHtmlSuggestion } from "@roughdraft/rfm";
+import { RejectSuggestion } from "../SuggestionActions";
+
+const SUGGESTIONS_HTML = `<!doctype html>
+<html lang="en"><head><title>S</title></head>
+<body>
+  <article>
+    <p>
+      We shipped
+      <ins data-rd-suggestion-id="s-1" data-rd-author="a" data-rd-created-at="2026-05-23T11:00:00Z" data-rd-status="open">three new</ins>
+      features this week.
+    </p>
+    <p>
+      We will replace
+      <del data-rd-suggestion-id="s-3" data-rd-author="a" data-rd-created-at="2026-05-23T11:02:30Z">the legacy parser</del><ins data-rd-suggestion-id="s-3" data-rd-author="a" data-rd-created-at="2026-05-23T11:02:30Z">the new streaming parser</ins>
+      next sprint.
+    </p>
+  </article>
+</body></html>`;
+
+describe("RejectSuggestion", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders a Reject button tied to the suggestion id", async () => {
+    await act(async () => {
+      root.render(<RejectSuggestion suggestionId="s-1" onReject={() => {}} />);
+    });
+    const button = container.querySelector(
+      '[data-testid="suggestion-reject"][data-suggestion-id="s-1"]',
+    ) as HTMLButtonElement | null;
+    expect(button).not.toBeNull();
+  });
+
+  it("calls onReject with the suggestion id when clicked", async () => {
+    const onReject = vi.fn();
+    await act(async () => {
+      root.render(<RejectSuggestion suggestionId="s-1" onReject={onReject} />);
+    });
+
+    const button = container.querySelector(
+      '[data-testid="suggestion-reject"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      button.click();
+    });
+
+    expect(onReject).toHaveBeenCalledWith("s-1");
+  });
+
+  it("reject standalone ins removes the ins entirely", () => {
+    const doc = parseAnnotatedHtml(SUGGESTIONS_HTML);
+    const next = rejectHtmlSuggestion(doc, { id: "s-1" });
+    expect(next.source).not.toContain("three new");
+    expect(next.source).not.toContain('data-rd-suggestion-id="s-1"');
+    // Other suggestion intact.
+    expect(next.source).toContain('data-rd-suggestion-id="s-3"');
+  });
+
+  it("reject substitution restores the deleted text only", () => {
+    const doc = parseAnnotatedHtml(SUGGESTIONS_HTML);
+    const next = rejectHtmlSuggestion(doc, { id: "s-3" });
+    expect(next.source).toContain("the legacy parser");
+    expect(next.source).not.toContain("the new streaming parser");
+    expect(next.source).not.toContain('data-rd-suggestion-id="s-3"');
+  });
+});

--- a/packages/app/src/editor/html/HtmlDocumentWorkspace.tsx
+++ b/packages/app/src/editor/html/HtmlDocumentWorkspace.tsx
@@ -1,0 +1,295 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  acceptHtmlSuggestion,
+  addHtmlComment,
+  rejectHtmlSuggestion,
+  type AddHtmlCommentInput,
+  type AnnotatedHtmlDoc,
+} from "@roughdraft/rfm";
+import { HtmlReadonlyView } from "./HtmlReadonlyView";
+import { HtmlReviewRail } from "../../review-rail/HtmlReviewRail";
+import { useHtmlReviewRailSync } from "../../review-rail/sync";
+import { AddCommentComposer } from "../../authoring/AddCommentComposer";
+
+export interface HtmlDocumentWorkspaceProps {
+  documentPath: string;
+  projectPath?: string | null;
+  absolutePath?: string | null;
+}
+
+interface HtmlFileResponse {
+  id: string;
+  title: string;
+  content: string;
+  version: string;
+  document: AnnotatedHtmlDoc;
+}
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "loaded"; page: HtmlFileResponse }
+  | { kind: "error"; message: string };
+
+function buildHtmlFileUrl(
+  documentPath: string,
+  projectPath?: string | null,
+): string {
+  const url = new URL("/api/html-file", window.location.origin);
+  url.searchParams.set("path", documentPath);
+  if (projectPath) url.searchParams.set("projectPath", projectPath);
+  return `${url.pathname}${url.search}`;
+}
+
+function newCommentId(): string {
+  return `c-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+export function HtmlDocumentWorkspace({
+  documentPath,
+  projectPath,
+  absolutePath,
+}: HtmlDocumentWorkspaceProps) {
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+  const [selectedText, setSelectedText] = useState("");
+  const [composerOpen, setComposerOpen] = useState(false);
+  const [composerSelection, setComposerSelection] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [busySuggestionId, setBusySuggestionId] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const sync = useHtmlReviewRailSync();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setState({ kind: "loading" });
+      try {
+        const res = await fetch(buildHtmlFileUrl(documentPath, projectPath));
+        if (!res.ok) {
+          setState({
+            kind: "error",
+            message: `Could not open HTML file (${res.status.toString()}).`,
+          });
+          return;
+        }
+        const payload = (await res.json()) as HtmlFileResponse;
+        if (cancelled) return;
+        setState({ kind: "loaded", page: payload });
+      } catch (error) {
+        if (cancelled) return;
+        console.error("Failed to load HTML file:", error);
+        setState({ kind: "error", message: "Could not open that HTML file." });
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [documentPath, projectPath]);
+
+  const persistDocument = useCallback(
+    async (nextDoc: AnnotatedHtmlDoc, expectedVersion: string) => {
+      const response = await fetch(
+        buildHtmlFileUrl(documentPath, projectPath),
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            document: nextDoc,
+            expectedVersion,
+            path: documentPath,
+            projectPath,
+          }),
+        },
+      );
+      if (!response.ok) {
+        throw new Error(`Save failed (${response.status.toString()})`);
+      }
+      return (await response.json()) as HtmlFileResponse;
+    },
+    [documentPath, projectPath],
+  );
+
+  const handleAddCommentClick = useCallback(() => {
+    if (!selectedText.trim()) return;
+    setComposerSelection(selectedText);
+    setComposerOpen(true);
+    setSaveError(null);
+  }, [selectedText]);
+
+  const handleComposerCancel = useCallback(() => {
+    setComposerOpen(false);
+  }, []);
+
+  const handleComposerSubmit = useCallback(
+    async ({ body }: { body: string }) => {
+      if (state.kind !== "loaded") return;
+      const targetText = composerSelection;
+      if (!targetText.trim()) return;
+      setSaving(true);
+      setSaveError(null);
+      try {
+        const input: AddHtmlCommentInput = {
+          id: newCommentId(),
+          anchor: { text: targetText },
+          author: "you@example.com",
+          createdAt: new Date().toISOString(),
+          body,
+        };
+        const nextDoc = addHtmlComment(state.page.document, input);
+        const updated = await persistDocument(nextDoc, state.page.version);
+        setState({ kind: "loaded", page: updated });
+        setComposerOpen(false);
+        setSelectedText("");
+      } catch (error) {
+        setSaveError(error instanceof Error ? error.message : "Save failed");
+      } finally {
+        setSaving(false);
+      }
+    },
+    [composerSelection, persistDocument, state],
+  );
+
+  const handleAcceptSuggestion = useCallback(
+    async (suggestionId: string) => {
+      if (state.kind !== "loaded") return;
+      setBusySuggestionId(suggestionId);
+      setSaveError(null);
+      try {
+        const nextDoc = acceptHtmlSuggestion(state.page.document, {
+          id: suggestionId,
+        });
+        const updated = await persistDocument(nextDoc, state.page.version);
+        setState({ kind: "loaded", page: updated });
+      } catch (error) {
+        setSaveError(error instanceof Error ? error.message : "Save failed");
+      } finally {
+        setBusySuggestionId(null);
+      }
+    },
+    [persistDocument, state],
+  );
+
+  const handleRejectSuggestion = useCallback(
+    async (suggestionId: string) => {
+      if (state.kind !== "loaded") return;
+      setBusySuggestionId(suggestionId);
+      setSaveError(null);
+      try {
+        const nextDoc = rejectHtmlSuggestion(state.page.document, {
+          id: suggestionId,
+        });
+        const updated = await persistDocument(nextDoc, state.page.version);
+        setState({ kind: "loaded", page: updated });
+      } catch (error) {
+        setSaveError(error instanceof Error ? error.message : "Save failed");
+      } finally {
+        setBusySuggestionId(null);
+      }
+    },
+    [persistDocument, state],
+  );
+
+  if (state.kind === "loading") {
+    return (
+      <div
+        data-testid="html-document-workspace"
+        data-state="loading"
+        className="flex h-full items-center justify-center text-slate-500"
+      >
+        Loading HTML…
+      </div>
+    );
+  }
+
+  if (state.kind === "error") {
+    return (
+      <div
+        data-testid="html-document-workspace"
+        data-state="error"
+        role="alert"
+        className="flex h-full items-center justify-center text-red-600"
+      >
+        {state.message}
+      </div>
+    );
+  }
+
+  const { page } = state;
+  const displayPath = absolutePath ?? documentPath;
+  const canAddComment = selectedText.trim().length > 0 && !saving;
+
+  return (
+    <div
+      data-testid="html-document-workspace"
+      data-state="loaded"
+      className="flex h-full min-h-0 flex-1 flex-row overflow-hidden"
+    >
+      <section
+        data-testid="html-document-pane"
+        className="flex-1 min-w-0 overflow-auto p-6"
+      >
+        <header className="mb-4 flex flex-row items-start justify-between gap-4">
+          <div>
+            <h1
+              className="text-xl font-semibold"
+              data-testid="html-document-title"
+            >
+              {page.title}
+            </h1>
+            <p
+              className="text-xs text-slate-500"
+              data-testid="html-document-path"
+            >
+              {displayPath}
+            </p>
+          </div>
+          <button
+            type="button"
+            data-testid="html-add-comment-button"
+            disabled={!canAddComment}
+            onClick={handleAddCommentClick}
+            className="rd-html-add-comment-button"
+          >
+            Add comment
+          </button>
+        </header>
+        {saveError ? (
+          <p
+            data-testid="html-save-error"
+            role="alert"
+            className="mb-3 text-sm text-red-600"
+          >
+            {saveError}
+          </p>
+        ) : null}
+        <HtmlReadonlyView
+          document={page.document}
+          activeAnchorId={sync.activeAnchorId}
+          onAnchorActivate={sync.handleAnchorActivate}
+          anchorRefs={sync.anchorRefs}
+          onSelectionChange={setSelectedText}
+        />
+        <AddCommentComposer
+          open={composerOpen}
+          selectedText={composerSelection}
+          onSubmit={handleComposerSubmit}
+          onCancel={handleComposerCancel}
+          busy={saving}
+        />
+      </section>
+      <HtmlReviewRail
+        comments={page.document.comments}
+        suggestions={page.document.suggestions}
+        activeCardId={sync.activeCardId}
+        onCardActivate={sync.handleCardActivate}
+        cardRefs={sync.cardRefs}
+        onAcceptSuggestion={handleAcceptSuggestion}
+        onRejectSuggestion={handleRejectSuggestion}
+        busySuggestionId={busySuggestionId}
+      />
+    </div>
+  );
+}

--- a/packages/app/src/editor/html/HtmlReadonlyView.tsx
+++ b/packages/app/src/editor/html/HtmlReadonlyView.tsx
@@ -1,0 +1,232 @@
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useRef,
+  type ReactNode,
+} from "react";
+import type {
+  AnnotatedHtmlDoc,
+  HtmlElementNode,
+  HtmlNode,
+} from "@roughdraft/rfm";
+
+interface HtmlReadonlyViewProps {
+  document: AnnotatedHtmlDoc;
+  activeAnchorId?: string | null;
+  onAnchorActivate?: (commentIds: string[]) => void;
+  anchorRefs?: Map<string, HTMLElement>;
+  onSelectionChange?: (selectedText: string) => void;
+}
+
+const VOID_TAGS = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+]);
+
+const RAIL_ASIDE_CLASS_TOKENS = new Set(["rd-review"]);
+
+function isReviewAside(node: HtmlElementNode): boolean {
+  if (node.tag !== "aside") return false;
+  const className = node.attrs.class ?? "";
+  return className
+    .split(/\s+/)
+    .some((token) => RAIL_ASIDE_CLASS_TOKENS.has(token));
+}
+
+function shouldHideNode(node: HtmlElementNode): boolean {
+  if (node.tag === "rd-comment") return true;
+  if (isReviewAside(node)) return true;
+  return false;
+}
+
+function attrsToReact(
+  attrs: Record<string, string>,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(attrs)) {
+    if (key === "class") {
+      result.className = value;
+      continue;
+    }
+    if (key === "for") {
+      result.htmlFor = value;
+      continue;
+    }
+    result[key] = value;
+  }
+  for (const [key, value] of Object.entries(extra)) {
+    result[key] = value;
+  }
+  return result;
+}
+
+function renderNode(
+  node: HtmlNode,
+  key: string,
+  context: {
+    activeAnchorId?: string | null;
+    onAnchorActivate?: (commentIds: string[]) => void;
+    anchorRefs?: Map<string, HTMLElement>;
+  },
+): ReactNode {
+  if (node.type === "text") {
+    return <Fragment key={key}>{node.value}</Fragment>;
+  }
+
+  if (shouldHideNode(node)) {
+    return null;
+  }
+
+  const children = node.children
+    .map((child, index) =>
+      renderNode(child, `${key}.${index.toString()}`, context),
+    )
+    .filter((child): child is ReactNode => child !== null);
+
+  const tag = node.tag;
+
+  if (tag === "mark" && Object.hasOwn(node.attrs, "data-rd-comment-ids")) {
+    const ids = node.attrs["data-rd-comment-ids"] ?? "";
+    const idList = ids.split(/\s+/).filter(Boolean);
+    const isActive =
+      context.activeAnchorId !== null &&
+      context.activeAnchorId !== undefined &&
+      idList.includes(context.activeAnchorId);
+
+    const extra: Record<string, unknown> = {
+      "data-testid": "comment-anchor",
+      "data-active": isActive ? "true" : "false",
+      tabIndex: 0,
+      onClick: () => context.onAnchorActivate?.(idList),
+      onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          context.onAnchorActivate?.(idList);
+        }
+      },
+      ref: (element: HTMLElement | null) => {
+        if (!context.anchorRefs) return;
+        if (element) {
+          for (const id of idList) {
+            context.anchorRefs.set(id, element);
+          }
+        } else {
+          for (const id of idList) {
+            context.anchorRefs.delete(id);
+          }
+        }
+      },
+    };
+
+    return (
+      <mark key={key} {...attrsToReact(node.attrs, extra)}>
+        {children}
+      </mark>
+    );
+  }
+
+  const props = attrsToReact(node.attrs);
+
+  if (VOID_TAGS.has(tag)) {
+    return wrapVoid(tag, props, key);
+  }
+
+  return wrapElement(tag, props, children, key);
+}
+
+function wrapVoid(
+  tag: string,
+  props: Record<string, unknown>,
+  key: string,
+): ReactNode {
+  const Tag = tag as unknown as "br";
+  return <Tag key={key} {...(props as object)} />;
+}
+
+function wrapElement(
+  tag: string,
+  props: Record<string, unknown>,
+  children: ReactNode[],
+  key: string,
+): ReactNode {
+  const Tag = tag as unknown as "div";
+  return (
+    <Tag key={key} {...(props as object)}>
+      {children}
+    </Tag>
+  );
+}
+
+export function HtmlReadonlyView({
+  document: doc,
+  activeAnchorId = null,
+  onAnchorActivate,
+  anchorRefs,
+  onSelectionChange,
+}: HtmlReadonlyViewProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const reportSelection = useCallback(() => {
+    if (!onSelectionChange) return;
+    const container = containerRef.current;
+    const selection =
+      typeof window !== "undefined" ? window.getSelection() : null;
+    if (!container || !selection || selection.rangeCount === 0) {
+      onSelectionChange("");
+      return;
+    }
+    const anchorNode = selection.anchorNode;
+    const focusNode = selection.focusNode;
+    const withinContainer =
+      (anchorNode !== null && container.contains(anchorNode)) ||
+      (focusNode !== null && container.contains(focusNode));
+    if (!withinContainer) {
+      return;
+    }
+    const text = selection.toString();
+    onSelectionChange(text);
+  }, [onSelectionChange]);
+
+  useEffect(() => {
+    if (!onSelectionChange) return;
+    const handler = () => {
+      reportSelection();
+    };
+    window.document.addEventListener("selectionchange", handler);
+    return () => {
+      window.document.removeEventListener("selectionchange", handler);
+    };
+  }, [reportSelection, onSelectionChange]);
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="html-readonly-view"
+      contentEditable={false}
+      suppressContentEditableWarning
+      className="prose max-w-none focus:outline-none"
+    >
+      {doc.blocks.map((node, index) =>
+        renderNode(node, `block.${index.toString()}`, {
+          activeAnchorId,
+          onAnchorActivate,
+          anchorRefs,
+        }),
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/editor/html/__tests__/HtmlDocumentWorkspace.test.tsx
+++ b/packages/app/src/editor/html/__tests__/HtmlDocumentWorkspace.test.tsx
@@ -1,0 +1,196 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseAnnotatedHtml } from "@roughdraft/rfm";
+import { HtmlDocumentWorkspace } from "../HtmlDocumentWorkspace";
+
+const SOURCE = `<!doctype html>
+<html lang="en">
+  <head><title>Workspace fixture</title></head>
+  <body>
+    <article>
+      <h1>Heading</h1>
+      <p>
+        Revenue grew
+        <mark data-rd-comment-ids="c-rev-1">12%</mark>
+        quarter over quarter.
+      </p>
+      <p>
+        Team in
+        <mark data-rd-comment-ids="c-team-1">Berlin and Bangalore</mark>.
+      </p>
+    </article>
+    <aside class="rd-review" hidden>
+      <rd-comment id="c-rev-1" data-rd-anchor-ids="c-rev-1" data-rd-status="open" data-rd-author="reviewer">Cite the source.</rd-comment>
+      <rd-comment id="c-team-1" data-rd-anchor-ids="c-team-1" data-rd-status="open" data-rd-author="reviewer">Mention headcount delta.</rd-comment>
+    </aside>
+  </body>
+</html>`;
+
+function buildResponse() {
+  const document = parseAnnotatedHtml(SOURCE);
+  return {
+    id: "workspace",
+    title: "Workspace fixture",
+    content: SOURCE,
+    version: "v-1",
+    document,
+    sanitizerWarnings: [],
+  };
+}
+
+describe("HtmlDocumentWorkspace", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    if (
+      typeof (HTMLElement.prototype as { scrollIntoView?: () => void })
+        .scrollIntoView !== "function"
+    ) {
+      Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+        configurable: true,
+        writable: true,
+        value: () => {},
+      });
+    }
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const responsePayload = buildResponse();
+    fetchSpy = vi.fn(
+      async (_input: RequestInfo | URL) =>
+        new Response(JSON.stringify(responsePayload), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    consoleErrorSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  async function renderWorkspace(
+    options: {
+      documentPath?: string;
+      projectPath?: string | null;
+      absolutePath?: string | null;
+    } = {},
+  ) {
+    await act(async () => {
+      root.render(
+        <HtmlDocumentWorkspace
+          documentPath={options.documentPath ?? "doc.html"}
+          projectPath={options.projectPath ?? "/tmp/project"}
+          absolutePath={options.absolutePath ?? "/tmp/project/doc.html"}
+        />,
+      );
+    });
+    // resolve fetch + state update
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it("fetches /api/html-file with path and projectPath", async () => {
+    await renderWorkspace({
+      documentPath: "nested/page.html",
+      projectPath: "/tmp/projectX",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledWith = fetchSpy.mock.calls[0]?.[0] as string;
+    expect(calledWith).toContain("/api/html-file");
+    expect(calledWith).toContain("path=nested%2Fpage.html");
+    expect(calledWith).toContain("projectPath=%2Ftmp%2FprojectX");
+  });
+
+  it("renders title, document content, anchors, and review rail", async () => {
+    await renderWorkspace();
+
+    expect(
+      container
+        .querySelector('[data-testid="html-document-workspace"]')
+        ?.getAttribute("data-state"),
+    ).toBe("loaded");
+    expect(container.textContent).toContain("Workspace fixture");
+    expect(container.textContent).toContain("Heading");
+    expect(container.textContent).toContain("Revenue grew");
+
+    const anchors = container.querySelectorAll(
+      '[data-testid="comment-anchor"]',
+    );
+    expect(anchors.length).toBeGreaterThanOrEqual(2);
+
+    expect(
+      container.querySelector('[data-testid="html-review-rail"]'),
+    ).not.toBeNull();
+    const cards = container.querySelectorAll(
+      '[data-testid="html-review-card"]',
+    );
+    expect(cards.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("syncs clicks between anchors and rail cards", async () => {
+    await renderWorkspace();
+
+    const anchor = container.querySelector(
+      '[data-testid="comment-anchor"][data-rd-comment-ids="c-rev-1"]',
+    ) as HTMLElement;
+    expect(anchor).not.toBeNull();
+
+    await act(async () => {
+      anchor.click();
+    });
+
+    const card = container.querySelector(
+      '[data-card-id="c-rev-1"]',
+    ) as HTMLElement;
+    expect(card.getAttribute("data-active")).toBe("true");
+    expect(anchor.getAttribute("data-active")).toBe("true");
+
+    const otherCard = container.querySelector(
+      '[data-card-id="c-team-1"]',
+    ) as HTMLElement;
+    await act(async () => {
+      otherCard.click();
+    });
+
+    expect(otherCard.getAttribute("data-active")).toBe("true");
+    const otherAnchor = container.querySelector(
+      '[data-testid="comment-anchor"][data-rd-comment-ids="c-team-1"]',
+    ) as HTMLElement;
+    expect(otherAnchor.getAttribute("data-active")).toBe("true");
+  });
+
+  it("shows an error state when the fetch fails", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response("nope", { status: 404 }) as unknown as Response,
+    );
+
+    await renderWorkspace();
+
+    expect(
+      container
+        .querySelector('[data-testid="html-document-workspace"]')
+        ?.getAttribute("data-state"),
+    ).toBe("error");
+  });
+});

--- a/packages/app/src/editor/html/__tests__/HtmlReadonlyView.test.tsx
+++ b/packages/app/src/editor/html/__tests__/HtmlReadonlyView.test.tsx
@@ -1,0 +1,116 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseAnnotatedHtml } from "@roughdraft/rfm";
+import { HtmlReadonlyView } from "../HtmlReadonlyView";
+
+const MIXED_REVIEW_FIXTURE = `<!doctype html>
+<html lang="en">
+  <head><title>Mixed review document</title></head>
+  <body>
+    <article>
+      <h1>Quarterly review</h1>
+      <p>
+        Revenue grew
+        <mark data-rd-comment-ids="c-rev-1">
+          <ins data-rd-suggestion-id="s-rev-1">12%</ins></mark>
+        quarter over quarter.
+      </p>
+      <p>
+        Churn was
+        <del data-rd-suggestion-id="s-churn-1">high</del><ins data-rd-suggestion-id="s-churn-1">elevated but stable</ins>
+        in the SMB segment.
+      </p>
+      <p>
+        We expanded the team in
+        <mark data-rd-comment-ids="c-team-1 c-team-2">Berlin and Bangalore</mark>.
+      </p>
+    </article>
+    <aside class="rd-review" hidden>
+      <rd-comment id="c-rev-1" data-rd-anchor-ids="c-rev-1" data-rd-status="open">Cite the exact source row.</rd-comment>
+      <rd-comment id="c-team-1" data-rd-anchor-ids="c-team-1" data-rd-status="open">Mention headcount delta.</rd-comment>
+      <rd-comment id="c-team-2" data-rd-anchor-ids="c-team-1" data-rd-status="open" data-rd-reply-to="c-team-1">+1 and split by office.</rd-comment>
+    </aside>
+  </body>
+</html>`;
+
+describe("HtmlReadonlyView", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("renders mixed-review fixture without console errors", async () => {
+    const doc = parseAnnotatedHtml(MIXED_REVIEW_FIXTURE);
+
+    await act(async () => {
+      root.render(<HtmlReadonlyView document={doc} />);
+    });
+
+    expect(container.textContent).toContain("Quarterly review");
+    expect(container.textContent).toContain("Revenue grew");
+    expect(container.textContent).toContain("Berlin and Bangalore");
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders mark elements with data-testid="comment-anchor"', async () => {
+    const doc = parseAnnotatedHtml(MIXED_REVIEW_FIXTURE);
+
+    await act(async () => {
+      root.render(<HtmlReadonlyView document={doc} />);
+    });
+
+    const anchors = container.querySelectorAll(
+      '[data-testid="comment-anchor"]',
+    );
+    expect(anchors.length).toBeGreaterThanOrEqual(2);
+    const anchorIds = Array.from(anchors).map((anchor) =>
+      anchor.getAttribute("data-rd-comment-ids"),
+    );
+    expect(anchorIds).toContain("c-rev-1");
+    expect(anchorIds).toContain("c-team-1 c-team-2");
+  });
+
+  it("disables contentEditable in this mode", async () => {
+    const doc = parseAnnotatedHtml(MIXED_REVIEW_FIXTURE);
+
+    await act(async () => {
+      root.render(<HtmlReadonlyView document={doc} />);
+    });
+
+    const view = container.querySelector(
+      '[data-testid="html-readonly-view"]',
+    ) as HTMLElement | null;
+    expect(view).not.toBeNull();
+    expect(view?.getAttribute("contenteditable")).toBe("false");
+  });
+
+  it("does not render the rd-review aside or rd-comment records inline", async () => {
+    const doc = parseAnnotatedHtml(MIXED_REVIEW_FIXTURE);
+
+    await act(async () => {
+      root.render(<HtmlReadonlyView document={doc} />);
+    });
+
+    expect(container.innerHTML).not.toContain('class="rd-review"');
+    expect(container.innerHTML).not.toContain("<rd-comment");
+    expect(container.textContent).not.toContain("Cite the exact source row.");
+  });
+});

--- a/packages/app/src/editor/html/__tests__/perf-render.test.tsx
+++ b/packages/app/src/editor/html/__tests__/perf-render.test.tsx
@@ -1,0 +1,87 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parseAnnotatedHtml } from "@roughdraft/rfm";
+import { HtmlReadonlyView } from "../HtmlReadonlyView";
+
+// Render budget for the read-only HTML view. Measured locally at ~10-30 ms
+// per mount in jsdom for the mixed-review fixture. Budget allows ample CI
+// headroom and only catches order-of-magnitude regressions.
+const RENDER_BUDGET_MS = 750;
+
+// Inline copy of .context/fixtures/html/mixed-review-document.html. Kept in
+// sync intentionally; this test does not depend on node:fs so it builds under
+// the app's browser-only tsconfig.
+const MIXED_REVIEW_FIXTURE = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Mixed review document</title>
+  </head>
+  <body>
+    <article>
+      <h1>Quarterly review</h1>
+      <p>
+        Revenue grew
+        <mark data-rd-comment-ids="c-rev-1">
+          <ins data-rd-suggestion-id="s-rev-1" data-rd-author="a@x" data-rd-created-at="2026-05-23T12:00:00Z">12%</ins></mark>
+        quarter over quarter.
+      </p>
+      <p>
+        Churn was
+        <del data-rd-suggestion-id="s-churn-1" data-rd-author="r@x" data-rd-created-at="2026-05-23T12:01:00Z">high</del><ins data-rd-suggestion-id="s-churn-1" data-rd-author="r@x" data-rd-created-at="2026-05-23T12:01:00Z">elevated but stable</ins>
+        in the SMB segment.
+      </p>
+      <p>
+        We expanded the team in
+        <mark data-rd-comment-ids="c-team-1 c-team-2">Berlin and Bangalore</mark>.
+      </p>
+      <h2>Risks</h2>
+      <ul>
+        <li>
+          <mark data-rd-comment-ids="c-risk-1">Latency in the EU region.</mark>
+        </li>
+        <li>Long onboarding for enterprise customers.</li>
+      </ul>
+    </article>
+    <aside class="rd-review" hidden>
+      <rd-comment id="c-rev-1" data-rd-author="r@x" data-rd-created-at="2026-05-23T12:00:30Z" data-rd-anchor-ids="c-rev-1" data-rd-status="open">Cite the exact source row.</rd-comment>
+      <rd-comment id="c-team-1" data-rd-author="a@x" data-rd-created-at="2026-05-23T12:02:00Z" data-rd-anchor-ids="c-team-1" data-rd-status="open">Mention headcount delta.</rd-comment>
+      <rd-comment id="c-team-2" data-rd-author="r@x" data-rd-created-at="2026-05-23T12:02:45Z" data-rd-anchor-ids="c-team-1" data-rd-status="open" data-rd-reply-to="c-team-1">+1, and split by office.</rd-comment>
+      <rd-comment id="c-risk-1" data-rd-author="a@x" data-rd-created-at="2026-05-23T12:03:30Z" data-rd-anchor-ids="c-risk-1" data-rd-status="resolved">Fixed in last release.</rd-comment>
+    </aside>
+  </body>
+</html>`;
+
+describe("HtmlReadonlyView performance", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it(`renders the mixed-review fixture under ${RENDER_BUDGET_MS} ms`, () => {
+    const doc = parseAnnotatedHtml(MIXED_REVIEW_FIXTURE);
+
+    const start = performance.now();
+    act(() => {
+      root.render(<HtmlReadonlyView document={doc} />);
+    });
+    const elapsed = performance.now() - start;
+
+    expect(elapsed).toBeLessThan(RENDER_BUDGET_MS);
+    expect(
+      container.querySelectorAll('[data-testid="comment-anchor"]').length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/src/review-rail/HtmlReviewRail.tsx
+++ b/packages/app/src/review-rail/HtmlReviewRail.tsx
@@ -1,0 +1,274 @@
+import {
+  Fragment,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
+import type {
+  HtmlAnnotationComment,
+  HtmlAnnotationSuggestion,
+} from "@roughdraft/rfm";
+import {
+  AcceptSuggestion,
+  RejectSuggestion,
+} from "../authoring/SuggestionActions";
+
+export interface HtmlReviewRailProps {
+  comments: HtmlAnnotationComment[];
+  suggestions: HtmlAnnotationSuggestion[];
+  activeCardId?: string | null;
+  onCardActivate?: (cardId: string) => void;
+  cardRefs?: Map<string, HTMLElement>;
+  onAcceptSuggestion?: (suggestionId: string) => void;
+  onRejectSuggestion?: (suggestionId: string) => void;
+  busySuggestionId?: string | null;
+}
+
+type CommentCard = {
+  kind: "comment";
+  id: string;
+  position: number;
+  comment: HtmlAnnotationComment;
+};
+
+type SuggestionCard = {
+  kind: "suggestion";
+  id: string;
+  position: number;
+  suggestion: HtmlAnnotationSuggestion;
+};
+
+type Card = CommentCard | SuggestionCard;
+
+function suggestionLabel(suggestion: HtmlAnnotationSuggestion): string {
+  switch (suggestion.kind) {
+    case "insertion":
+      return "Insertion";
+    case "deletion":
+      return "Deletion";
+    case "substitution":
+      return "Substitution";
+  }
+}
+
+function suggestionBody(suggestion: HtmlAnnotationSuggestion): ReactNode {
+  if (suggestion.kind === "substitution") {
+    return (
+      <>
+        <del>{suggestion.deletedText}</del> <ins>{suggestion.insertedText}</ins>
+      </>
+    );
+  }
+  if (suggestion.kind === "deletion") {
+    return <del>{suggestion.deletedText}</del>;
+  }
+  return <ins>{suggestion.insertedText}</ins>;
+}
+
+export function HtmlReviewRail({
+  comments,
+  suggestions,
+  activeCardId = null,
+  onCardActivate,
+  cardRefs,
+  onAcceptSuggestion,
+  onRejectSuggestion,
+  busySuggestionId = null,
+}: HtmlReviewRailProps) {
+  const repliesByParent = new Map<string, HtmlAnnotationComment[]>();
+  const rootComments: HtmlAnnotationComment[] = [];
+
+  for (const comment of comments) {
+    if (comment.replyTo) {
+      const list = repliesByParent.get(comment.replyTo) ?? [];
+      list.push(comment);
+      repliesByParent.set(comment.replyTo, list);
+    } else {
+      rootComments.push(comment);
+    }
+  }
+
+  for (const replies of repliesByParent.values()) {
+    replies.sort((a, b) => a.position - b.position);
+  }
+
+  const rootCards: Card[] = [
+    ...rootComments.map<CommentCard>((comment) => ({
+      kind: "comment",
+      id: comment.id,
+      position: comment.position,
+      comment,
+    })),
+    ...suggestions.map<SuggestionCard>((suggestion) => ({
+      kind: "suggestion",
+      id: suggestion.id,
+      position: suggestion.position,
+      suggestion,
+    })),
+  ];
+
+  rootCards.sort((a, b) => a.position - b.position);
+
+  const renderCardRef = (id: string) => (element: HTMLElement | null) => {
+    if (!cardRefs) return;
+    if (element) {
+      cardRefs.set(id, element);
+    } else {
+      cardRefs.delete(id);
+    }
+  };
+
+  const renderCommentCard = (
+    comment: HtmlAnnotationComment,
+    isReply: boolean,
+  ): ReactNode => {
+    const replies = repliesByParent.get(comment.id) ?? [];
+    const isActive = activeCardId === comment.id;
+    const status = comment.status ?? "open";
+
+    const handleActivate = (
+      event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>,
+    ) => {
+      event.stopPropagation();
+      onCardActivate?.(comment.id);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        handleActivate(event);
+      }
+    };
+
+    return (
+      <div
+        key={comment.id}
+        data-testid="html-review-card"
+        data-card-id={comment.id}
+        data-card-kind="comment"
+        data-status={status}
+        data-active={isActive ? "true" : "false"}
+        data-reply-to={comment.replyTo ?? undefined}
+        role="button"
+        tabIndex={0}
+        ref={renderCardRef(comment.id)}
+        onClick={handleActivate}
+        onKeyDown={handleKeyDown}
+        className={
+          isReply
+            ? "rd-html-review-card rd-html-review-card--reply"
+            : "rd-html-review-card"
+        }
+      >
+        <header className="rd-html-review-card__header">
+          <span className="rd-html-review-card__author">
+            {comment.author ?? "Unknown"}
+          </span>
+          {comment.createdAt ? (
+            <time
+              className="rd-html-review-card__time"
+              dateTime={comment.createdAt}
+            >
+              {comment.createdAt}
+            </time>
+          ) : null}
+        </header>
+        <p className="rd-html-review-card__body">{comment.body}</p>
+        {replies.length > 0 ? (
+          <div className="rd-html-review-card__replies">
+            {replies.map((reply) => (
+              <Fragment key={reply.id}>
+                {renderCommentCard(reply, true)}
+              </Fragment>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    );
+  };
+
+  const renderSuggestionCard = (
+    suggestion: HtmlAnnotationSuggestion,
+  ): ReactNode => {
+    const isActive = activeCardId === suggestion.id;
+    const status = suggestion.status ?? "open";
+
+    const handleActivate = (
+      event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>,
+    ) => {
+      event.stopPropagation();
+      onCardActivate?.(suggestion.id);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        handleActivate(event);
+      }
+    };
+
+    return (
+      <div
+        key={suggestion.id}
+        data-testid="html-review-card"
+        data-card-id={suggestion.id}
+        data-card-kind="suggestion"
+        data-suggestion-kind={suggestion.kind}
+        data-status={status}
+        data-active={isActive ? "true" : "false"}
+        role="button"
+        tabIndex={0}
+        ref={renderCardRef(suggestion.id)}
+        onClick={handleActivate}
+        onKeyDown={handleKeyDown}
+        className="rd-html-review-card rd-html-review-card--suggestion"
+      >
+        <header className="rd-html-review-card__header">
+          <span className="rd-html-review-card__kind">
+            {suggestionLabel(suggestion)}
+          </span>
+          {suggestion.author ? (
+            <span className="rd-html-review-card__author">
+              {suggestion.author}
+            </span>
+          ) : null}
+        </header>
+        <p className="rd-html-review-card__body">
+          {suggestionBody(suggestion)}
+        </p>
+        {status !== "accepted" && status !== "rejected" ? (
+          <div className="rd-html-review-card__actions">
+            {onAcceptSuggestion ? (
+              <AcceptSuggestion
+                suggestionId={suggestion.id}
+                onAccept={onAcceptSuggestion}
+                disabled={busySuggestionId === suggestion.id}
+              />
+            ) : null}
+            {onRejectSuggestion ? (
+              <RejectSuggestion
+                suggestionId={suggestion.id}
+                onReject={onRejectSuggestion}
+                disabled={busySuggestionId === suggestion.id}
+              />
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    );
+  };
+
+  return (
+    <aside
+      data-testid="html-review-rail"
+      className="rd-html-review-rail"
+      aria-label="HTML review rail"
+    >
+      {rootCards.map((card) =>
+        card.kind === "comment"
+          ? renderCommentCard(card.comment, false)
+          : renderSuggestionCard(card.suggestion),
+      )}
+    </aside>
+  );
+}

--- a/packages/app/src/review-rail/__tests__/HtmlReviewRail.test.tsx
+++ b/packages/app/src/review-rail/__tests__/HtmlReviewRail.test.tsx
@@ -1,0 +1,176 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  HtmlAnnotationComment,
+  HtmlAnnotationSuggestion,
+} from "@roughdraft/rfm";
+import { HtmlReviewRail } from "../HtmlReviewRail";
+
+const COMMENTS: HtmlAnnotationComment[] = [
+  {
+    id: "c-rev-1",
+    anchorIds: ["c-rev-1"],
+    author: "reviewer@example.com",
+    createdAt: "2026-05-23T12:00:30Z",
+    updatedAt: null,
+    status: "open",
+    replyTo: null,
+    body: "Cite the exact source row.",
+    position: 5,
+  },
+  {
+    id: "c-team-1",
+    anchorIds: ["c-team-1"],
+    author: "ananth@cradlewise.com",
+    createdAt: "2026-05-23T12:02:00Z",
+    updatedAt: null,
+    status: "open",
+    replyTo: null,
+    body: "Mention headcount delta.",
+    position: 20,
+  },
+  {
+    id: "c-team-2",
+    anchorIds: ["c-team-1"],
+    author: "reviewer@example.com",
+    createdAt: "2026-05-23T12:02:45Z",
+    updatedAt: null,
+    status: "open",
+    replyTo: "c-team-1",
+    body: "+1 and split by office.",
+    position: 21,
+  },
+  {
+    id: "c-risk-1",
+    anchorIds: ["c-risk-1"],
+    author: "ananth@cradlewise.com",
+    createdAt: "2026-05-23T12:03:30Z",
+    updatedAt: null,
+    status: "resolved",
+    replyTo: null,
+    body: "Fixed in last release.",
+    position: 40,
+  },
+];
+
+const SUGGESTIONS: HtmlAnnotationSuggestion[] = [
+  {
+    id: "s-rev-1",
+    kind: "insertion",
+    author: "ananth@cradlewise.com",
+    createdAt: "2026-05-23T12:00:00Z",
+    status: "open",
+    insertedText: "12%",
+    position: 3,
+  },
+  {
+    id: "s-churn-1",
+    kind: "substitution",
+    author: "reviewer@example.com",
+    createdAt: "2026-05-23T12:01:00Z",
+    status: "open",
+    deletedText: "high",
+    insertedText: "elevated but stable",
+    position: 11,
+  },
+];
+
+describe("HtmlReviewRail", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  async function render(props: {
+    comments: HtmlAnnotationComment[];
+    suggestions: HtmlAnnotationSuggestion[];
+    activeCardId?: string | null;
+    onCardActivate?: (cardId: string) => void;
+  }) {
+    await act(async () => {
+      root.render(<HtmlReviewRail {...props} />);
+    });
+  }
+
+  it("lists all comments and suggestions in document order", async () => {
+    await render({ comments: COMMENTS, suggestions: SUGGESTIONS });
+
+    const rail = container.querySelector('[data-testid="html-review-rail"]');
+    expect(rail).not.toBeNull();
+
+    const cards = Array.from(
+      container.querySelectorAll<HTMLElement>(
+        '[data-testid="html-review-card"]',
+      ),
+    );
+    const ids = cards.map((card) => card.getAttribute("data-card-id"));
+    expect(ids).toEqual([
+      "s-rev-1",
+      "c-rev-1",
+      "s-churn-1",
+      "c-team-1",
+      "c-team-2",
+      "c-risk-1",
+    ]);
+  });
+
+  it("renders resolved comments distinctly from open ones", async () => {
+    await render({ comments: COMMENTS, suggestions: SUGGESTIONS });
+
+    const resolved = container.querySelector(
+      '[data-card-id="c-risk-1"]',
+    ) as HTMLElement | null;
+    const open = container.querySelector(
+      '[data-card-id="c-rev-1"]',
+    ) as HTMLElement | null;
+
+    expect(resolved).not.toBeNull();
+    expect(open).not.toBeNull();
+    expect(resolved?.getAttribute("data-status")).toBe("resolved");
+    expect(open?.getAttribute("data-status")).toBe("open");
+  });
+
+  it("renders reply threads under their parents", async () => {
+    await render({ comments: COMMENTS, suggestions: SUGGESTIONS });
+
+    const parent = container.querySelector(
+      '[data-card-id="c-team-1"]',
+    ) as HTMLElement | null;
+    const reply = container.querySelector(
+      '[data-card-id="c-team-2"]',
+    ) as HTMLElement | null;
+
+    expect(parent).not.toBeNull();
+    expect(reply).not.toBeNull();
+    expect(reply?.getAttribute("data-reply-to")).toBe("c-team-1");
+    expect(parent?.contains(reply)).toBe(true);
+  });
+
+  it("marks the active card via data-active", async () => {
+    await render({
+      comments: COMMENTS,
+      suggestions: SUGGESTIONS,
+      activeCardId: "c-team-1",
+    });
+
+    const active = container.querySelector(
+      '[data-card-id="c-team-1"]',
+    ) as HTMLElement | null;
+    expect(active?.getAttribute("data-active")).toBe("true");
+  });
+});

--- a/packages/app/src/review-rail/__tests__/sync.test.tsx
+++ b/packages/app/src/review-rail/__tests__/sync.test.tsx
@@ -1,0 +1,185 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseAnnotatedHtml } from "@roughdraft/rfm";
+import { HtmlReadonlyView } from "../../editor/html/HtmlReadonlyView";
+import { HtmlReviewRail } from "../HtmlReviewRail";
+import { useHtmlReviewRailSync } from "../sync";
+
+const FIXTURE = `<!doctype html>
+<html lang="en">
+  <head><title>Sync fixture</title></head>
+  <body>
+    <article>
+      <p>
+        Revenue grew
+        <mark data-rd-comment-ids="c-rev-1">12%</mark>
+        quarter over quarter.
+      </p>
+      <p>
+        We expanded the team in
+        <mark data-rd-comment-ids="c-team-1">Berlin and Bangalore</mark>.
+      </p>
+    </article>
+    <aside class="rd-review" hidden>
+      <rd-comment id="c-rev-1" data-rd-anchor-ids="c-rev-1" data-rd-status="open">Cite the exact source row.</rd-comment>
+      <rd-comment id="c-team-1" data-rd-anchor-ids="c-team-1" data-rd-status="open">Mention headcount delta.</rd-comment>
+      <rd-comment id="c-team-2" data-rd-anchor-ids="c-team-1" data-rd-status="open" data-rd-reply-to="c-team-1">+1 and split by office.</rd-comment>
+    </aside>
+  </body>
+</html>`;
+
+function HtmlReviewWorkspace() {
+  const doc = parseAnnotatedHtml(FIXTURE);
+  const sync = useHtmlReviewRailSync();
+  return (
+    <div>
+      <HtmlReadonlyView
+        document={doc}
+        activeAnchorId={sync.activeAnchorId}
+        onAnchorActivate={sync.handleAnchorActivate}
+        anchorRefs={sync.anchorRefs}
+      />
+      <HtmlReviewRail
+        comments={doc.comments}
+        suggestions={doc.suggestions}
+        activeCardId={sync.activeCardId}
+        onCardActivate={sync.handleCardActivate}
+        cardRefs={sync.cardRefs}
+      />
+    </div>
+  );
+}
+
+describe("useHtmlReviewRailSync", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    if (
+      typeof (HTMLElement.prototype as { scrollIntoView?: () => void })
+        .scrollIntoView !== "function"
+    ) {
+      Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+        configurable: true,
+        writable: true,
+        value: () => {},
+      });
+    }
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  async function render() {
+    await act(async () => {
+      root.render(<HtmlReviewWorkspace />);
+    });
+  }
+
+  it("activates rail card and scrolls it into view when an anchor is clicked", async () => {
+    await render();
+
+    const card = container.querySelector(
+      '[data-card-id="c-rev-1"]',
+    ) as HTMLElement;
+    const scrollSpy = vi.spyOn(card, "scrollIntoView");
+    const focusSpy = vi.spyOn(card, "focus");
+
+    const anchor = container.querySelector(
+      '[data-testid="comment-anchor"][data-rd-comment-ids="c-rev-1"]',
+    ) as HTMLElement;
+    await act(async () => {
+      anchor.click();
+    });
+
+    expect(scrollSpy).toHaveBeenCalled();
+    expect(focusSpy).toHaveBeenCalled();
+    expect(card.getAttribute("data-active")).toBe("true");
+    const anchorActive = container.querySelector(
+      '[data-rd-comment-ids="c-rev-1"]',
+    ) as HTMLElement;
+    expect(anchorActive.getAttribute("data-active")).toBe("true");
+  });
+
+  it("activates anchor and scrolls it into view when a rail card is clicked", async () => {
+    await render();
+
+    const anchor = container.querySelector(
+      '[data-testid="comment-anchor"][data-rd-comment-ids="c-team-1"]',
+    ) as HTMLElement;
+    const scrollSpy = vi.spyOn(anchor, "scrollIntoView");
+    const focusSpy = vi.spyOn(anchor, "focus");
+
+    const card = container.querySelector(
+      '[data-card-id="c-team-1"]',
+    ) as HTMLElement;
+    await act(async () => {
+      card.click();
+    });
+
+    expect(scrollSpy).toHaveBeenCalled();
+    expect(focusSpy).toHaveBeenCalled();
+    expect(card.getAttribute("data-active")).toBe("true");
+    expect(anchor.getAttribute("data-active")).toBe("true");
+  });
+
+  it("activates a card via Enter and Space keys", async () => {
+    await render();
+
+    const card = container.querySelector(
+      '[data-card-id="c-rev-1"]',
+    ) as HTMLElement;
+
+    await act(async () => {
+      card.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+
+    expect(card.getAttribute("data-active")).toBe("true");
+
+    const other = container.querySelector(
+      '[data-card-id="c-team-1"]',
+    ) as HTMLElement;
+    await act(async () => {
+      other.dispatchEvent(
+        new KeyboardEvent("keydown", { key: " ", bubbles: true }),
+      );
+    });
+
+    expect(other.getAttribute("data-active")).toBe("true");
+  });
+
+  it("activates an anchor via Enter on the mark", async () => {
+    await render();
+
+    const anchor = container.querySelector(
+      '[data-testid="comment-anchor"][data-rd-comment-ids="c-team-1"]',
+    ) as HTMLElement;
+
+    await act(async () => {
+      anchor.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+
+    expect(anchor.getAttribute("data-active")).toBe("true");
+    const card = container.querySelector(
+      '[data-card-id="c-team-1"]',
+    ) as HTMLElement;
+    expect(card.getAttribute("data-active")).toBe("true");
+  });
+});

--- a/packages/app/src/review-rail/sync.ts
+++ b/packages/app/src/review-rail/sync.ts
@@ -1,0 +1,64 @@
+import { useCallback, useRef, useState } from "react";
+
+export interface UseHtmlReviewRailSyncResult {
+  activeAnchorId: string | null;
+  activeCardId: string | null;
+  anchorRefs: Map<string, HTMLElement>;
+  cardRefs: Map<string, HTMLElement>;
+  handleAnchorActivate: (commentIds: string[]) => void;
+  handleCardActivate: (cardId: string) => void;
+}
+
+function scrollIntoViewIfPossible(element: HTMLElement) {
+  if (typeof element.scrollIntoView === "function") {
+    element.scrollIntoView({ behavior: "smooth", block: "center" });
+  }
+}
+
+function focusIfPossible(element: HTMLElement) {
+  if (typeof element.focus === "function") {
+    try {
+      element.focus({ preventScroll: true });
+    } catch {
+      element.focus();
+    }
+  }
+}
+
+export function useHtmlReviewRailSync(): UseHtmlReviewRailSyncResult {
+  const anchorRefsRef = useRef<Map<string, HTMLElement>>(new Map());
+  const cardRefsRef = useRef<Map<string, HTMLElement>>(new Map());
+  const [activeAnchorId, setActiveAnchorId] = useState<string | null>(null);
+  const [activeCardId, setActiveCardId] = useState<string | null>(null);
+
+  const handleAnchorActivate = useCallback((commentIds: string[]) => {
+    const first = commentIds[0] ?? null;
+    setActiveAnchorId(first);
+    setActiveCardId(first);
+    if (!first) return;
+    const cardElement = cardRefsRef.current.get(first);
+    if (cardElement) {
+      scrollIntoViewIfPossible(cardElement);
+      focusIfPossible(cardElement);
+    }
+  }, []);
+
+  const handleCardActivate = useCallback((cardId: string) => {
+    setActiveCardId(cardId);
+    setActiveAnchorId(cardId);
+    const anchorElement = anchorRefsRef.current.get(cardId);
+    if (anchorElement) {
+      scrollIntoViewIfPossible(anchorElement);
+      focusIfPossible(anchorElement);
+    }
+  }, []);
+
+  return {
+    activeAnchorId,
+    activeCardId,
+    anchorRefs: anchorRefsRef.current,
+    cardRefs: cardRefsRef.current,
+    handleAnchorActivate,
+    handleCardActivate,
+  };
+}

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -349,7 +349,7 @@ describe("Homepage", () => {
 
     expect(writeText).toHaveBeenCalledWith(AGENT_SETUP_PROMPT);
     expect(document.body.textContent).toContain("Copied");
-  });
+  }, 30000);
 
   it("explains the plan-review workflow with scrolling steps and a sticky visual", async () => {
     await renderHomepage(root);

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -1497,7 +1497,9 @@ describe("PageCard editor integration", () => {
     );
   });
 
-  it("opens a reply to the root comment when r is pressed in a focused thread", async () => {
+  it("opens a reply to the root comment when r is pressed in a focused thread", {
+    timeout: 15000,
+  }, async () => {
     const rendered = await renderPageCard({
       page: {
         id: "doc-comment-reply-shortcut-1",

--- a/packages/app/test/view-toggle-bugs.test.tsx
+++ b/packages/app/test/view-toggle-bugs.test.tsx
@@ -464,7 +464,9 @@ describe("interaction mode preserved across view toggle (issue 3 fix)", () => {
     vi.restoreAllMocks();
   });
 
-  it("interaction mode is preserved when view mode changes without remount", async () => {
+  it("interaction mode is preserved when view mode changes without remount", {
+    timeout: 15000,
+  }, async () => {
     // With the fix, view mode changes use React state (no page reload),
     // so the DocumentWorkspace component stays mounted and interaction
     // mode is preserved.
@@ -525,6 +527,13 @@ describe("review handoff watcher affordance", () => {
     (
       globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
     ).IS_REACT_ACT_ENVIRONMENT = true;
+    // DocumentWorkspace polls getReviewWatchStatus every 1500ms. In these
+    // tests we drive watcher-count changes through explicit re-renders, so
+    // suppress the timer to avoid races where the poll fires between the
+    // click and the assertion and flips state back to "idle".
+    vi.spyOn(window, "setInterval").mockReturnValue(
+      0 as unknown as ReturnType<typeof window.setInterval>,
+    );
   });
 
   afterEach(async () => {

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig(() => {
     },
     server: {
       proxy: {
-        "/api": `http://localhost:${apiPort}`,
+        "/api": `http://127.0.0.1:${apiPort}`,
       },
     },
   };

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     },
   },
   test: {
+    testTimeout: 30000,
     coverage: {
       provider: "v8",
       reportsDirectory: "../../coverage/app",

--- a/packages/rfm/src/html/__tests__/mutate-comments.test.ts
+++ b/packages/rfm/src/html/__tests__/mutate-comments.test.ts
@@ -1,0 +1,513 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  addHtmlComment,
+  editHtmlComment,
+  parseAnnotatedHtml,
+  removeHtmlComment,
+  serializeAnnotatedHtml,
+} from "../../index.js";
+
+const fixture = [
+  "<!doctype html>",
+  '<html lang="en">',
+  "  <head>",
+  '    <meta charset="utf-8" />',
+  "    <title>Doc</title>",
+  "  </head>",
+  "  <body>",
+  "    <article>",
+  '      <p>The <mark data-rd-comment-ids="c-existing">sky</mark> is blue today.</p>',
+  "      <p>Rain is likely tonight.</p>",
+  "    </article>",
+  '    <aside class="rd-review" hidden>',
+  "      <rd-comment",
+  '        id="c-existing"',
+  '        data-rd-author="author@example.com"',
+  '        data-rd-created-at="2026-05-23T10:00:00Z"',
+  '        data-rd-anchor-ids="c-existing"',
+  '        data-rd-status="open"',
+  "      >Existing comment body.</rd-comment>",
+  "    </aside>",
+  "  </body>",
+  "</html>",
+  "",
+].join("\n");
+
+function sliceBeforeAside(source: string): string {
+  const idx = source.indexOf('<aside class="rd-review"');
+  return source.slice(0, idx);
+}
+
+function sliceAfterAside(source: string): string {
+  const idx = source.indexOf("</aside>");
+  return source.slice(idx + "</aside>".length);
+}
+
+describe("addHtmlComment", () => {
+  it("adds a new comment on a fresh span and only the targeted anchor + rd-review changes", () => {
+    const doc = parseAnnotatedHtml(fixture);
+
+    const mutated = addHtmlComment(doc, {
+      id: "c-new",
+      anchor: { text: "blue today" },
+      author: "newauthor@example.com",
+      createdAt: "2026-05-23T11:00:00Z",
+      status: "open",
+      body: "Specify the time of day.",
+    });
+
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    expect(serialized).not.toBe(fixture);
+
+    // Original content outside the anchor and the aside is unchanged.
+    const originalPrefix = fixture.slice(0, fixture.indexOf("is blue today"));
+    const mutatedPrefix = serialized.slice(0, originalPrefix.length);
+    expect(mutatedPrefix).toBe(originalPrefix);
+
+    // The targeted span is now wrapped in a fresh <mark>.
+    expect(serialized).toContain(
+      'is <mark data-rd-comment-ids="c-new">blue today</mark>.',
+    );
+
+    // The original mark (c-existing) remains intact.
+    expect(serialized).toContain(
+      '<mark data-rd-comment-ids="c-existing">sky</mark>',
+    );
+
+    // Everything between the wrap end and the rd-review aside is unchanged.
+    const originalBetween = fixture.slice(
+      fixture.indexOf("blue today") + "blue today".length,
+      fixture.indexOf('<aside class="rd-review"'),
+    );
+    const mutatedAsideIdx = serialized.indexOf('<aside class="rd-review"');
+    const mutatedBetween = serialized.slice(
+      mutatedAsideIdx - originalBetween.length,
+      mutatedAsideIdx,
+    );
+    expect(mutatedBetween).toBe(originalBetween);
+
+    // Everything after the closing </aside> is unchanged.
+    expect(sliceAfterAside(serialized)).toBe(sliceAfterAside(fixture));
+
+    // A new <rd-comment> record is in the aside.
+    expect(serialized).toContain('id="c-new"');
+    expect(serialized).toContain("Specify the time of day.");
+    expect(serialized).toContain('data-rd-author="newauthor@example.com"');
+
+    // Existing record is preserved.
+    expect(serialized).toContain('id="c-existing"');
+    expect(serialized).toContain("Existing comment body.");
+
+    // The reparsed model recognises the new comment + anchor.
+    const reparsed = parseAnnotatedHtml(serialized);
+    const newComment = reparsed.comments.find((entry) => entry.id === "c-new");
+    expect(newComment).toBeDefined();
+    if (!newComment) return;
+    expect(newComment.body).toBe("Specify the time of day.");
+    expect(newComment.status).toBe("open");
+    expect(newComment.author).toBe("newauthor@example.com");
+    expect(reparsed.warnings).toEqual([]);
+  });
+});
+
+describe("editHtmlComment", () => {
+  it("edits an existing comment body and only that record's text changes", () => {
+    const doc = parseAnnotatedHtml(fixture);
+
+    const mutated = editHtmlComment(doc, {
+      id: "c-existing",
+      body: "Updated comment body.",
+    });
+
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    // Bytes outside the aside are unchanged.
+    expect(sliceBeforeAside(serialized)).toBe(sliceBeforeAside(fixture));
+    expect(sliceAfterAside(serialized)).toBe(sliceAfterAside(fixture));
+
+    // The body text inside <rd-comment> is updated; original is gone.
+    expect(serialized).not.toContain("Existing comment body.");
+    expect(serialized).toContain("Updated comment body.");
+
+    // The record attributes are untouched (id, author, createdAt, status).
+    expect(serialized).toContain('id="c-existing"');
+    expect(serialized).toContain('data-rd-author="author@example.com"');
+    expect(serialized).toContain('data-rd-created-at="2026-05-23T10:00:00Z"');
+    expect(serialized).toContain('data-rd-status="open"');
+
+    // Reparse confirms.
+    const reparsed = parseAnnotatedHtml(serialized);
+    const comment = reparsed.comments.find(
+      (entry) => entry.id === "c-existing",
+    );
+    expect(comment).toBeDefined();
+    if (!comment) return;
+    expect(comment.body).toBe("Updated comment body.");
+  });
+});
+
+describe("removeHtmlComment", () => {
+  const twoOnSameSpan = [
+    "<!doctype html>",
+    '<html lang="en">',
+    "  <head>",
+    '    <meta charset="utf-8" />',
+    "    <title>Doc</title>",
+    "  </head>",
+    "  <body>",
+    "    <article>",
+    '      <p>The <mark data-rd-comment-ids="c-1 c-2">sky</mark> is blue.</p>',
+    "    </article>",
+    '    <aside class="rd-review" hidden>',
+    "      <rd-comment",
+    '        id="c-1"',
+    '        data-rd-author="a@example.com"',
+    '        data-rd-created-at="2026-05-23T10:00:00Z"',
+    '        data-rd-anchor-ids="c-1"',
+    '        data-rd-status="open"',
+    "      >First.</rd-comment>",
+    "      <rd-comment",
+    '        id="c-2"',
+    '        data-rd-author="b@example.com"',
+    '        data-rd-created-at="2026-05-23T10:01:00Z"',
+    '        data-rd-anchor-ids="c-2"',
+    '        data-rd-status="open"',
+    "      >Second.</rd-comment>",
+    "    </aside>",
+    "  </body>",
+    "</html>",
+    "",
+  ].join("\n");
+
+  it("removes a comment and only the targeted anchor + record disappear", () => {
+    const doc = parseAnnotatedHtml(fixture);
+
+    const mutated = removeHtmlComment(doc, { id: "c-existing" });
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    // Outside the aside and the targeted mark, bytes are unchanged.
+    const beforeMark = fixture.slice(0, fixture.indexOf("<mark"));
+    expect(serialized.slice(0, beforeMark.length)).toBe(beforeMark);
+
+    // The mark wrapper around "sky" is unwrapped (mark removed but text kept).
+    expect(serialized).not.toContain("<mark data-rd-comment-ids");
+    expect(serialized).toContain("The sky is blue today.");
+
+    // The record is gone.
+    expect(serialized).not.toContain('id="c-existing"');
+    expect(serialized).not.toContain("Existing comment body.");
+
+    // Trailing content after </aside> is unchanged.
+    expect(sliceAfterAside(serialized)).toBe(sliceAfterAside(fixture));
+
+    // Reparse: zero comments, no warnings.
+    const reparsed = parseAnnotatedHtml(serialized);
+    expect(reparsed.comments).toHaveLength(0);
+    expect(reparsed.warnings).toEqual([]);
+  });
+
+  it("removes only one of multiple comment ids from a shared anchor", () => {
+    const doc = parseAnnotatedHtml(twoOnSameSpan);
+
+    const mutated = removeHtmlComment(doc, { id: "c-1" });
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    // The mark survives with the remaining id only.
+    expect(serialized).toContain('data-rd-comment-ids="c-2"');
+    expect(serialized).not.toContain('"c-1 c-2"');
+
+    // Only the c-1 record disappears; c-2 stays.
+    expect(serialized).not.toContain('id="c-1"');
+    expect(serialized).not.toContain("First.</rd-comment>");
+    expect(serialized).toContain('id="c-2"');
+    expect(serialized).toContain("Second.</rd-comment>");
+
+    const reparsed = parseAnnotatedHtml(serialized);
+    expect(reparsed.comments.map((entry) => entry.id)).toEqual(["c-2"]);
+    expect(reparsed.warnings).toEqual([]);
+  });
+});
+
+describe("addHtmlComment protected/literal zones", () => {
+  const literalThenBody = [
+    "<!doctype html>",
+    '<html lang="en">',
+    "  <body>",
+    "    <article>",
+    "      <div data-rd-literal>",
+    "        Example showing the phrase quick brown fox in a literal block.",
+    "      </div>",
+    "      <p>The quick brown fox jumps over the lazy dog.</p>",
+    "    </article>",
+    '    <aside class="rd-review" hidden>',
+    "    </aside>",
+    "  </body>",
+    "</html>",
+    "",
+  ].join("\n");
+
+  it("skips occurrences inside data-rd-literal subtrees and keeps the literal block byte-for-byte", () => {
+    const doc = parseAnnotatedHtml(literalThenBody);
+
+    const mutated = addHtmlComment(doc, {
+      id: "c-fox",
+      anchor: { text: "quick brown fox" },
+      author: "a@example.com",
+      createdAt: "2026-05-23T12:00:00Z",
+      body: "Targeting the body occurrence.",
+    });
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    // The literal block bytes are unchanged (the literal occurrence is NOT wrapped).
+    const literalOpen = literalThenBody.indexOf("<div data-rd-literal>");
+    const literalClose =
+      literalThenBody.indexOf("</div>", literalOpen) + "</div>".length;
+    const originalLiteralBlock = literalThenBody.slice(
+      literalOpen,
+      literalClose,
+    );
+    expect(serialized).toContain(originalLiteralBlock);
+
+    // The body occurrence is wrapped in the new <mark>.
+    expect(serialized).toContain(
+      '<p>The <mark data-rd-comment-ids="c-fox">quick brown fox</mark> jumps over the lazy dog.</p>',
+    );
+  });
+});
+
+describe("removeHtmlComment protected/literal zones", () => {
+  const literalMarkOnly = [
+    "<!doctype html>",
+    '<html lang="en">',
+    "  <body>",
+    "    <article>",
+    "      <div data-rd-literal>",
+    '        <mark data-rd-comment-ids="c-literal">documentation example</mark>',
+    "      </div>",
+    "      <p>Plain body content.</p>",
+    "    </article>",
+    '    <aside class="rd-review" hidden>',
+    "      <rd-comment",
+    '        id="c-literal"',
+    '        data-rd-author="a@example.com"',
+    '        data-rd-created-at="2026-05-23T10:00:00Z"',
+    '        data-rd-anchor-ids="c-literal"',
+    '        data-rd-status="open"',
+    "      >Real record with malformed shared id.</rd-comment>",
+    "    </aside>",
+    "  </body>",
+    "</html>",
+    "",
+  ].join("\n");
+
+  const literalAndRealMark = [
+    "<!doctype html>",
+    '<html lang="en">',
+    "  <body>",
+    "    <article>",
+    "      <div data-rd-literal>",
+    '        <mark data-rd-comment-ids="c-real">literal sample text</mark>',
+    "      </div>",
+    '      <p>Real body content: <mark data-rd-comment-ids="c-real">target span</mark>.</p>',
+    "    </article>",
+    '    <aside class="rd-review" hidden>',
+    "      <rd-comment",
+    '        id="c-real"',
+    '        data-rd-author="a@example.com"',
+    '        data-rd-created-at="2026-05-23T10:00:00Z"',
+    '        data-rd-anchor-ids="c-real"',
+    '        data-rd-status="open"',
+    "      >Body.</rd-comment>",
+    "    </aside>",
+    "  </body>",
+    "</html>",
+    "",
+  ].join("\n");
+
+  it("does not touch a <mark> inside data-rd-literal when removing a different real comment", () => {
+    const otherIdFixture = [
+      "<!doctype html>",
+      '<html lang="en">',
+      "  <body>",
+      "    <article>",
+      "      <div data-rd-literal>",
+      '        <mark data-rd-comment-ids="c-other">literal example</mark>',
+      "      </div>",
+      '      <p>Body <mark data-rd-comment-ids="c-real">target</mark> text.</p>',
+      "    </article>",
+      '    <aside class="rd-review" hidden>',
+      "      <rd-comment",
+      '        id="c-real"',
+      '        data-rd-author="a@example.com"',
+      '        data-rd-created-at="2026-05-23T10:00:00Z"',
+      '        data-rd-anchor-ids="c-real"',
+      '        data-rd-status="open"',
+      "      >Body.</rd-comment>",
+      "    </aside>",
+      "  </body>",
+      "</html>",
+      "",
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(otherIdFixture);
+
+    const mutated = removeHtmlComment(doc, { id: "c-real" });
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    // The literal mark is preserved byte-for-byte.
+    expect(serialized).toContain(
+      '<mark data-rd-comment-ids="c-other">literal example</mark>',
+    );
+
+    // The real anchor mark has been unwrapped (it was the only real anchor for c-real).
+    expect(serialized).toContain("<p>Body target text.</p>");
+
+    // The real record is gone.
+    expect(serialized).not.toContain('id="c-real"');
+  });
+
+  it("preserves literal mark bytes even when its data-rd-comment-ids id collides with the comment being removed", () => {
+    const doc = parseAnnotatedHtml(literalMarkOnly);
+
+    const mutated = removeHtmlComment(doc, { id: "c-literal" });
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    // The literal mark survives byte-for-byte even though its id matches.
+    expect(serialized).toContain(
+      '<mark data-rd-comment-ids="c-literal">documentation example</mark>',
+    );
+
+    // The real record is gone.
+    expect(serialized).not.toContain('id="c-literal"');
+    expect(serialized).not.toContain("Real record with malformed shared id.");
+  });
+
+  it("removes the real-body mark while preserving an identically-tagged literal mark", () => {
+    const doc = parseAnnotatedHtml(literalAndRealMark);
+
+    const mutated = removeHtmlComment(doc, { id: "c-real" });
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    // Literal mark intact.
+    expect(serialized).toContain(
+      '<mark data-rd-comment-ids="c-real">literal sample text</mark>',
+    );
+
+    // Real body mark is unwrapped.
+    expect(serialized).toContain("<p>Real body content: target span.</p>");
+
+    // Real record is gone.
+    expect(serialized).not.toContain('id="c-real"');
+    expect(serialized).not.toContain(">Body.</rd-comment>");
+  });
+
+  it("ignores rd-comment records inside data-rd-literal and removes the real review record only", () => {
+    const literalRecordBeforeReal = [
+      "<!doctype html>",
+      '<html lang="en">',
+      "  <body>",
+      "    <article>",
+      "      <div data-rd-literal>",
+      '        <rd-comment id="c-real" data-rd-author="docs@example.com" data-rd-created-at="2026-05-23T09:00:00Z" data-rd-anchor-ids="c-real" data-rd-status="open">literal fake</rd-comment>',
+      "      </div>",
+      '      <p>Real body: <mark data-rd-comment-ids="c-real">target</mark>.</p>',
+      "    </article>",
+      '    <aside class="rd-review" hidden>',
+      "      <rd-comment",
+      '        id="c-real"',
+      '        data-rd-author="a@example.com"',
+      '        data-rd-created-at="2026-05-23T10:00:00Z"',
+      '        data-rd-anchor-ids="c-real"',
+      '        data-rd-status="open"',
+      "      >real body</rd-comment>",
+      "    </aside>",
+      "  </body>",
+      "</html>",
+      "",
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(literalRecordBeforeReal);
+
+    const literalOpen = literalRecordBeforeReal.indexOf(
+      "<div data-rd-literal>",
+    );
+    const literalClose =
+      literalRecordBeforeReal.indexOf("</div>", literalOpen) + "</div>".length;
+    const originalLiteralBlock = literalRecordBeforeReal.slice(
+      literalOpen,
+      literalClose,
+    );
+
+    const mutated = removeHtmlComment(doc, { id: "c-real" });
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    // Literal block bytes unchanged.
+    expect(serialized).toContain(originalLiteralBlock);
+
+    // The real anchor mark is unwrapped.
+    expect(serialized).toContain("<p>Real body: target.</p>");
+
+    // The real review record is gone (the only remaining rd-comment is the literal one).
+    expect(serialized).not.toContain(">real body</rd-comment>");
+    const realRecordIdx = serialized.indexOf('<aside class="rd-review"');
+    expect(realRecordIdx).toBeGreaterThan(-1);
+    const asideTail = serialized.slice(realRecordIdx);
+    expect(asideTail).not.toContain('id="c-real"');
+  });
+});
+
+describe("editHtmlComment protected/literal zones", () => {
+  it("ignores rd-comment records inside data-rd-literal and edits the real review record only", () => {
+    const literalRecordBeforeReal = [
+      "<!doctype html>",
+      '<html lang="en">',
+      "  <body>",
+      "    <article>",
+      "      <div data-rd-literal>",
+      '        <rd-comment id="c-real" data-rd-author="docs@example.com" data-rd-created-at="2026-05-23T09:00:00Z" data-rd-anchor-ids="c-real" data-rd-status="open">literal fake</rd-comment>',
+      "      </div>",
+      "      <p>Real body content.</p>",
+      "    </article>",
+      '    <aside class="rd-review" hidden>',
+      "      <rd-comment",
+      '        id="c-real"',
+      '        data-rd-author="a@example.com"',
+      '        data-rd-created-at="2026-05-23T10:00:00Z"',
+      '        data-rd-anchor-ids="c-real"',
+      '        data-rd-status="open"',
+      "      >real body</rd-comment>",
+      "    </aside>",
+      "  </body>",
+      "</html>",
+      "",
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(literalRecordBeforeReal);
+
+    const literalOpen = literalRecordBeforeReal.indexOf(
+      "<div data-rd-literal>",
+    );
+    const literalClose =
+      literalRecordBeforeReal.indexOf("</div>", literalOpen) + "</div>".length;
+    const originalLiteralBlock = literalRecordBeforeReal.slice(
+      literalOpen,
+      literalClose,
+    );
+
+    const mutated = editHtmlComment(doc, {
+      id: "c-real",
+      body: "updated real body",
+    });
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    // Literal block bytes unchanged.
+    expect(serialized).toContain(originalLiteralBlock);
+
+    // The literal fake body remains, the real record body is updated.
+    expect(serialized).toContain(">literal fake</rd-comment>");
+    expect(serialized).toContain(">updated real body</rd-comment>");
+    expect(serialized).not.toContain(">real body</rd-comment>");
+  });
+});

--- a/packages/rfm/src/html/__tests__/mutate-suggestions.test.ts
+++ b/packages/rfm/src/html/__tests__/mutate-suggestions.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  acceptHtmlSuggestion,
+  parseAnnotatedHtml,
+  rejectHtmlSuggestion,
+  serializeAnnotatedHtml,
+} from "../../index.js";
+
+const fixture = [
+  "<!doctype html>",
+  '<html lang="en">',
+  "  <head>",
+  '    <meta charset="utf-8" />',
+  "    <title>Doc</title>",
+  "  </head>",
+  "  <body>",
+  "    <article>",
+  "      <p>",
+  "        We will replace",
+  "        <del",
+  '          data-rd-suggestion-id="s-3"',
+  '          data-rd-author="a@example.com"',
+  '          data-rd-created-at="2026-05-23T11:02:30Z"',
+  "        >the legacy parser</del><ins",
+  '          data-rd-suggestion-id="s-3"',
+  '          data-rd-author="a@example.com"',
+  '          data-rd-created-at="2026-05-23T11:02:30Z"',
+  "        >the new streaming parser</ins>",
+  "        next sprint.",
+  "      </p>",
+  "      <p>Other paragraph stays untouched.</p>",
+  "    </article>",
+  "  </body>",
+  "</html>",
+  "",
+].join("\n");
+
+describe("acceptHtmlSuggestion", () => {
+  it("accepts a substitution and replaces it with the ins content; nothing else changes", () => {
+    const doc = parseAnnotatedHtml(fixture);
+
+    const mutated = acceptHtmlSuggestion(doc, { id: "s-3" });
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    // Prefix up to the <del> is unchanged.
+    const prefixEnd = fixture.indexOf("<del");
+    expect(serialized.slice(0, prefixEnd)).toBe(fixture.slice(0, prefixEnd));
+
+    // Suffix from just after </ins> is unchanged.
+    const suffixStart = fixture.indexOf("</ins>") + "</ins>".length;
+    expect(serialized.slice(serialized.indexOf("\n        next sprint"))).toBe(
+      fixture.slice(suffixStart),
+    );
+
+    // The del+ins pair is gone; the ins text remains as plain text.
+    expect(serialized).not.toContain("<del");
+    expect(serialized).not.toContain("<ins");
+    expect(serialized).not.toContain("the legacy parser");
+    expect(serialized).toContain("the new streaming parser");
+
+    // Other content untouched.
+    expect(serialized).toContain("Other paragraph stays untouched.");
+
+    // Reparse: no suggestions remain.
+    const reparsed = parseAnnotatedHtml(serialized);
+    expect(reparsed.suggestions).toHaveLength(0);
+  });
+
+  it("accepts a standalone insertion by removing the wrapper and keeping the text", () => {
+    const insertionFixture = [
+      "<!doctype html>",
+      '<html lang="en">',
+      "  <body>",
+      "    <p>We shipped <ins",
+      '        data-rd-suggestion-id="s-1"',
+      '        data-rd-author="a@example.com"',
+      '        data-rd-created-at="2026-05-23T11:00:00Z"',
+      "      >three new</ins> features.</p>",
+      "  </body>",
+      "</html>",
+      "",
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(insertionFixture);
+    const mutated = acceptHtmlSuggestion(doc, { id: "s-1" });
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    expect(serialized).not.toContain("<ins");
+    expect(serialized).toContain("We shipped three new features.");
+
+    const reparsed = parseAnnotatedHtml(serialized);
+    expect(reparsed.suggestions).toHaveLength(0);
+  });
+
+  it("accepts a standalone deletion by removing the wrapper and dropping the text", () => {
+    const deletionFixture = [
+      "<!doctype html>",
+      '<html lang="en">',
+      "  <body>",
+      "    <p>Performance is <del",
+      '        data-rd-suggestion-id="s-2"',
+      '        data-rd-author="a@example.com"',
+      '        data-rd-created-at="2026-05-23T11:01:00Z"',
+      "      >slightly degraded</del> on the home page.</p>",
+      "  </body>",
+      "</html>",
+      "",
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(deletionFixture);
+    const mutated = acceptHtmlSuggestion(doc, { id: "s-2" });
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    expect(serialized).not.toContain("<del");
+    expect(serialized).not.toContain("slightly degraded");
+    expect(serialized).toContain("Performance is  on the home page.");
+
+    const reparsed = parseAnnotatedHtml(serialized);
+    expect(reparsed.suggestions).toHaveLength(0);
+  });
+});
+
+describe("rejectHtmlSuggestion", () => {
+  it("rejects a substitution and restores the del content; nothing else changes", () => {
+    const doc = parseAnnotatedHtml(fixture);
+
+    const mutated = rejectHtmlSuggestion(doc, { id: "s-3" });
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    // Prefix up to the <del> is unchanged.
+    const prefixEnd = fixture.indexOf("<del");
+    expect(serialized.slice(0, prefixEnd)).toBe(fixture.slice(0, prefixEnd));
+
+    // Suffix from the next-sprint text onward is unchanged.
+    const suffixStart = fixture.indexOf("</ins>") + "</ins>".length;
+    expect(serialized.slice(serialized.indexOf("\n        next sprint"))).toBe(
+      fixture.slice(suffixStart),
+    );
+
+    expect(serialized).not.toContain("<del");
+    expect(serialized).not.toContain("<ins");
+    expect(serialized).toContain("the legacy parser");
+    expect(serialized).not.toContain("the new streaming parser");
+
+    expect(serialized).toContain("Other paragraph stays untouched.");
+
+    const reparsed = parseAnnotatedHtml(serialized);
+    expect(reparsed.suggestions).toHaveLength(0);
+  });
+
+  it("rejects a standalone insertion by removing the wrapper and its text", () => {
+    const insertionFixture = [
+      "<!doctype html>",
+      '<html lang="en">',
+      "  <body>",
+      "    <p>We shipped <ins",
+      '        data-rd-suggestion-id="s-1"',
+      '        data-rd-author="a@example.com"',
+      '        data-rd-created-at="2026-05-23T11:00:00Z"',
+      "      >three new</ins> features.</p>",
+      "  </body>",
+      "</html>",
+      "",
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(insertionFixture);
+    const mutated = rejectHtmlSuggestion(doc, { id: "s-1" });
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    expect(serialized).not.toContain("<ins");
+    expect(serialized).not.toContain("three new");
+    expect(serialized).toContain("We shipped  features.");
+  });
+
+  it("rejects a standalone deletion by keeping its text", () => {
+    const deletionFixture = [
+      "<!doctype html>",
+      '<html lang="en">',
+      "  <body>",
+      "    <p>Performance is <del",
+      '        data-rd-suggestion-id="s-2"',
+      '        data-rd-author="a@example.com"',
+      '        data-rd-created-at="2026-05-23T11:01:00Z"',
+      "      >slightly degraded</del> on the home page.</p>",
+      "  </body>",
+      "</html>",
+      "",
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(deletionFixture);
+    const mutated = rejectHtmlSuggestion(doc, { id: "s-2" });
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    expect(serialized).not.toContain("<del");
+    expect(serialized).toContain(
+      "Performance is slightly degraded on the home page.",
+    );
+  });
+});
+
+describe("suggestion mutators protected/literal zones", () => {
+  const preCodeThenReal = [
+    "<!doctype html>",
+    '<html lang="en">',
+    "  <body>",
+    "    <article>",
+    "      <pre><code>",
+    '<ins data-rd-suggestion-id="s-1">literal ins inside pre</ins>',
+    '<del data-rd-suggestion-id="s-1">literal del inside pre</del>',
+    "      </code></pre>",
+    "      <p>",
+    "        Real change here: <del",
+    '          data-rd-suggestion-id="s-1"',
+    '          data-rd-author="a@example.com"',
+    '          data-rd-created-at="2026-05-23T11:02:30Z"',
+    "        >old phrase</del><ins",
+    '          data-rd-suggestion-id="s-1"',
+    '          data-rd-author="a@example.com"',
+    '          data-rd-created-at="2026-05-23T11:02:30Z"',
+    "        >new phrase</ins> end.",
+    "      </p>",
+    "    </article>",
+    "  </body>",
+    "</html>",
+    "",
+  ].join("\n");
+
+  const literalZoneThenReal = [
+    "<!doctype html>",
+    '<html lang="en">',
+    "  <body>",
+    "    <article>",
+    "      <div data-rd-literal>",
+    '        <ins data-rd-suggestion-id="s-7">literal-ins</ins>',
+    "      </div>",
+    "      <p>Real: <ins",
+    '          data-rd-suggestion-id="s-7"',
+    '          data-rd-author="a@example.com"',
+    '          data-rd-created-at="2026-05-23T11:02:30Z"',
+    "        >real-ins</ins> end.</p>",
+    "    </article>",
+    "  </body>",
+    "</html>",
+    "",
+  ].join("\n");
+
+  it("acceptHtmlSuggestion ignores <ins>/<del> inside <pre><code> and mutates the real one only", () => {
+    const doc = parseAnnotatedHtml(preCodeThenReal);
+
+    const preOpen = preCodeThenReal.indexOf("<pre>");
+    const preClose =
+      preCodeThenReal.indexOf("</pre>", preOpen) + "</pre>".length;
+    const literalPreBlock = preCodeThenReal.slice(preOpen, preClose);
+
+    const mutated = acceptHtmlSuggestion(doc, { id: "s-1" });
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    // The pre/code block survives byte-for-byte.
+    expect(serialized).toContain(literalPreBlock);
+
+    // The real substitution was resolved to the ins text.
+    expect(serialized).toContain("Real change here: new phrase end.");
+
+    // The real <del>/<ins> pair is gone.
+    expect(serialized).not.toContain("old phrase");
+    expect(serialized).not.toContain(">new phrase</ins>");
+  });
+
+  it("rejectHtmlSuggestion ignores <ins>/<del> inside <pre><code> and mutates the real one only", () => {
+    const doc = parseAnnotatedHtml(preCodeThenReal);
+
+    const preOpen = preCodeThenReal.indexOf("<pre>");
+    const preClose =
+      preCodeThenReal.indexOf("</pre>", preOpen) + "</pre>".length;
+    const literalPreBlock = preCodeThenReal.slice(preOpen, preClose);
+
+    const mutated = rejectHtmlSuggestion(doc, { id: "s-1" });
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    // pre/code block intact.
+    expect(serialized).toContain(literalPreBlock);
+
+    // Real substitution resolved to del text (rejected).
+    expect(serialized).toContain("Real change here: old phrase end.");
+    expect(serialized).not.toContain(">new phrase</ins>");
+  });
+
+  it("acceptHtmlSuggestion ignores <ins> inside data-rd-literal and mutates the real one only", () => {
+    const doc = parseAnnotatedHtml(literalZoneThenReal);
+
+    const litOpen = literalZoneThenReal.indexOf("<div data-rd-literal>");
+    const litClose =
+      literalZoneThenReal.indexOf("</div>", litOpen) + "</div>".length;
+    const litBlock = literalZoneThenReal.slice(litOpen, litClose);
+
+    const mutated = acceptHtmlSuggestion(doc, { id: "s-7" });
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    // Literal subtree intact byte-for-byte.
+    expect(serialized).toContain(litBlock);
+
+    // Real insertion accepted -> text remains as plain text.
+    expect(serialized).toContain("<p>Real: real-ins end.</p>");
+  });
+
+  it("rejectHtmlSuggestion ignores <ins> inside data-rd-literal and mutates the real one only", () => {
+    const doc = parseAnnotatedHtml(literalZoneThenReal);
+
+    const litOpen = literalZoneThenReal.indexOf("<div data-rd-literal>");
+    const litClose =
+      literalZoneThenReal.indexOf("</div>", litOpen) + "</div>".length;
+    const litBlock = literalZoneThenReal.slice(litOpen, litClose);
+
+    const mutated = rejectHtmlSuggestion(doc, { id: "s-7" });
+    const serialized = serializeAnnotatedHtml(mutated);
+
+    // Literal subtree intact byte-for-byte.
+    expect(serialized).toContain(litBlock);
+
+    // Real insertion rejected -> text dropped.
+    expect(serialized).toContain("<p>Real:  end.</p>");
+    expect(serialized).not.toContain(">real-ins</ins>");
+  });
+});

--- a/packages/rfm/src/html/__tests__/parse-comments.test.ts
+++ b/packages/rfm/src/html/__tests__/parse-comments.test.ts
@@ -1,0 +1,201 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  type HtmlElementNode,
+  type HtmlNode,
+  parseAnnotatedHtml,
+} from "../../index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(here, "../../../../../.context/fixtures/html");
+
+function readFixture(name: string): string {
+  return readFileSync(resolve(fixturesDir, name), "utf-8");
+}
+
+function findElements(
+  nodes: HtmlNode[],
+  predicate: (element: HtmlElementNode) => boolean,
+): HtmlElementNode[] {
+  const found: HtmlElementNode[] = [];
+  const walk = (list: HtmlNode[]) => {
+    for (const node of list) {
+      if (node.type !== "element") continue;
+      if (predicate(node)) found.push(node);
+      walk(node.children);
+    }
+  };
+  walk(nodes);
+  return found;
+}
+
+describe("parseAnnotatedHtml — comment anchors and records", () => {
+  it("pairs each anchor id with its comment record", () => {
+    const html = readFixture("commented-document.html");
+    const doc = parseAnnotatedHtml(html);
+
+    const anchors = findElements(
+      doc.blocks,
+      (element) =>
+        element.tag === "mark" &&
+        Object.hasOwn(element.attrs, "data-rd-comment-ids"),
+    );
+
+    const anchorIds = anchors.flatMap((mark) =>
+      (mark.attrs["data-rd-comment-ids"] ?? "")
+        .split(/\s+/)
+        .filter((id) => id.length > 0),
+    );
+
+    expect(anchorIds).toEqual(["c-7uG2", "c-9aB1", "c-3xY8"]);
+
+    const commentIds = doc.comments.map((comment) => comment.id);
+    expect(commentIds).toContain("c-7uG2");
+    expect(commentIds).toContain("c-9aB1");
+    expect(commentIds).toContain("c-3xY8");
+
+    const primary = doc.comments.find((comment) => comment.id === "c-7uG2");
+    expect(primary).toBeDefined();
+    if (!primary) return;
+    expect(primary.author).toBe("ananth@cradlewise.com");
+    expect(primary.createdAt).toBe("2026-05-23T10:14:11Z");
+    expect(primary.anchorIds).toEqual(["c-7uG2"]);
+    expect(primary.status).toBe("open");
+    expect(primary.replyTo).toBeNull();
+    expect(primary.updatedAt).toBeNull();
+    expect(primary.body).toContain("clear sky");
+  });
+
+  it("parses multi-id anchors and exposes them as one mark with N ids", () => {
+    const html = readFixture("commented-document.html");
+    const doc = parseAnnotatedHtml(html);
+
+    const multiAnchors = findElements(
+      doc.blocks,
+      (element) =>
+        element.tag === "mark" &&
+        (element.attrs["data-rd-comment-ids"] ?? "")
+          .split(/\s+/)
+          .filter(Boolean).length > 1,
+    );
+
+    expect(multiAnchors).toHaveLength(1);
+    const mark = multiAnchors[0];
+    if (!mark) return;
+    expect(mark.attrs["data-rd-comment-ids"]).toBe("c-9aB1 c-3xY8");
+
+    const ids = (mark.attrs["data-rd-comment-ids"] ?? "")
+      .split(/\s+/)
+      .filter((id) => id.length > 0);
+    expect(ids).toEqual(["c-9aB1", "c-3xY8"]);
+
+    for (const id of ids) {
+      expect(doc.comments.find((comment) => comment.id === id)).toBeDefined();
+    }
+  });
+
+  it("parses reply threads via data-rd-reply-to", () => {
+    const html = readFixture("commented-document.html");
+    const doc = parseAnnotatedHtml(html);
+
+    const reply = doc.comments.find((comment) => comment.id === "c-3xY8");
+    expect(reply).toBeDefined();
+    if (!reply) return;
+    expect(reply.replyTo).toBe("c-9aB1");
+
+    const parent = doc.comments.find((comment) => comment.id === "c-9aB1");
+    expect(parent).toBeDefined();
+    if (!parent) return;
+    expect(parent.replyTo).toBeNull();
+  });
+
+  it("parses resolved records and exposes status", () => {
+    const html = readFixture("commented-document.html");
+    const doc = parseAnnotatedHtml(html);
+
+    const resolved = doc.comments.find((comment) => comment.id === "c-4r5T");
+    expect(resolved).toBeDefined();
+    if (!resolved) return;
+    expect(resolved.status).toBe("resolved");
+  });
+
+  it("records orphan anchors as warnings, not exceptions", () => {
+    const input = [
+      "<p>",
+      '  <mark data-rd-comment-ids="c-ghost">word</mark>',
+      "</p>",
+      '<aside class="rd-review" hidden></aside>',
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(input);
+
+    expect(doc.warnings.length).toBeGreaterThan(0);
+    const warning = doc.warnings.find(
+      (entry) => entry.code === "orphan-anchor",
+    );
+    expect(warning).toBeDefined();
+    if (!warning) return;
+    expect(warning.message).toContain("c-ghost");
+  });
+
+  it("records orphan records as warnings, not exceptions", () => {
+    const input = [
+      "<p>plain</p>",
+      '<aside class="rd-review" hidden>',
+      "  <rd-comment",
+      '    id="c-stray"',
+      '    data-rd-author="someone@example.com"',
+      '    data-rd-created-at="2026-05-23T10:14:11Z"',
+      '    data-rd-anchor-ids=""',
+      '    data-rd-status="open"',
+      "  >No anchor for this one.</rd-comment>",
+      "</aside>",
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(input);
+
+    const stray = doc.comments.find((comment) => comment.id === "c-stray");
+    expect(stray).toBeDefined();
+
+    const warning = doc.warnings.find(
+      (entry) => entry.code === "orphan-record",
+    );
+    expect(warning).toBeDefined();
+    if (!warning) return;
+    expect(warning.message).toContain("c-stray");
+  });
+
+  it("does not flag reply records without anchors as orphans", () => {
+    const input = [
+      "<p>",
+      '  <mark data-rd-comment-ids="c-1">word</mark>',
+      "</p>",
+      '<aside class="rd-review" hidden>',
+      "  <rd-comment",
+      '    id="c-1"',
+      '    data-rd-author="a@example.com"',
+      '    data-rd-created-at="2026-05-23T10:14:11Z"',
+      '    data-rd-anchor-ids="c-1"',
+      '    data-rd-status="open"',
+      "  >Parent.</rd-comment>",
+      "  <rd-comment",
+      '    id="c-2"',
+      '    data-rd-author="b@example.com"',
+      '    data-rd-created-at="2026-05-23T10:15:11Z"',
+      '    data-rd-anchor-ids=""',
+      '    data-rd-status="open"',
+      '    data-rd-reply-to="c-1"',
+      "  >Reply.</rd-comment>",
+      "</aside>",
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(input);
+
+    expect(
+      doc.warnings.find((entry) => entry.code === "orphan-record"),
+    ).toBeUndefined();
+  });
+});

--- a/packages/rfm/src/html/__tests__/parse-literal-zones.test.ts
+++ b/packages/rfm/src/html/__tests__/parse-literal-zones.test.ts
@@ -1,0 +1,203 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  type HtmlElementNode,
+  type HtmlNode,
+  parseAnnotatedHtml,
+} from "../../index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(here, "../../../../../.context/fixtures/html");
+
+function readFixture(name: string): string {
+  return readFileSync(resolve(fixturesDir, name), "utf-8");
+}
+
+function findElements(
+  nodes: HtmlNode[],
+  predicate: (element: HtmlElementNode) => boolean,
+): HtmlElementNode[] {
+  const found: HtmlElementNode[] = [];
+  const walk = (list: HtmlNode[]) => {
+    for (const node of list) {
+      if (node.type !== "element") continue;
+      if (predicate(node)) found.push(node);
+      walk(node.children);
+    }
+  };
+  walk(nodes);
+  return found;
+}
+
+describe("parseAnnotatedHtml — literal / protected zones", () => {
+  it("does not extract comments or suggestions from <script> bodies", () => {
+    const input = [
+      "<html>",
+      "  <head>",
+      "    <script>",
+      '      const example = "<mark data-rd-comment-ids=\\"c-script-1\\">x</mark>";',
+      '      const r = "<rd-comment id=\\"c-script-1\\">x</rd-comment>";',
+      "    </script>",
+      "  </head>",
+      "  <body><p>hello</p></body>",
+      "</html>",
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(input);
+
+    expect(
+      doc.comments.find((comment) => comment.id === "c-script-1"),
+    ).toBeUndefined();
+    const scriptAnchorIds = doc.warnings
+      .filter((w) => w.code === "orphan-anchor")
+      .map((w) => w.message);
+    for (const message of scriptAnchorIds) {
+      expect(message).not.toContain("c-script-1");
+    }
+  });
+
+  it("does not extract comments from <style> bodies", () => {
+    const input = [
+      "<html>",
+      "  <head>",
+      "    <style>",
+      '      /* <mark data-rd-comment-ids="c-style-1">x</mark> */',
+      '      /* <rd-comment id="c-style-1">x</rd-comment> */',
+      "    </style>",
+      "  </head>",
+      "  <body><p>hello</p></body>",
+      "</html>",
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(input);
+
+    expect(
+      doc.comments.find((comment) => comment.id === "c-style-1"),
+    ).toBeUndefined();
+    for (const warning of doc.warnings) {
+      expect(warning.message).not.toContain("c-style-1");
+    }
+  });
+
+  it("does not extract comments from <pre><code> bodies with actual nested markup", () => {
+    const input = [
+      "<article>",
+      "  <pre><code>",
+      '    <mark data-rd-comment-ids="c-pre-1">looks like an anchor</mark>',
+      '    <rd-comment id="c-pre-1" data-rd-author="x@example.com" data-rd-created-at="2026-05-23T13:00:00Z" data-rd-anchor-ids="c-pre-1" data-rd-status="open">looks like a record</rd-comment>',
+      "  </code></pre>",
+      "</article>",
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(input);
+
+    expect(
+      doc.comments.find((comment) => comment.id === "c-pre-1"),
+    ).toBeUndefined();
+    for (const warning of doc.warnings) {
+      expect(warning.message).not.toContain("c-pre-1");
+    }
+  });
+
+  it("does not extract suggestions from <pre><code> bodies", () => {
+    const input = [
+      "<article>",
+      "  <pre><code>",
+      '    <ins data-rd-suggestion-id="s-pre-1" data-rd-author="x@example.com" data-rd-created-at="2026-05-23T13:00:00Z">looks inserted</ins>',
+      '    <del data-rd-suggestion-id="s-pre-2" data-rd-author="x@example.com" data-rd-created-at="2026-05-23T13:00:00Z">looks deleted</del>',
+      "  </code></pre>",
+      "</article>",
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(input);
+
+    expect(doc.suggestions.find((s) => s.id === "s-pre-1")).toBeUndefined();
+    expect(doc.suggestions.find((s) => s.id === "s-pre-2")).toBeUndefined();
+  });
+
+  it("does not extract comments from a standalone <code> element with actual nested markup", () => {
+    const input = [
+      "<p>",
+      "  Inline ",
+      '  <code><mark data-rd-comment-ids="c-code-1">snippet</mark></code>',
+      "  here.",
+      "</p>",
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(input);
+
+    expect(
+      doc.comments.find((comment) => comment.id === "c-code-1"),
+    ).toBeUndefined();
+    const codeAnchor = findElements(
+      doc.blocks,
+      (element) =>
+        element.tag === "mark" &&
+        element.attrs["data-rd-comment-ids"] === "c-code-1",
+    );
+    expect(codeAnchor.length).toBe(1);
+  });
+
+  it("does not extract comments from elements with data-rd-literal", () => {
+    const input = [
+      "<article>",
+      "  <div data-rd-literal>",
+      '    <mark data-rd-comment-ids="c-literal-1">not parsed</mark>',
+      '    <rd-comment id="c-literal-1" data-rd-author="x@example.com" data-rd-created-at="2026-05-23T13:00:00Z" data-rd-anchor-ids="c-literal-1" data-rd-status="open">ignored</rd-comment>',
+      '    <ins data-rd-suggestion-id="s-literal-1" data-rd-author="x@example.com" data-rd-created-at="2026-05-23T13:00:00Z">also ignored</ins>',
+      "  </div>",
+      "</article>",
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(input);
+
+    expect(
+      doc.comments.find((comment) => comment.id === "c-literal-1"),
+    ).toBeUndefined();
+    expect(doc.suggestions.find((s) => s.id === "s-literal-1")).toBeUndefined();
+    for (const warning of doc.warnings) {
+      expect(warning.message).not.toContain("c-literal-1");
+    }
+  });
+
+  it("preserves protected-zone children in doc.blocks as ordinary nodes", () => {
+    const input = [
+      "<article>",
+      "  <div data-rd-literal>",
+      '    <mark data-rd-comment-ids="c-literal-1">not parsed</mark>',
+      "  </div>",
+      "</article>",
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(input);
+
+    const literalMark = findElements(
+      doc.blocks,
+      (element) =>
+        element.tag === "mark" &&
+        element.attrs["data-rd-comment-ids"] === "c-literal-1",
+    );
+    expect(literalMark.length).toBe(1);
+  });
+
+  it("still parses the one real comment in literal-zones.html", () => {
+    const html = readFixture("literal-zones.html");
+    const doc = parseAnnotatedHtml(html);
+
+    const real = doc.comments.find((comment) => comment.id === "c-real-1");
+    expect(real).toBeDefined();
+    if (!real) return;
+    expect(real.author).toBe("ananth@cradlewise.com");
+    expect(real.status).toBe("open");
+    expect(real.body).toContain("only real comment");
+
+    expect(doc.comments).toHaveLength(1);
+
+    for (const warning of doc.warnings) {
+      expect(warning.code).not.toBe("orphan-anchor");
+    }
+  });
+});

--- a/packages/rfm/src/html/__tests__/parse-mixed-review.test.ts
+++ b/packages/rfm/src/html/__tests__/parse-mixed-review.test.ts
@@ -1,0 +1,260 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  type HtmlElementNode,
+  type HtmlNode,
+  parseAnnotatedHtml,
+} from "../../index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(here, "../../../../../.context/fixtures/html");
+
+function readFixture(name: string): string {
+  return readFileSync(resolve(fixturesDir, name), "utf-8");
+}
+
+function findElements(
+  nodes: HtmlNode[],
+  predicate: (element: HtmlElementNode) => boolean,
+): HtmlElementNode[] {
+  const found: HtmlElementNode[] = [];
+  const walk = (list: HtmlNode[]) => {
+    for (const node of list) {
+      if (node.type !== "element") continue;
+      if (predicate(node)) found.push(node);
+      walk(node.children);
+    }
+  };
+  walk(nodes);
+  return found;
+}
+
+function firstElement(
+  nodes: HtmlNode[],
+  predicate: (element: HtmlElementNode) => boolean,
+): HtmlElementNode | undefined {
+  return findElements(nodes, predicate)[0];
+}
+
+describe("parseAnnotatedHtml — mixed-review acceptance", () => {
+  it("parses every comment, suggestion, and anchor in mixed-review-document.html into a stable shape", () => {
+    const html = readFixture("mixed-review-document.html");
+    const doc = parseAnnotatedHtml(html);
+
+    expect(doc.format).toBe("annotated-html");
+    expect(doc.version).toBe("0.1");
+    expect(doc.source).toBe(html);
+
+    const topLevelTags = doc.blocks
+      .filter((node): node is HtmlElementNode => node.type === "element")
+      .map((element) => element.tag);
+    expect(topLevelTags).toEqual(["article", "aside"]);
+
+    expect(doc.warnings).toEqual([]);
+
+    expect(doc.comments.map((comment) => comment.id)).toEqual([
+      "c-rev-1",
+      "c-team-1",
+      "c-team-2",
+      "c-risk-1",
+    ]);
+
+    const byId = new Map(doc.comments.map((comment) => [comment.id, comment]));
+
+    const rev = byId.get("c-rev-1");
+    expect(rev).toBeDefined();
+    if (!rev) return;
+    expect(rev.author).toBe("reviewer@example.com");
+    expect(rev.status).toBe("open");
+    expect(rev.replyTo).toBeNull();
+    expect(rev.anchorIds).toEqual(["c-rev-1"]);
+    expect(rev.body).toBe("Cite the exact source row.");
+
+    const team1 = byId.get("c-team-1");
+    expect(team1).toBeDefined();
+    if (!team1) return;
+    expect(team1.author).toBe("ananth@cradlewise.com");
+    expect(team1.status).toBe("open");
+    expect(team1.replyTo).toBeNull();
+    expect(team1.anchorIds).toEqual(["c-team-1"]);
+    expect(team1.body).toBe("Mention headcount delta.");
+
+    const team2 = byId.get("c-team-2");
+    expect(team2).toBeDefined();
+    if (!team2) return;
+    expect(team2.author).toBe("reviewer@example.com");
+    expect(team2.status).toBe("open");
+    expect(team2.replyTo).toBe("c-team-1");
+    expect(team2.anchorIds).toEqual(["c-team-1"]);
+    expect(team2.body).toBe("+1, and split by office.");
+
+    const risk = byId.get("c-risk-1");
+    expect(risk).toBeDefined();
+    if (!risk) return;
+    expect(risk.author).toBe("ananth@cradlewise.com");
+    expect(risk.status).toBe("resolved");
+    expect(risk.replyTo).toBeNull();
+    expect(risk.anchorIds).toEqual(["c-risk-1"]);
+    expect(risk.body).toBe("Fixed in last release.");
+
+    expect(doc.suggestions.map((suggestion) => suggestion.id)).toEqual([
+      "s-rev-1",
+      "s-churn-1",
+    ]);
+
+    const sRev = doc.suggestions.find((s) => s.id === "s-rev-1");
+    expect(sRev).toBeDefined();
+    if (!sRev) return;
+    expect(sRev.kind).toBe("insertion");
+    expect(sRev.author).toBe("ananth@cradlewise.com");
+    expect(sRev.createdAt).toBe("2026-05-23T12:00:00Z");
+    expect(sRev.insertedText).toBe("12%");
+    expect(sRev.deletedText).toBeUndefined();
+
+    const sChurn = doc.suggestions.find((s) => s.id === "s-churn-1");
+    expect(sChurn).toBeDefined();
+    if (!sChurn) return;
+    expect(sChurn.kind).toBe("substitution");
+    expect(sChurn.author).toBe("reviewer@example.com");
+    expect(sChurn.createdAt).toBe("2026-05-23T12:01:00Z");
+    expect(sChurn.deletedText).toBe("high");
+    expect(sChurn.insertedText).toBe("elevated but stable");
+
+    const multiAnchors = findElements(
+      doc.blocks,
+      (element) =>
+        element.tag === "mark" &&
+        (element.attrs["data-rd-comment-ids"] ?? "")
+          .split(/\s+/)
+          .filter(Boolean).length > 1,
+    );
+    expect(multiAnchors).toHaveLength(1);
+    const multi = multiAnchors[0];
+    if (!multi) return;
+    expect(multi.attrs["data-rd-comment-ids"]).toBe("c-team-1 c-team-2");
+  });
+
+  it("assigns each model node a deterministic position-in-document so later chunks can sort by it", () => {
+    const html = readFixture("mixed-review-document.html");
+    const first = parseAnnotatedHtml(html);
+    const second = parseAnnotatedHtml(html);
+
+    const collectPositions = (nodes: HtmlNode[]): number[] => {
+      const positions: number[] = [];
+      const walk = (list: HtmlNode[]) => {
+        for (const node of list) {
+          positions.push(node.position);
+          if (node.type === "element") walk(node.children);
+        }
+      };
+      walk(nodes);
+      return positions;
+    };
+
+    const firstPositions = collectPositions(first.blocks);
+    const secondPositions = collectPositions(second.blocks);
+
+    expect(firstPositions.length).toBeGreaterThan(0);
+    expect(firstPositions).toEqual(secondPositions);
+
+    const uniquePositions = new Set(firstPositions);
+    expect(uniquePositions.size).toBe(firstPositions.length);
+
+    const article = firstElement(
+      first.blocks,
+      (element) => element.tag === "article",
+    );
+    const aside = firstElement(
+      first.blocks,
+      (element) => element.tag === "aside",
+    );
+    expect(article).toBeDefined();
+    expect(aside).toBeDefined();
+    if (!article || !aside) return;
+    expect(article.position).toBeLessThan(aside.position);
+
+    const suggestionPositionById = new Map(
+      first.suggestions.map((suggestion) => [
+        suggestion.id,
+        suggestion.position,
+      ]),
+    );
+    const sRevPos = suggestionPositionById.get("s-rev-1");
+    const sChurnPos = suggestionPositionById.get("s-churn-1");
+    expect(typeof sRevPos).toBe("number");
+    expect(typeof sChurnPos).toBe("number");
+    if (sRevPos === undefined || sChurnPos === undefined) return;
+    expect(sRevPos).toBeLessThan(sChurnPos);
+
+    const delElements = findElements(
+      first.blocks,
+      (element) =>
+        element.tag === "del" &&
+        element.attrs["data-rd-suggestion-id"] === "s-churn-1",
+    );
+    const insElements = findElements(
+      first.blocks,
+      (element) =>
+        element.tag === "ins" &&
+        element.attrs["data-rd-suggestion-id"] === "s-churn-1",
+    );
+    expect(delElements).toHaveLength(1);
+    expect(insElements).toHaveLength(1);
+    const delEl = delElements[0];
+    const insEl = insElements[0];
+    if (!delEl || !insEl) return;
+    expect(delEl.position).toBeLessThan(insEl.position);
+    expect(sChurnPos).toBe(delEl.position);
+
+    const sRevInsElements = findElements(
+      first.blocks,
+      (element) =>
+        element.tag === "ins" &&
+        element.attrs["data-rd-suggestion-id"] === "s-rev-1",
+    );
+    expect(sRevInsElements).toHaveLength(1);
+    const sRevIns = sRevInsElements[0];
+    if (!sRevIns) return;
+    expect(sRevPos).toBe(sRevIns.position);
+
+    const commentPositionById = new Map(
+      first.comments.map((comment) => [comment.id, comment.position]),
+    );
+    const cRev = commentPositionById.get("c-rev-1");
+    const cTeam1 = commentPositionById.get("c-team-1");
+    const cTeam2 = commentPositionById.get("c-team-2");
+    const cRisk = commentPositionById.get("c-risk-1");
+    expect(typeof cRev).toBe("number");
+    expect(typeof cTeam1).toBe("number");
+    expect(typeof cTeam2).toBe("number");
+    expect(typeof cRisk).toBe("number");
+    if (
+      cRev === undefined ||
+      cTeam1 === undefined ||
+      cTeam2 === undefined ||
+      cRisk === undefined
+    ) {
+      return;
+    }
+    expect(cRev).toBeLessThan(cTeam1);
+    expect(cTeam1).toBeLessThan(cTeam2);
+    expect(cTeam2).toBeLessThan(cRisk);
+
+    const rdCommentElements = findElements(
+      first.blocks,
+      (element) => element.tag === "rd-comment",
+    );
+    const elementPositionById = new Map(
+      rdCommentElements.map((element) => [
+        element.attrs.id ?? "",
+        element.position,
+      ]),
+    );
+    for (const [id, position] of commentPositionById) {
+      expect(elementPositionById.get(id)).toBe(position);
+    }
+  });
+});

--- a/packages/rfm/src/html/__tests__/parse-plain.test.ts
+++ b/packages/rfm/src/html/__tests__/parse-plain.test.ts
@@ -1,0 +1,137 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  type HtmlElementNode,
+  type HtmlNode,
+  parseAnnotatedHtml,
+} from "../../index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(here, "../../../../../.context/fixtures/html");
+
+function readFixture(name: string): string {
+  return readFileSync(resolve(fixturesDir, name), "utf-8");
+}
+
+function asElement(node: HtmlNode | undefined): HtmlElementNode {
+  if (!node || node.type !== "element") {
+    throw new Error(`Expected element node, got ${node?.type ?? "undefined"}`);
+  }
+  return node;
+}
+
+function elementChildren(element: HtmlElementNode): HtmlElementNode[] {
+  return element.children.filter(
+    (child): child is HtmlElementNode => child.type === "element",
+  );
+}
+
+describe("parseAnnotatedHtml — plain HTML", () => {
+  it("parses an empty document into an empty AnnotatedHtmlDoc", () => {
+    const doc = parseAnnotatedHtml("");
+
+    expect(doc.format).toBe("annotated-html");
+    expect(doc.version).toBe("0.1");
+    expect(doc.source).toBe("");
+    expect(doc.blocks).toEqual([]);
+    expect(doc.comments).toEqual([]);
+    expect(doc.suggestions).toEqual([]);
+    expect(doc.warnings).toEqual([]);
+  });
+
+  it("parses plain-document.html and exposes top-level blocks in document order", () => {
+    const html = readFixture("plain-document.html");
+    const doc = parseAnnotatedHtml(html);
+
+    expect(doc.format).toBe("annotated-html");
+    expect(doc.source).toBe(html);
+    expect(doc.blocks).toHaveLength(1);
+
+    const article = asElement(doc.blocks[0]);
+    expect(article.tag).toBe("article");
+
+    const articleChildren = elementChildren(article);
+    expect(articleChildren.map((child) => child.tag)).toEqual([
+      "h1",
+      "p",
+      "p",
+      "ul",
+    ]);
+
+    const list = asElement(articleChildren[3]);
+    const items = elementChildren(list);
+    expect(items.map((item) => item.tag)).toEqual(["li", "li", "li"]);
+    expect(
+      items.map((item) =>
+        item.children
+          .filter(
+            (child): child is { type: "text"; value: string } =>
+              child.type === "text",
+          )
+          .map((child) => child.value)
+          .join(""),
+      ),
+    ).toEqual([
+      "Morning: clear.",
+      "Afternoon: scattered clouds.",
+      "Evening: rain likely.",
+    ]);
+  });
+
+  it("does not invent ids, comments, or suggestions for plain content", () => {
+    const html = readFixture("plain-document.html");
+    const doc = parseAnnotatedHtml(html);
+
+    expect(doc.comments).toEqual([]);
+    expect(doc.suggestions).toEqual([]);
+    expect(doc.warnings).toEqual([]);
+  });
+
+  it("parses a fragment without doctype/head/body", () => {
+    const doc = parseAnnotatedHtml(
+      "<p>First paragraph.</p><p>Second paragraph.</p>",
+    );
+
+    expect(doc.blocks).toHaveLength(2);
+    expect(doc.blocks.map((node) => asElement(node).tag)).toEqual(["p", "p"]);
+    expect(doc.comments).toEqual([]);
+    expect(doc.suggestions).toEqual([]);
+    expect(doc.warnings).toEqual([]);
+  });
+
+  it("preserves the order and identity of inline runs inside a paragraph", () => {
+    const doc = parseAnnotatedHtml(
+      "<p>Hello <strong>brave</strong> <em>new</em> world!</p>",
+    );
+
+    expect(doc.blocks).toHaveLength(1);
+    const paragraph = asElement(doc.blocks[0]);
+    expect(paragraph.tag).toBe("p");
+
+    const summary = paragraph.children.map((child) =>
+      child.type === "text"
+        ? { kind: "text" as const, value: child.value }
+        : { kind: "element" as const, tag: child.tag },
+    );
+
+    expect(summary).toEqual([
+      { kind: "text", value: "Hello " },
+      { kind: "element", tag: "strong" },
+      { kind: "text", value: " " },
+      { kind: "element", tag: "em" },
+      { kind: "text", value: " world!" },
+    ]);
+
+    const strong = asElement(paragraph.children[1]);
+    expect(strong.children).toEqual([
+      expect.objectContaining({ type: "text", value: "brave" }),
+    ]);
+    const em = asElement(paragraph.children[3]);
+    expect(em.children).toEqual([
+      expect.objectContaining({ type: "text", value: "new" }),
+    ]);
+  });
+});

--- a/packages/rfm/src/html/__tests__/parse-suggestions.test.ts
+++ b/packages/rfm/src/html/__tests__/parse-suggestions.test.ts
@@ -1,0 +1,171 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  type HtmlElementNode,
+  type HtmlNode,
+  parseAnnotatedHtml,
+} from "../../index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(here, "../../../../../.context/fixtures/html");
+
+function readFixture(name: string): string {
+  return readFileSync(resolve(fixturesDir, name), "utf-8");
+}
+
+function findElements(
+  nodes: HtmlNode[],
+  predicate: (element: HtmlElementNode) => boolean,
+): HtmlElementNode[] {
+  const found: HtmlElementNode[] = [];
+  const walk = (list: HtmlNode[]) => {
+    for (const node of list) {
+      if (node.type !== "element") continue;
+      if (predicate(node)) found.push(node);
+      walk(node.children);
+    }
+  };
+  walk(nodes);
+  return found;
+}
+
+describe("parseAnnotatedHtml — suggestions", () => {
+  it("parses a standalone insertion from suggestions-document.html", () => {
+    const html = readFixture("suggestions-document.html");
+    const doc = parseAnnotatedHtml(html);
+
+    const insertion = doc.suggestions.find(
+      (suggestion) => suggestion.id === "s-1",
+    );
+
+    expect(insertion).toBeDefined();
+    if (!insertion) return;
+    expect(insertion.kind).toBe("insertion");
+    expect(insertion.author).toBe("ananth@cradlewise.com");
+    expect(insertion.createdAt).toBe("2026-05-23T11:00:00Z");
+    expect(insertion.status).toBe("open");
+    expect(insertion.insertedText).toBe("three new");
+    expect(insertion.deletedText).toBeUndefined();
+  });
+
+  it("parses a standalone deletion from suggestions-document.html", () => {
+    const html = readFixture("suggestions-document.html");
+    const doc = parseAnnotatedHtml(html);
+
+    const deletion = doc.suggestions.find(
+      (suggestion) => suggestion.id === "s-2",
+    );
+
+    expect(deletion).toBeDefined();
+    if (!deletion) return;
+    expect(deletion.kind).toBe("deletion");
+    expect(deletion.author).toBe("ananth@cradlewise.com");
+    expect(deletion.createdAt).toBe("2026-05-23T11:01:10Z");
+    expect(deletion.status).toBe("open");
+    expect(deletion.deletedText).toBe("slightly degraded");
+    expect(deletion.insertedText).toBeUndefined();
+  });
+
+  it("parses a del + ins substitution pair sharing one id as one logical suggestion", () => {
+    const html = readFixture("suggestions-document.html");
+    const doc = parseAnnotatedHtml(html);
+
+    const matching = doc.suggestions.filter(
+      (suggestion) => suggestion.id === "s-3",
+    );
+
+    expect(matching).toHaveLength(1);
+    const substitution = matching[0];
+    if (!substitution) return;
+    expect(substitution.kind).toBe("substitution");
+    expect(substitution.deletedText).toBe("the legacy parser");
+    expect(substitution.insertedText).toBe("the new streaming parser");
+    expect(substitution.author).toBe("ananth@cradlewise.com");
+    expect(substitution.createdAt).toBe("2026-05-23T11:02:30Z");
+    expect(substitution.status).toBe("open");
+  });
+
+  it("treats a del + ins with mismatched ids as two independent suggestions", () => {
+    const input = [
+      "<p>",
+      '  Before <del data-rd-suggestion-id="d-1" data-rd-author="a@example.com" data-rd-created-at="2026-05-23T12:00:00Z">old</del><ins data-rd-suggestion-id="i-2" data-rd-author="b@example.com" data-rd-created-at="2026-05-23T12:00:05Z">new</ins> after.',
+      "</p>",
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(input);
+
+    expect(doc.suggestions).toHaveLength(2);
+
+    const deletion = doc.suggestions.find(
+      (suggestion) => suggestion.id === "d-1",
+    );
+    const insertion = doc.suggestions.find(
+      (suggestion) => suggestion.id === "i-2",
+    );
+
+    expect(deletion).toBeDefined();
+    if (!deletion) return;
+    expect(deletion.kind).toBe("deletion");
+    expect(deletion.deletedText).toBe("old");
+
+    expect(insertion).toBeDefined();
+    if (!insertion) return;
+    expect(insertion.kind).toBe("insertion");
+    expect(insertion.insertedText).toBe("new");
+  });
+
+  it("preserves <ins> and <del> nodes in doc.blocks with attrs intact", () => {
+    const html = readFixture("suggestions-document.html");
+    const doc = parseAnnotatedHtml(html);
+
+    const insElements = findElements(
+      doc.blocks,
+      (element) => element.tag === "ins",
+    );
+    const delElements = findElements(
+      doc.blocks,
+      (element) => element.tag === "del",
+    );
+
+    expect(insElements.length).toBeGreaterThanOrEqual(2);
+    expect(delElements.length).toBeGreaterThanOrEqual(2);
+
+    const insIds = insElements.map(
+      (element) => element.attrs["data-rd-suggestion-id"],
+    );
+    const delIds = delElements.map(
+      (element) => element.attrs["data-rd-suggestion-id"],
+    );
+
+    expect(insIds).toContain("s-1");
+    expect(insIds).toContain("s-3");
+    expect(delIds).toContain("s-2");
+    expect(delIds).toContain("s-3");
+  });
+
+  it("defaults status to open when the attribute is missing and ignores unknown values", () => {
+    const input = [
+      '<p><ins data-rd-suggestion-id="s-default" data-rd-author="a@example.com" data-rd-created-at="2026-05-23T12:00:00Z">added</ins></p>',
+      '<p><del data-rd-suggestion-id="s-unknown" data-rd-author="a@example.com" data-rd-created-at="2026-05-23T12:00:01Z" data-rd-status="weird">gone</del></p>',
+    ].join("\n");
+
+    const doc = parseAnnotatedHtml(input);
+
+    const defaulted = doc.suggestions.find(
+      (suggestion) => suggestion.id === "s-default",
+    );
+    expect(defaulted).toBeDefined();
+    if (!defaulted) return;
+    expect(defaulted.status).toBe("open");
+
+    const unknown = doc.suggestions.find(
+      (suggestion) => suggestion.id === "s-unknown",
+    );
+    expect(unknown).toBeDefined();
+    if (!unknown) return;
+    expect(unknown.status).toBe("open");
+  });
+});

--- a/packages/rfm/src/html/__tests__/perf-mixed-review.test.ts
+++ b/packages/rfm/src/html/__tests__/perf-mixed-review.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  parseAnnotatedHtml,
+  sanitizeAnnotatedHtml,
+  serializeAnnotatedHtml,
+} from "../../index.js";
+
+// Performance budgets are intentionally loose so we catch only order-of-
+// magnitude regressions, not normal CI jitter. Measured locally:
+//   parse(mixed-review-document.html):     ~1-3 ms
+//   sanitize(mixed-review-document.html):  ~1-2 ms
+//   serialize(parse(mixed)):               ~1 ms
+// Budgets are 10x-ish those numbers, scaled up to forgive a busy CI runner.
+// Update the budget if measurements consistently drift; do not tighten until
+// we have a real signal that today's headroom is causing latent bugs.
+const PARSE_BUDGET_MS = 200;
+const SANITIZE_BUDGET_MS = 200;
+const SERIALIZE_BUDGET_MS = 200;
+const ITERATIONS = 50;
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(here, "../../../../../.context/fixtures/html");
+
+function readFixture(name: string): string {
+  return readFileSync(resolve(fixturesDir, name), "utf-8");
+}
+
+function timeMs(fn: () => void): number {
+  const start = performance.now();
+  fn();
+  return performance.now() - start;
+}
+
+describe("html performance budgets (mixed-review fixture)", () => {
+  const source = readFixture("mixed-review-document.html");
+
+  it(`parse stays under ${PARSE_BUDGET_MS} ms on the mixed-review fixture`, () => {
+    // Warm-up to avoid first-call JIT bias.
+    parseAnnotatedHtml(source);
+    const elapsed = timeMs(() => {
+      for (let i = 0; i < ITERATIONS; i += 1) {
+        parseAnnotatedHtml(source);
+      }
+    });
+    const perIteration = elapsed / ITERATIONS;
+    expect(perIteration).toBeLessThan(PARSE_BUDGET_MS);
+  });
+
+  it(`sanitize stays under ${SANITIZE_BUDGET_MS} ms on the mixed-review fixture`, () => {
+    sanitizeAnnotatedHtml(source);
+    const elapsed = timeMs(() => {
+      for (let i = 0; i < ITERATIONS; i += 1) {
+        sanitizeAnnotatedHtml(source);
+      }
+    });
+    const perIteration = elapsed / ITERATIONS;
+    expect(perIteration).toBeLessThan(SANITIZE_BUDGET_MS);
+  });
+
+  it(`serialize(parse(...)) stays under ${SERIALIZE_BUDGET_MS} ms on the mixed-review fixture`, () => {
+    const doc = parseAnnotatedHtml(source);
+    serializeAnnotatedHtml(doc);
+    const elapsed = timeMs(() => {
+      for (let i = 0; i < ITERATIONS; i += 1) {
+        serializeAnnotatedHtml(doc);
+      }
+    });
+    const perIteration = elapsed / ITERATIONS;
+    expect(perIteration).toBeLessThan(SERIALIZE_BUDGET_MS);
+  });
+});

--- a/packages/rfm/src/html/__tests__/sanitize-allowlist.test.ts
+++ b/packages/rfm/src/html/__tests__/sanitize-allowlist.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type HtmlSanitizerWarning,
+  sanitizeAnnotatedHtml,
+} from "../../index.js";
+
+function codes(warnings: HtmlSanitizerWarning[]): string[] {
+  return warnings.map((warning) => warning.code);
+}
+
+function expectWarningCode(
+  warnings: HtmlSanitizerWarning[],
+  code: string,
+): void {
+  expect(
+    warnings.some((warning) => warning.code === code),
+    `expected a warning with code "${code}", got: ${JSON.stringify(codes(warnings))}`,
+  ).toBe(true);
+}
+
+describe("sanitizeAnnotatedHtml — ADR 0005 §6 allowlist", () => {
+  describe("disallowed elements", () => {
+    it("strips <script> in body and records a warning", () => {
+      const { html, warnings } = sanitizeAnnotatedHtml(
+        '<body><p>Hello.</p><script>alert("xss")</script></body>',
+      );
+
+      expect(html).not.toMatch(/<script/i);
+      expect(html).not.toContain('alert("xss")');
+      expect(html).toContain("Hello.");
+      expectWarningCode(warnings, "disallowed-element");
+    });
+
+    it("strips <iframe> and records a warning", () => {
+      const { html, warnings } = sanitizeAnnotatedHtml(
+        '<p>Before</p><iframe src="https://evil.example/"></iframe><p>After</p>',
+      );
+
+      expect(html).not.toMatch(/<iframe/i);
+      expect(html).toContain("Before");
+      expect(html).toContain("After");
+      expectWarningCode(warnings, "disallowed-element");
+    });
+
+    it.each([
+      ["object", '<object data="https://evil.example/">x</object>'],
+      ["embed", '<embed src="https://evil.example/">'],
+      ["form", '<form action="/x"><p>inside</p></form>'],
+      ["input", '<input type="text" name="x">'],
+      ["button", "<button>Click</button>"],
+      ["select", "<select><option>a</option></select>"],
+      ["textarea", "<textarea>hi</textarea>"],
+    ])("strips <%s> and records a warning", (tag, fragment) => {
+      const { html, warnings } = sanitizeAnnotatedHtml(
+        `<p>Before</p>${fragment}<p>After</p>`,
+      );
+
+      expect(html.toLowerCase()).not.toContain(`<${tag}`);
+      expect(html).toContain("Before");
+      expect(html).toContain("After");
+      expectWarningCode(warnings, "disallowed-element");
+    });
+  });
+
+  describe("disallowed attributes", () => {
+    it("strips on* event-handler attributes and records a warning", () => {
+      const { html, warnings } = sanitizeAnnotatedHtml(
+        '<p onclick="steal()" onmouseover="more()">Hi</p>',
+      );
+
+      expect(html).not.toMatch(/onclick/i);
+      expect(html).not.toMatch(/onmouseover/i);
+      expect(html).not.toContain("steal()");
+      expect(html).toContain("<p");
+      expect(html).toContain("Hi");
+      expectWarningCode(warnings, "disallowed-attribute");
+    });
+
+    it("strips inline style attributes and records a warning", () => {
+      const { html, warnings } = sanitizeAnnotatedHtml(
+        '<p style="color:red">Hi</p>',
+      );
+
+      expect(html).not.toMatch(/style=/i);
+      expect(html).toContain("Hi");
+      expectWarningCode(warnings, "disallowed-attribute");
+    });
+
+    it("keeps allowed global attributes (id, class, lang, title, dir, hidden)", () => {
+      const { html, warnings } = sanitizeAnnotatedHtml(
+        '<p id="p1" class="lead" lang="en" title="t" dir="ltr" hidden>Hi</p>',
+      );
+
+      expect(html).toContain('id="p1"');
+      expect(html).toContain('class="lead"');
+      expect(html).toContain('lang="en"');
+      expect(html).toContain('title="t"');
+      expect(html).toContain('dir="ltr"');
+      expect(html).toMatch(/hidden(=|\s|>)/);
+      expect(warnings).toEqual([]);
+    });
+
+    it("keeps the data-rd-* namespace on review elements", () => {
+      const html = [
+        '<p>The <mark data-rd-comment-ids="c-1">sky</mark> is blue.</p>',
+        '<ins data-rd-suggestion-id="s-1" data-rd-author="a" data-rd-created-at="2026-05-23T00:00:00Z">new</ins>',
+        '<del data-rd-suggestion-id="s-2" data-rd-author="a" data-rd-created-at="2026-05-23T00:00:00Z">old</del>',
+        '<aside class="rd-review" hidden>',
+        '<rd-comment id="c-1" data-rd-author="a" data-rd-created-at="2026-05-23T00:00:00Z" data-rd-anchor-ids="c-1" data-rd-status="open">Body.</rd-comment>',
+        "</aside>",
+      ].join("");
+
+      const result = sanitizeAnnotatedHtml(html);
+
+      expect(result.html).toContain('data-rd-comment-ids="c-1"');
+      expect(result.html).toContain('data-rd-suggestion-id="s-1"');
+      expect(result.html).toContain('data-rd-suggestion-id="s-2"');
+      expect(result.html).toContain('data-rd-anchor-ids="c-1"');
+      expect(result.html).toContain('data-rd-status="open"');
+      expect(result.html).toContain("<rd-comment");
+      expect(result.warnings).toEqual([]);
+    });
+  });
+
+  describe("URL scheme handling", () => {
+    it("strips javascript: URLs from a[href] and records a warning", () => {
+      const { html, warnings } = sanitizeAnnotatedHtml(
+        '<a href="javascript:alert(1)">click</a>',
+      );
+
+      expect(html).not.toMatch(/javascript:/i);
+      expect(html).toContain("click");
+      expectWarningCode(warnings, "disallowed-url");
+    });
+
+    it("strips javascript: URLs from img[src] and records a warning", () => {
+      const { html, warnings } = sanitizeAnnotatedHtml(
+        '<img src="javascript:alert(1)" alt="x">',
+      );
+
+      expect(html).not.toMatch(/javascript:/i);
+      expectWarningCode(warnings, "disallowed-url");
+    });
+
+    it("strips non-image data: URLs from a[href] and records a warning", () => {
+      const { html, warnings } = sanitizeAnnotatedHtml(
+        '<a href="data:text/html,<script>alert(1)</script>">x</a>',
+      );
+
+      expect(html).not.toMatch(/href="data:/i);
+      expect(html).toContain("x");
+      expectWarningCode(warnings, "disallowed-url");
+    });
+
+    it("strips non-image data: URLs from img[src] and records a warning", () => {
+      const { html, warnings } = sanitizeAnnotatedHtml(
+        '<img src="data:text/html,<b>nope</b>" alt="x">',
+      );
+
+      expect(html).not.toMatch(/src="data:/i);
+      expectWarningCode(warnings, "disallowed-url");
+    });
+
+    it("keeps data:image/* in img[src]", () => {
+      const dataUrl =
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX/AAAZ4gk3AAAAAXRSTlMAQObYZgAAAAtJREFUCNdjYAAAAAIAAUivpHEAAAAASUVORK5CYII=";
+
+      const { html, warnings } = sanitizeAnnotatedHtml(
+        `<img src="${dataUrl}" alt="px">`,
+      );
+
+      expect(html).toContain(`src="${dataUrl}"`);
+      expect(html).toContain('alt="px"');
+      expect(warnings).toEqual([]);
+    });
+  });
+
+  describe("protected / literal zones", () => {
+    it("preserves <pre> body bytes verbatim, including annotation-looking text", () => {
+      const inner =
+        '<mark data-rd-comment-ids="c-not-real">sky</mark> &amp; sea\n  with    spacing';
+      const { html, warnings } = sanitizeAnnotatedHtml(`<pre>${inner}</pre>`);
+
+      expect(html).toContain(`<pre>${inner}</pre>`);
+      expect(warnings).toEqual([]);
+    });
+
+    it("preserves <code> body bytes verbatim", () => {
+      const inner = '<ins data-rd-suggestion-id="s-not-real">x</ins>';
+      const { html, warnings } = sanitizeAnnotatedHtml(`<code>${inner}</code>`);
+
+      expect(html).toContain(`<code>${inner}</code>`);
+      expect(warnings).toEqual([]);
+    });
+
+    it("preserves data-rd-literal body bytes verbatim", () => {
+      const inner =
+        '<rd-comment id="c-not-real" data-rd-author="x">literal example</rd-comment>';
+      const { html, warnings } = sanitizeAnnotatedHtml(
+        `<div data-rd-literal>${inner}</div>`,
+      );
+
+      expect(html).toContain(inner);
+      expect(warnings).toEqual([]);
+    });
+
+    it("still sanitizes dangerous attributes on the outer tag of a protected element", () => {
+      const inner = "console.log('hi')";
+      const { html, warnings } = sanitizeAnnotatedHtml(
+        `<pre onclick="steal()" style="color:red">${inner}</pre>`,
+      );
+
+      expect(html).toContain(inner);
+      expect(html).toContain("<pre");
+      expect(html).not.toMatch(/onclick/i);
+      expect(html).not.toMatch(/style=/i);
+      expectWarningCode(warnings, "disallowed-attribute");
+    });
+  });
+
+  describe("element allowlist (ADR §6)", () => {
+    it("strips unknown elements outside the allowlist and records a warning", () => {
+      const { html, warnings } = sanitizeAnnotatedHtml(
+        '<p>Before</p><marquee behavior="scroll">flash</marquee><p>After</p>',
+      );
+
+      expect(html.toLowerCase()).not.toContain("<marquee");
+      expect(html.toLowerCase()).not.toContain("behavior=");
+      expect(html).toContain("flash");
+      expect(html).toContain("Before");
+      expect(html).toContain("After");
+      expectWarningCode(warnings, "disallowed-element");
+    });
+
+    it("strips unknown self-closing elements outside the allowlist", () => {
+      const { html, warnings } = sanitizeAnnotatedHtml(
+        "<p>Before</p><custom-thing/><p>After</p>",
+      );
+
+      expect(html.toLowerCase()).not.toContain("<custom-thing");
+      expect(html).toContain("Before");
+      expect(html).toContain("After");
+      expectWarningCode(warnings, "disallowed-element");
+    });
+
+    it("keeps the ADR structural and inline allowlisted elements", () => {
+      const fragment = [
+        "<article>",
+        "<h1>Title</h1>",
+        "<h2>Subtitle</h2>",
+        "<p>A <strong>bold</strong> <em>emphasized</em> phrase with <code>code</code>, ",
+        "<kbd>Ctrl</kbd>+<kbd>C</kbd>, <samp>output</samp>, <var>x</var>, ",
+        "H<sub>2</sub>O, x<sup>2</sup>, line<br>break.</p>",
+        "<blockquote>quote</blockquote>",
+        "<ul><li>one</li><li>two</li></ul>",
+        "<ol><li>a</li></ol>",
+        "<figure><figcaption>Figure 1</figcaption></figure>",
+        "<table><thead><tr><th>h</th></tr></thead><tbody><tr><td>v</td></tr></tbody></table>",
+        "</article>",
+      ].join("");
+
+      const { html, warnings } = sanitizeAnnotatedHtml(fragment);
+
+      expect(warnings).toEqual([]);
+      expect(html).toContain("<article>");
+      expect(html).toContain("<h1>Title</h1>");
+      expect(html).toContain("<h2>Subtitle</h2>");
+      expect(html).toContain("<strong>bold</strong>");
+      expect(html).toContain("<em>emphasized</em>");
+      expect(html).toContain("<code>code</code>");
+      expect(html).toContain("<kbd>Ctrl</kbd>");
+      expect(html).toContain("<samp>output</samp>");
+      expect(html).toContain("<var>x</var>");
+      expect(html).toContain("<sub>2</sub>");
+      expect(html).toContain("<sup>2</sup>");
+      expect(html).toContain("<br>");
+      expect(html).toContain("<blockquote>quote</blockquote>");
+      expect(html).toContain("<figure>");
+      expect(html).toContain("<figcaption>Figure 1</figcaption>");
+      expect(html).toContain("<table>");
+      expect(html).toContain("<thead>");
+      expect(html).toContain("<tbody>");
+      expect(html).toContain("<th>h</th>");
+      expect(html).toContain("<td>v</td>");
+    });
+  });
+
+  describe("attribute allowlist (ADR §6)", () => {
+    it("strips non-allowlisted attributes from allowed elements and records a warning", () => {
+      const { html, warnings } = sanitizeAnnotatedHtml(
+        '<p aria-label="x" role="note" spellcheck="true" data-user="x">Hi</p>',
+      );
+
+      expect(html).toContain("Hi");
+      expect(html).toMatch(/<p\s*>|<p>/);
+      expect(html).not.toMatch(/aria-label/i);
+      expect(html).not.toMatch(/\brole=/i);
+      expect(html).not.toMatch(/spellcheck/i);
+      expect(html).not.toMatch(/data-user/i);
+      expectWarningCode(warnings, "disallowed-attribute");
+    });
+
+    it("keeps element-specific attributes only on the elements they belong to", () => {
+      const { html: anchorHtml, warnings: anchorWarnings } =
+        sanitizeAnnotatedHtml('<a href="/safe">link</a>');
+      expect(anchorHtml).toContain('href="/safe"');
+      expect(anchorWarnings).toEqual([]);
+
+      const { html: imgHtml, warnings: imgWarnings } = sanitizeAnnotatedHtml(
+        '<img src="/safe.png" alt="hi">',
+      );
+      expect(imgHtml).toContain('src="/safe.png"');
+      expect(imgHtml).toContain('alt="hi"');
+      expect(imgWarnings).toEqual([]);
+
+      const { html: pHtml, warnings: pWarnings } = sanitizeAnnotatedHtml(
+        '<p href="/x" src="/y" alt="z">Hi</p>',
+      );
+      expect(pHtml).toContain("Hi");
+      expect(pHtml).not.toMatch(/href=/i);
+      expect(pHtml).not.toMatch(/\bsrc=/i);
+      expect(pHtml).not.toMatch(/\balt=/i);
+      expectWarningCode(pWarnings, "disallowed-attribute");
+    });
+  });
+
+  describe("warning shape", () => {
+    it("returns typed warnings with code and message strings", () => {
+      const { warnings } = sanitizeAnnotatedHtml(
+        '<p onclick="x()"><script>y()</script></p>',
+      );
+
+      expect(warnings.length).toBeGreaterThan(0);
+      for (const warning of warnings) {
+        expect(typeof warning.code).toBe("string");
+        expect(warning.code.length).toBeGreaterThan(0);
+        expect(typeof warning.message).toBe("string");
+        expect(warning.message.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("returns an empty warnings list for input that is already clean", () => {
+      const { html, warnings } = sanitizeAnnotatedHtml(
+        '<p id="p1" class="lead">Hello <strong>world</strong>.</p>',
+      );
+
+      expect(html).toContain("Hello");
+      expect(html).toContain("<strong>world</strong>");
+      expect(warnings).toEqual([]);
+    });
+  });
+});

--- a/packages/rfm/src/html/__tests__/serialize-comments.test.ts
+++ b/packages/rfm/src/html/__tests__/serialize-comments.test.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  type HtmlElementNode,
+  type HtmlNode,
+  parseAnnotatedHtml,
+  serializeAnnotatedHtml,
+} from "../../index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(here, "../../../../../.context/fixtures/html");
+
+function readFixture(name: string): string {
+  return readFileSync(resolve(fixturesDir, name), "utf-8");
+}
+
+function findElements(
+  nodes: HtmlNode[],
+  predicate: (element: HtmlElementNode) => boolean,
+): HtmlElementNode[] {
+  const found: HtmlElementNode[] = [];
+  const walk = (list: HtmlNode[]) => {
+    for (const node of list) {
+      if (node.type !== "element") continue;
+      if (predicate(node)) found.push(node);
+      walk(node.children);
+    }
+  };
+  walk(nodes);
+  return found;
+}
+
+describe("serializeAnnotatedHtml — commented HTML", () => {
+  it("round-trips commented-document.html under low-churn equality", () => {
+    const html = readFixture("commented-document.html");
+
+    const serialized = serializeAnnotatedHtml(parseAnnotatedHtml(html));
+    expect(serialized).toBe(html);
+
+    const reparsed = parseAnnotatedHtml(serialized);
+
+    const expected = [
+      {
+        id: "c-7uG2",
+        status: "open",
+        replyTo: null,
+        bodyIncludes: "clear sky",
+      },
+      {
+        id: "c-9aB1",
+        status: "open",
+        replyTo: null,
+        bodyIncludes: "specific time window",
+      },
+      {
+        id: "c-3xY8",
+        status: "open",
+        replyTo: "c-9aB1",
+        bodyIncludes: "after 7pm",
+      },
+      {
+        id: "c-4r5T",
+        status: "resolved",
+        replyTo: null,
+        bodyIncludes: "Resolved offline",
+      },
+    ];
+
+    for (const expectedComment of expected) {
+      const comment = reparsed.comments.find(
+        (entry) => entry.id === expectedComment.id,
+      );
+      expect(comment).toBeDefined();
+      if (!comment) continue;
+      expect(comment.status).toBe(expectedComment.status);
+      expect(comment.replyTo).toBe(expectedComment.replyTo);
+      expect(comment.body).toContain(expectedComment.bodyIncludes);
+    }
+  });
+
+  it("preserves comment order in the rd-review aside", () => {
+    const html = readFixture("commented-document.html");
+
+    const serialized = serializeAnnotatedHtml(parseAnnotatedHtml(html));
+
+    const ids = Array.from(
+      serialized.matchAll(/<rd-comment\b[^>]*\sid="([^"]+)"/g),
+      (match) => match[1] ?? "",
+    );
+
+    expect(ids).toEqual(["c-7uG2", "c-9aB1", "c-3xY8", "c-4r5T"]);
+  });
+
+  it("preserves multi-id anchor attribute value order", () => {
+    const html = readFixture("commented-document.html");
+
+    const serialized = serializeAnnotatedHtml(parseAnnotatedHtml(html));
+
+    expect(serialized).toContain('data-rd-comment-ids="c-9aB1 c-3xY8"');
+
+    const reparsed = parseAnnotatedHtml(serialized);
+
+    const multiAnchors = findElements(
+      reparsed.blocks,
+      (element) =>
+        element.tag === "mark" &&
+        (element.attrs["data-rd-comment-ids"] ?? "")
+          .split(/\s+/)
+          .filter(Boolean).length > 1,
+    );
+
+    expect(multiAnchors).toHaveLength(1);
+    const mark = multiAnchors[0];
+    if (!mark) return;
+
+    const ids = (mark.attrs["data-rd-comment-ids"] ?? "")
+      .split(/\s+/)
+      .filter((id) => id.length > 0);
+    expect(ids).toEqual(["c-9aB1", "c-3xY8"]);
+  });
+});

--- a/packages/rfm/src/html/__tests__/serialize-literal-zones.test.ts
+++ b/packages/rfm/src/html/__tests__/serialize-literal-zones.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { parseAnnotatedHtml, serializeAnnotatedHtml } from "../../index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(here, "../../../../../.context/fixtures/html");
+
+function readFixture(name: string): string {
+  return readFileSync(resolve(fixturesDir, name), "utf-8");
+}
+
+function extractBetween(html: string, start: string, end: string): string {
+  const startIdx = html.indexOf(start);
+  if (startIdx === -1) {
+    throw new Error(`start marker not found: ${start}`);
+  }
+  const afterStart = startIdx + start.length;
+  const endIdx = html.indexOf(end, afterStart);
+  if (endIdx === -1) {
+    throw new Error(`end marker not found: ${end}`);
+  }
+  return html.slice(afterStart, endIdx);
+}
+
+describe("serializeAnnotatedHtml — literal / protected zones", () => {
+  it("preserves <script> body byte-for-byte", () => {
+    const html = readFixture("literal-zones.html");
+    const serialized = serializeAnnotatedHtml(parseAnnotatedHtml(html));
+
+    expect(serialized).toBe(html);
+
+    const originalScript = extractBetween(html, "<script>", "</script>");
+    const serializedScript = extractBetween(
+      serialized,
+      "<script>",
+      "</script>",
+    );
+
+    expect(serializedScript).toBe(originalScript);
+  });
+
+  it("preserves <pre><code> body byte-for-byte", () => {
+    const html = readFixture("literal-zones.html");
+    const serialized = serializeAnnotatedHtml(parseAnnotatedHtml(html));
+
+    const originalPre = extractBetween(html, "<pre><code>", "</code></pre>");
+    const serializedPre = extractBetween(
+      serialized,
+      "<pre><code>",
+      "</code></pre>",
+    );
+
+    expect(serializedPre).toBe(originalPre);
+    expect(serializedPre).toContain(
+      '&lt;rd-comment id="c-pre-1"&gt;not a real comment&lt;/rd-comment&gt;',
+    );
+  });
+
+  it("preserves data-rd-literal body byte-for-byte and exposes only the real comment", () => {
+    const html = readFixture("literal-zones.html");
+    const serialized = serializeAnnotatedHtml(parseAnnotatedHtml(html));
+
+    const literalStart = "<div data-rd-literal>";
+    const literalEnd = "</div>";
+
+    const originalBlock = extractBetween(html, literalStart, literalEnd);
+    const serializedBlock = extractBetween(
+      serialized,
+      literalStart,
+      literalEnd,
+    );
+
+    expect(serializedBlock).toBe(originalBlock);
+
+    const reparsed = parseAnnotatedHtml(serialized);
+
+    const commentIds = reparsed.comments.map((comment) => comment.id);
+    expect(commentIds).toEqual(["c-real-1"]);
+
+    expect(
+      reparsed.suggestions.find((s) => s.id === "s-pre-1"),
+    ).toBeUndefined();
+    expect(
+      reparsed.comments.find((comment) => comment.id === "c-pre-1"),
+    ).toBeUndefined();
+    expect(
+      reparsed.comments.find((comment) => comment.id === "c-literal-1"),
+    ).toBeUndefined();
+  });
+});

--- a/packages/rfm/src/html/__tests__/serialize-mixed-review.test.ts
+++ b/packages/rfm/src/html/__tests__/serialize-mixed-review.test.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  type AnnotatedHtmlDoc,
+  type HtmlNode,
+  parseAnnotatedHtml,
+  serializeAnnotatedHtml,
+} from "../../index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(here, "../../../../../.context/fixtures/html");
+
+function readFixture(name: string): string {
+  return readFileSync(resolve(fixturesDir, name), "utf-8");
+}
+
+interface StableElement {
+  type: "element";
+  tag: string;
+  attrs: Record<string, string>;
+  children: StableNode[];
+}
+
+interface StableText {
+  type: "text";
+  value: string;
+}
+
+type StableNode = StableElement | StableText;
+
+function toStableTree(nodes: HtmlNode[]): StableNode[] {
+  return nodes.map((node) => {
+    if (node.type === "element") {
+      return {
+        type: "element",
+        tag: node.tag,
+        attrs: { ...node.attrs },
+        children: toStableTree(node.children),
+      };
+    }
+    return { type: "text", value: node.value };
+  });
+}
+
+interface StableComment {
+  id: string;
+  status: AnnotatedHtmlDoc["comments"][number]["status"];
+  replyTo: string | null;
+  body: string;
+  anchorIds: string[];
+}
+
+function toStableComments(doc: AnnotatedHtmlDoc): StableComment[] {
+  return doc.comments.map((comment) => ({
+    id: comment.id,
+    status: comment.status,
+    replyTo: comment.replyTo,
+    body: comment.body,
+    anchorIds: [...comment.anchorIds],
+  }));
+}
+
+interface StableSuggestion {
+  id: string;
+  kind: AnnotatedHtmlDoc["suggestions"][number]["kind"];
+  status: AnnotatedHtmlDoc["suggestions"][number]["status"];
+  author: string | null;
+  createdAt: string | null;
+  deletedText: string | undefined;
+  insertedText: string | undefined;
+}
+
+function toStableSuggestions(doc: AnnotatedHtmlDoc): StableSuggestion[] {
+  return doc.suggestions.map((suggestion) => ({
+    id: suggestion.id,
+    kind: suggestion.kind,
+    status: suggestion.status,
+    author: suggestion.author,
+    createdAt: suggestion.createdAt,
+    deletedText: suggestion.deletedText,
+    insertedText: suggestion.insertedText,
+  }));
+}
+
+interface StableWarning {
+  code: string;
+  message: string;
+}
+
+function toStableWarnings(doc: AnnotatedHtmlDoc): StableWarning[] {
+  return doc.warnings.map((warning) => ({
+    code: warning.code,
+    message: warning.message,
+  }));
+}
+
+describe("serializeAnnotatedHtml — mixed-review acceptance", () => {
+  it("round-trips mixed-review-document.html under low-churn equality", () => {
+    const html = readFixture("mixed-review-document.html");
+
+    const serialized = serializeAnnotatedHtml(parseAnnotatedHtml(html));
+
+    expect(serialized).toBe(html);
+  });
+
+  it("model from parse(serialize(model)) equals the original model", () => {
+    const html = readFixture("mixed-review-document.html");
+
+    const doc = parseAnnotatedHtml(html);
+    const serialized = serializeAnnotatedHtml(doc);
+    const reparsed = parseAnnotatedHtml(serialized);
+
+    expect(toStableComments(reparsed)).toEqual(toStableComments(doc));
+    expect(toStableSuggestions(reparsed)).toEqual(toStableSuggestions(doc));
+    expect(toStableWarnings(reparsed)).toEqual(toStableWarnings(doc));
+    expect(toStableTree(reparsed.blocks)).toEqual(toStableTree(doc.blocks));
+  });
+});

--- a/packages/rfm/src/html/__tests__/serialize-plain.test.ts
+++ b/packages/rfm/src/html/__tests__/serialize-plain.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  type AnnotatedHtmlDoc,
+  parseAnnotatedHtml,
+  serializeAnnotatedHtml,
+} from "../../index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(here, "../../../../../.context/fixtures/html");
+
+function readFixture(name: string): string {
+  return readFileSync(resolve(fixturesDir, name), "utf-8");
+}
+
+describe("serializeAnnotatedHtml — plain HTML", () => {
+  it("serializes an empty model into an empty document", () => {
+    const emptyDoc: AnnotatedHtmlDoc = {
+      format: "annotated-html",
+      version: "0.1",
+      source: "",
+      blocks: [],
+      comments: [],
+      suggestions: [],
+      warnings: [],
+    };
+
+    expect(serializeAnnotatedHtml(emptyDoc)).toBe("");
+  });
+
+  it("serializes parseAnnotatedHtml('') back to an empty string", () => {
+    expect(serializeAnnotatedHtml(parseAnnotatedHtml(""))).toBe("");
+  });
+
+  it("round-trips plain-document.html with low-churn equality", () => {
+    const html = readFixture("plain-document.html");
+
+    expect(serializeAnnotatedHtml(parseAnnotatedHtml(html))).toBe(html);
+  });
+
+  it("is idempotent: serialize(parse(serialize(parse(plain)))) === serialize(parse(plain))", () => {
+    const html = readFixture("plain-document.html");
+
+    const once = serializeAnnotatedHtml(parseAnnotatedHtml(html));
+    const twice = serializeAnnotatedHtml(parseAnnotatedHtml(once));
+
+    expect(twice).toBe(once);
+  });
+});

--- a/packages/rfm/src/html/__tests__/serialize-suggestions.test.ts
+++ b/packages/rfm/src/html/__tests__/serialize-suggestions.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { parseAnnotatedHtml, serializeAnnotatedHtml } from "../../index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(here, "../../../../../.context/fixtures/html");
+
+function readFixture(name: string): string {
+  return readFileSync(resolve(fixturesDir, name), "utf-8");
+}
+
+describe("serializeAnnotatedHtml — suggestions", () => {
+  it("round-trips standalone insertions and deletions", () => {
+    const html = readFixture("suggestions-document.html");
+
+    const serialized = serializeAnnotatedHtml(parseAnnotatedHtml(html));
+    expect(serialized).toBe(html);
+
+    const reparsed = parseAnnotatedHtml(serialized);
+
+    const insertion = reparsed.suggestions.find(
+      (suggestion) => suggestion.id === "s-1",
+    );
+    expect(insertion).toBeDefined();
+    if (!insertion) return;
+    expect(insertion.kind).toBe("insertion");
+    expect(insertion.status).toBe("open");
+    expect(insertion.author).toBe("ananth@cradlewise.com");
+    expect(insertion.createdAt).toBe("2026-05-23T11:00:00Z");
+    expect(insertion.insertedText).toBe("three new");
+
+    const deletion = reparsed.suggestions.find(
+      (suggestion) => suggestion.id === "s-2",
+    );
+    expect(deletion).toBeDefined();
+    if (!deletion) return;
+    expect(deletion.kind).toBe("deletion");
+    expect(deletion.status).toBe("open");
+    expect(deletion.author).toBe("ananth@cradlewise.com");
+    expect(deletion.createdAt).toBe("2026-05-23T11:01:10Z");
+    expect(deletion.deletedText).toBe("slightly degraded");
+  });
+
+  it("round-trips substitution pairs with shared id", () => {
+    const html = readFixture("suggestions-document.html");
+
+    const serialized = serializeAnnotatedHtml(parseAnnotatedHtml(html));
+    const reparsed = parseAnnotatedHtml(serialized);
+
+    const matching = reparsed.suggestions.filter(
+      (suggestion) => suggestion.id === "s-3",
+    );
+
+    expect(matching).toHaveLength(1);
+    const substitution = matching[0];
+    if (!substitution) return;
+    expect(substitution.kind).toBe("substitution");
+    expect(substitution.deletedText).toBe("the legacy parser");
+    expect(substitution.insertedText).toBe("the new streaming parser");
+    expect(substitution.author).toBe("ananth@cradlewise.com");
+    expect(substitution.createdAt).toBe("2026-05-23T11:02:30Z");
+    expect(substitution.status).toBe("open");
+  });
+
+  it("keeps del immediately adjacent to ins for substitutions", () => {
+    const html = readFixture("suggestions-document.html");
+
+    const serialized = serializeAnnotatedHtml(parseAnnotatedHtml(html));
+
+    expect(serialized).toContain(
+      '>the legacy parser</del><ins\n          data-rd-suggestion-id="s-3"',
+    );
+  });
+});

--- a/packages/rfm/src/html/mutate.ts
+++ b/packages/rfm/src/html/mutate.ts
@@ -1,0 +1,700 @@
+import { parseAnnotatedHtml } from "./parse.js";
+import type {
+  AnnotatedHtmlDoc,
+  HtmlCommentStatus,
+  HtmlSuggestionStatus,
+} from "./types.js";
+
+export interface AddHtmlCommentAnchor {
+  text: string;
+  occurrence?: number;
+}
+
+export interface AddHtmlCommentInput {
+  id: string;
+  anchor: AddHtmlCommentAnchor;
+  author: string;
+  createdAt: string;
+  body: string;
+  status?: HtmlCommentStatus;
+  replyTo?: string;
+  anchorIds?: string[];
+}
+
+export interface EditHtmlCommentInput {
+  id: string;
+  body?: string;
+  status?: HtmlCommentStatus;
+  updatedAt?: string;
+}
+
+export interface RemoveHtmlCommentInput {
+  id: string;
+}
+
+export interface SuggestionMutationInput {
+  id: string;
+}
+
+export function addHtmlComment(
+  doc: AnnotatedHtmlDoc,
+  input: AddHtmlCommentInput,
+): AnnotatedHtmlDoc {
+  if (!isValidId(input.id)) {
+    throw new Error(`addHtmlComment: invalid id "${input.id}"`);
+  }
+  let source = doc.source;
+  source = wrapTextWithMark(
+    source,
+    input.anchor.text,
+    input.id,
+    input.anchor.occurrence ?? 1,
+  );
+  const record = buildCommentRecord({
+    id: input.id,
+    author: input.author,
+    createdAt: input.createdAt,
+    status: input.status ?? "open",
+    body: input.body,
+    anchorIds: input.anchorIds ?? [input.id],
+    replyTo: input.replyTo,
+  });
+  source = insertCommentRecordIntoAside(source, record);
+  return parseAnnotatedHtml(source);
+}
+
+export function editHtmlComment(
+  doc: AnnotatedHtmlDoc,
+  input: EditHtmlCommentInput,
+): AnnotatedHtmlDoc {
+  let source = doc.source;
+  const range = findCommentRecord(source, input.id);
+  if (!range) {
+    throw new Error(`editHtmlComment: comment id "${input.id}" not found`);
+  }
+
+  if (input.body !== undefined) {
+    source =
+      source.slice(0, range.bodyStart) +
+      escapeText(input.body) +
+      source.slice(range.bodyEnd);
+  }
+
+  if (input.status !== undefined || input.updatedAt !== undefined) {
+    const range2 = findCommentRecord(source, input.id);
+    if (!range2) {
+      throw new Error(`editHtmlComment: lost comment "${input.id}"`);
+    }
+    let openTag = source.slice(range2.openStart, range2.openEnd);
+    if (input.status !== undefined) {
+      openTag = setAttr(openTag, "data-rd-status", input.status);
+    }
+    if (input.updatedAt !== undefined) {
+      openTag = setAttr(openTag, "data-rd-updated-at", input.updatedAt);
+    }
+    source =
+      source.slice(0, range2.openStart) +
+      openTag +
+      source.slice(range2.openEnd);
+  }
+
+  return parseAnnotatedHtml(source);
+}
+
+export function removeHtmlComment(
+  doc: AnnotatedHtmlDoc,
+  input: RemoveHtmlCommentInput,
+): AnnotatedHtmlDoc {
+  let source = doc.source;
+  source = removeIdFromAnchors(source, input.id);
+  source = removeCommentRecord(source, input.id);
+  return parseAnnotatedHtml(source);
+}
+
+export function acceptHtmlSuggestion(
+  doc: AnnotatedHtmlDoc,
+  input: SuggestionMutationInput,
+): AnnotatedHtmlDoc {
+  const found = findSuggestion(doc.source, input.id);
+  if (!found) {
+    throw new Error(`acceptHtmlSuggestion: suggestion "${input.id}" not found`);
+  }
+  let replacement: string;
+  if (found.kind === "substitution") {
+    replacement = found.insText ?? "";
+  } else if (found.kind === "insertion") {
+    replacement = found.insText ?? "";
+  } else {
+    replacement = "";
+  }
+  const next =
+    doc.source.slice(0, found.start) +
+    replacement +
+    doc.source.slice(found.end);
+  return parseAnnotatedHtml(next);
+}
+
+export function rejectHtmlSuggestion(
+  doc: AnnotatedHtmlDoc,
+  input: SuggestionMutationInput,
+): AnnotatedHtmlDoc {
+  const found = findSuggestion(doc.source, input.id);
+  if (!found) {
+    throw new Error(`rejectHtmlSuggestion: suggestion "${input.id}" not found`);
+  }
+  let replacement: string;
+  if (found.kind === "substitution") {
+    replacement = found.delText ?? "";
+  } else if (found.kind === "deletion") {
+    replacement = found.delText ?? "";
+  } else {
+    replacement = "";
+  }
+  const next =
+    doc.source.slice(0, found.start) +
+    replacement +
+    doc.source.slice(found.end);
+  return parseAnnotatedHtml(next);
+}
+
+function buildCommentRecord(input: {
+  id: string;
+  author: string;
+  createdAt: string;
+  status: HtmlCommentStatus;
+  body: string;
+  anchorIds: string[];
+  replyTo: string | undefined;
+}): string {
+  const replyAttr = input.replyTo
+    ? ` data-rd-reply-to="${escapeAttr(input.replyTo)}"`
+    : "";
+  return [
+    "<rd-comment",
+    ` id="${escapeAttr(input.id)}"`,
+    ` data-rd-author="${escapeAttr(input.author)}"`,
+    ` data-rd-created-at="${escapeAttr(input.createdAt)}"`,
+    ` data-rd-anchor-ids="${escapeAttr(input.anchorIds.join(" "))}"`,
+    ` data-rd-status="${escapeAttr(input.status)}"`,
+    replyAttr,
+    `>${escapeText(input.body)}</rd-comment>`,
+  ].join("");
+}
+
+function wrapTextWithMark(
+  source: string,
+  target: string,
+  id: string,
+  occurrence: number,
+): string {
+  if (target.length === 0) {
+    throw new Error("addHtmlComment: anchor text must not be empty");
+  }
+  const positions = findPlainTextOccurrences(source, target);
+  if (positions.length < occurrence) {
+    throw new Error(
+      `addHtmlComment: anchor text "${target}" not found at occurrence ${occurrence}`,
+    );
+  }
+  const pos = positions[occurrence - 1] ?? -1;
+
+  const merged = tryMergeIntoExistingMark(source, pos, target, id);
+  if (merged !== null) return merged;
+
+  return (
+    source.slice(0, pos) +
+    `<mark data-rd-comment-ids="${escapeAttr(id)}">${target}</mark>` +
+    source.slice(pos + target.length)
+  );
+}
+
+function tryMergeIntoExistingMark(
+  source: string,
+  pos: number,
+  target: string,
+  id: string,
+): string | null {
+  if (pos <= 0) return null;
+  if (source[pos - 1] !== ">") return null;
+  let start = pos - 1;
+  while (start > 0 && source[start] !== "<") {
+    start -= 1;
+  }
+  if (source[start] !== "<") return null;
+  const openTag = source.slice(start, pos);
+  if (!/^<mark\b/i.test(openTag)) return null;
+  if (
+    source.slice(pos + target.length, pos + target.length + 7) !== "</mark>"
+  ) {
+    return null;
+  }
+  const idsMatch = /\bdata-rd-comment-ids\s*=\s*"([^"]*)"/.exec(openTag);
+  if (!idsMatch) return null;
+  const existing = (idsMatch[1] ?? "").split(/\s+/).filter(Boolean);
+  if (existing.includes(id)) return source;
+  const newIds = [...existing, id].join(" ");
+  const newOpenTag = openTag.replace(
+    /\bdata-rd-comment-ids\s*=\s*"[^"]*"/,
+    `data-rd-comment-ids="${escapeAttr(newIds)}"`,
+  );
+  return source.slice(0, start) + newOpenTag + source.slice(pos);
+}
+
+function findPlainTextOccurrences(source: string, target: string): number[] {
+  const positions: number[] = [];
+  const ranges = computeProtectedRanges(source);
+  let cursor = 0;
+  while (cursor <= source.length - target.length) {
+    const index = source.indexOf(target, cursor);
+    if (index === -1) break;
+    if (
+      isPlainTextOffset(source, index) &&
+      !isInProtectedRange(index, ranges)
+    ) {
+      positions.push(index);
+    }
+    cursor = index + 1;
+  }
+  return positions;
+}
+
+const PROTECTED_TAGS = new Set(["script", "style", "pre", "code"]);
+
+const VOID_TAGS = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+]);
+
+// Returns true when `offset` is not inside an open tag (e.g. inside attribute
+// markup). It does NOT check protected-zone subtrees; callers must also use
+// `computeProtectedRanges`/`isInProtectedRange` for that purpose.
+function isPlainTextOffset(source: string, offset: number): boolean {
+  let cursor = 0;
+  let inTag = false;
+  let quote: string | null = null;
+
+  while (cursor < offset) {
+    const ch = source[cursor];
+    if (inTag) {
+      if (quote) {
+        if (ch === quote) quote = null;
+        cursor += 1;
+        continue;
+      }
+      if (ch === '"' || ch === "'") {
+        quote = ch;
+        cursor += 1;
+        continue;
+      }
+      if (ch === ">") {
+        inTag = false;
+        cursor += 1;
+        continue;
+      }
+      cursor += 1;
+      continue;
+    }
+
+    if (ch === "<") {
+      inTag = true;
+      cursor += 1;
+      continue;
+    }
+
+    cursor += 1;
+  }
+
+  return !inTag;
+}
+
+interface ParsedTag {
+  tag: string;
+  isClose: boolean;
+  selfClosing: boolean;
+  hasRdLiteral: boolean;
+  tagEnd: number;
+}
+
+function peekTag(source: string, start: number): ParsedTag | null {
+  if (source[start] !== "<") return null;
+  let i = start + 1;
+  let isClose = false;
+  if (source[i] === "/") {
+    isClose = true;
+    i += 1;
+  }
+  const nameStart = i;
+  while (i < source.length && /[A-Za-z0-9-]/.test(source[i] ?? "")) {
+    i += 1;
+  }
+  if (i === nameStart) return null;
+  const tag = source.slice(nameStart, i).toLowerCase();
+
+  let quote: string | null = null;
+  while (i < source.length) {
+    const ch = source[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      i += 1;
+      continue;
+    }
+    if (ch === ">") break;
+    i += 1;
+  }
+  if (i >= source.length) return null;
+
+  const tagEnd = i;
+  const selfClosing = source[tagEnd - 1] === "/";
+  const attrSection = source.slice(nameStart + tag.length, tagEnd);
+  const hasRdLiteral = !isClose && attrHasName(attrSection, "data-rd-literal");
+  return { tag, isClose, selfClosing, hasRdLiteral, tagEnd };
+}
+
+function attrHasName(section: string, name: string): boolean {
+  let i = 0;
+  while (i < section.length) {
+    while (i < section.length && /\s/.test(section[i] ?? "")) i += 1;
+    if (i >= section.length) break;
+    const ch = section[i];
+    if (ch === "/" || ch === ">") {
+      i += 1;
+      continue;
+    }
+    const nameStart = i;
+    while (i < section.length && !/[\s=/>]/.test(section[i] ?? "")) i += 1;
+    const attrName = section.slice(nameStart, i).toLowerCase();
+    while (i < section.length && /\s/.test(section[i] ?? "")) i += 1;
+    if (section[i] === "=") {
+      i += 1;
+      while (i < section.length && /\s/.test(section[i] ?? "")) i += 1;
+      const q = section[i];
+      if (q === '"' || q === "'") {
+        i += 1;
+        while (i < section.length && section[i] !== q) i += 1;
+        if (i < section.length) i += 1;
+      } else {
+        while (i < section.length && !/[\s>]/.test(section[i] ?? "")) i += 1;
+      }
+    }
+    if (attrName === name) return true;
+  }
+  return false;
+}
+
+type ProtectedRange = readonly [number, number];
+
+function computeProtectedRanges(source: string): ProtectedRange[] {
+  const ranges: Array<[number, number]> = [];
+  const stack: Array<{ tag: string; start: number; protected: boolean }> = [];
+  let cursor = 0;
+  while (cursor < source.length) {
+    if (source[cursor] !== "<") {
+      cursor += 1;
+      continue;
+    }
+    const tagInfo = peekTag(source, cursor);
+    if (!tagInfo) {
+      cursor += 1;
+      continue;
+    }
+    const tagEnd = tagInfo.tagEnd;
+    if (tagInfo.isClose) {
+      for (let i = stack.length - 1; i >= 0; i -= 1) {
+        const entry = stack[i];
+        if (entry && entry.tag === tagInfo.tag) {
+          if (entry.protected) {
+            ranges.push([entry.start, tagEnd + 1]);
+          }
+          stack.splice(i, 1);
+          break;
+        }
+      }
+    } else if (!tagInfo.selfClosing && !VOID_TAGS.has(tagInfo.tag)) {
+      const isProtected =
+        PROTECTED_TAGS.has(tagInfo.tag) || tagInfo.hasRdLiteral;
+      stack.push({ tag: tagInfo.tag, start: cursor, protected: isProtected });
+    }
+    cursor = tagEnd + 1;
+  }
+  // Any unclosed protected tags: protect from their start to end-of-source.
+  for (const entry of stack) {
+    if (entry.protected) {
+      ranges.push([entry.start, source.length]);
+    }
+  }
+  return ranges;
+}
+
+function isInProtectedRange(
+  offset: number,
+  ranges: readonly ProtectedRange[],
+): boolean {
+  for (const [start, end] of ranges) {
+    if (offset >= start && offset < end) return true;
+  }
+  return false;
+}
+
+function insertCommentRecordIntoAside(source: string, record: string): string {
+  const asideOpen = /<aside\b([^>]*)>/gi;
+  while (true) {
+    const match = asideOpen.exec(source);
+    if (match === null) break;
+    const attrs = match[1] ?? "";
+    if (!/\bclass\s*=\s*"[^"]*\brd-review\b[^"]*"/.test(attrs)) continue;
+    const openEnd = match.index + match[0].length;
+    const closeIdx = source.indexOf("</aside>", openEnd);
+    if (closeIdx === -1) break;
+
+    let lineStart = closeIdx;
+    while (lineStart > openEnd && source[lineStart - 1] !== "\n") {
+      lineStart -= 1;
+    }
+    const closeIndent = source.slice(lineStart, closeIdx);
+    const recordIndent = `${closeIndent}  `;
+    const inserted = `${recordIndent}${record}\n`;
+    return source.slice(0, lineStart) + inserted + source.slice(lineStart);
+  }
+
+  return createAsideWithRecord(source, record);
+}
+
+function createAsideWithRecord(source: string, record: string): string {
+  const bodyClose = source.lastIndexOf("</body>");
+  if (bodyClose === -1) {
+    return `${source}\n<aside class="rd-review" hidden>\n  ${record}\n</aside>\n`;
+  }
+  let lineStart = bodyClose;
+  while (lineStart > 0 && source[lineStart - 1] !== "\n") {
+    lineStart -= 1;
+  }
+  const indent = source.slice(lineStart, bodyClose);
+  const asideBlock =
+    `${indent}<aside class="rd-review" hidden>\n` +
+    `${indent}  ${record}\n` +
+    `${indent}</aside>\n`;
+  return source.slice(0, lineStart) + asideBlock + source.slice(lineStart);
+}
+
+interface CommentRange {
+  openStart: number;
+  openEnd: number;
+  bodyStart: number;
+  bodyEnd: number;
+  closeStart: number;
+  closeEnd: number;
+}
+
+function findCommentRecord(source: string, id: string): CommentRange | null {
+  const ranges = computeProtectedRanges(source);
+  const re = /<rd-comment\b([^>]*)>/gi;
+  while (true) {
+    const match = re.exec(source);
+    if (match === null) break;
+    if (isInProtectedRange(match.index, ranges)) continue;
+    const attrs = match[1] ?? "";
+    const idMatch = /\bid\s*=\s*"([^"]*)"/.exec(attrs);
+    if (!idMatch || idMatch[1] !== id) continue;
+    const openStart = match.index;
+    const openEnd = match.index + match[0].length;
+    const closeStart = source.indexOf("</rd-comment>", openEnd);
+    if (closeStart === -1) return null;
+    return {
+      openStart,
+      openEnd,
+      bodyStart: openEnd,
+      bodyEnd: closeStart,
+      closeStart,
+      closeEnd: closeStart + "</rd-comment>".length,
+    };
+  }
+  return null;
+}
+
+function removeCommentRecord(source: string, id: string): string {
+  const range = findCommentRecord(source, id);
+  if (!range) return source;
+  let start = range.openStart;
+  while (
+    start > 0 &&
+    (source[start - 1] === " " || source[start - 1] === "\t")
+  ) {
+    start -= 1;
+  }
+  if (start > 0 && source[start - 1] === "\n") start -= 1;
+  return source.slice(0, start) + source.slice(range.closeEnd);
+}
+
+function removeIdFromAnchors(source: string, id: string): string {
+  const ranges = computeProtectedRanges(source);
+  const markRe = /<mark\b([^>]*)>([\s\S]*?)<\/mark>/gi;
+  const replacements: Array<{
+    start: number;
+    end: number;
+    replacement: string;
+  }> = [];
+  while (true) {
+    const match = markRe.exec(source);
+    if (match === null) break;
+    if (isInProtectedRange(match.index, ranges)) continue;
+    const attrs = match[1] ?? "";
+    const inner = match[2] ?? "";
+    const idsMatch = /\bdata-rd-comment-ids\s*=\s*"([^"]*)"/.exec(attrs);
+    if (!idsMatch) continue;
+    const ids = (idsMatch[1] ?? "").split(/\s+/).filter(Boolean);
+    if (!ids.includes(id)) continue;
+    const remaining = ids.filter((value) => value !== id);
+    const replacement =
+      remaining.length === 0
+        ? inner
+        : `<mark${attrs.replace(
+            /\bdata-rd-comment-ids\s*=\s*"[^"]*"/,
+            `data-rd-comment-ids="${escapeAttr(remaining.join(" "))}"`,
+          )}>${inner}</mark>`;
+    replacements.push({
+      start: match.index,
+      end: match.index + match[0].length,
+      replacement,
+    });
+  }
+  if (replacements.length === 0) return source;
+  let result = "";
+  let cursor = 0;
+  for (const r of replacements) {
+    result += source.slice(cursor, r.start) + r.replacement;
+    cursor = r.end;
+  }
+  result += source.slice(cursor);
+  return result;
+}
+
+interface SuggestionMatch {
+  kind: "substitution" | "insertion" | "deletion";
+  start: number;
+  end: number;
+  delText?: string;
+  insText?: string;
+}
+
+function findSuggestion(source: string, id: string): SuggestionMatch | null {
+  const ranges = computeProtectedRanges(source);
+  const escaped = escapeReg(id);
+  const substRe = new RegExp(
+    `<del\\b([^>]*?\\bdata-rd-suggestion-id\\s*=\\s*"${escaped}"[^>]*)>([\\s\\S]*?)</del>(\\s*)<ins\\b([^>]*?\\bdata-rd-suggestion-id\\s*=\\s*"${escaped}"[^>]*)>([\\s\\S]*?)</ins>`,
+    "gi",
+  );
+  const sm = findFirstNonProtected(source, substRe, ranges);
+  if (sm) {
+    const end = sm.index + sm[0].length;
+    if (!isInProtectedRange(end - 1, ranges)) {
+      return {
+        kind: "substitution",
+        start: sm.index,
+        end,
+        delText: sm[2] ?? "",
+        insText: sm[5] ?? "",
+      };
+    }
+  }
+
+  const insRe = new RegExp(
+    `<ins\\b([^>]*?\\bdata-rd-suggestion-id\\s*=\\s*"${escaped}"[^>]*)>([\\s\\S]*?)</ins>`,
+    "gi",
+  );
+  const im = findFirstNonProtected(source, insRe, ranges);
+  if (im) {
+    return {
+      kind: "insertion",
+      start: im.index,
+      end: im.index + im[0].length,
+      insText: im[2] ?? "",
+    };
+  }
+
+  const delRe = new RegExp(
+    `<del\\b([^>]*?\\bdata-rd-suggestion-id\\s*=\\s*"${escaped}"[^>]*)>([\\s\\S]*?)</del>`,
+    "gi",
+  );
+  const dm = findFirstNonProtected(source, delRe, ranges);
+  if (dm) {
+    return {
+      kind: "deletion",
+      start: dm.index,
+      end: dm.index + dm[0].length,
+      delText: dm[2] ?? "",
+    };
+  }
+
+  return null;
+}
+
+function findFirstNonProtected(
+  source: string,
+  re: RegExp,
+  ranges: readonly ProtectedRange[],
+): RegExpExecArray | null {
+  re.lastIndex = 0;
+  while (true) {
+    const m = re.exec(source);
+    if (!m) return null;
+    if (!isInProtectedRange(m.index, ranges)) {
+      return m;
+    }
+    re.lastIndex = m.index + 1;
+  }
+}
+
+function setAttr(openTag: string, name: string, value: string): string {
+  const re = new RegExp(`\\b${escapeReg(name)}\\s*=\\s*"[^"]*"`);
+  const replacement = `${name}="${escapeAttr(value)}"`;
+  if (re.test(openTag)) {
+    return openTag.replace(re, replacement);
+  }
+  const insertAt = openTag.lastIndexOf(">");
+  if (insertAt === -1) return openTag;
+  const before = openTag.slice(0, insertAt);
+  const after = openTag.slice(insertAt);
+  const padded = before.endsWith(" ") ? before : `${before} `;
+  return `${padded}${replacement}${after}`;
+}
+
+function escapeAttr(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;");
+}
+
+function escapeText(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function escapeReg(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isValidId(value: string): boolean {
+  return /^[A-Za-z0-9_-]+$/.test(value);
+}
+
+export type { HtmlCommentStatus, HtmlSuggestionStatus };

--- a/packages/rfm/src/html/parse.ts
+++ b/packages/rfm/src/html/parse.ts
@@ -1,0 +1,566 @@
+import type {
+  AnnotatedHtmlDoc,
+  HtmlAnnotationComment,
+  HtmlAnnotationSuggestion,
+  HtmlAnnotationWarning,
+  HtmlCommentStatus,
+  HtmlElementNode,
+  HtmlNode,
+  HtmlSuggestionStatus,
+} from "./types.js";
+
+const VOID_ELEMENTS = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+]);
+
+const RAW_TEXT_ELEMENTS = new Set(["script", "style"]);
+
+const PROTECTED_ZONE_TAGS = new Set(["script", "style", "pre", "code"]);
+
+function isProtectedZone(node: HtmlElementNode): boolean {
+  if (PROTECTED_ZONE_TAGS.has(node.tag)) return true;
+  return Object.hasOwn(node.attrs, "data-rd-literal");
+}
+
+const ROOT_TAG = "#root";
+
+type Token =
+  | { kind: "doctype" }
+  | { kind: "comment" }
+  | { kind: "text"; value: string }
+  | {
+      kind: "open";
+      tag: string;
+      attrs: Record<string, string>;
+      selfClosing: boolean;
+    }
+  | { kind: "close"; tag: string };
+
+export function parseAnnotatedHtml(input: string): AnnotatedHtmlDoc {
+  const doc: AnnotatedHtmlDoc = {
+    format: "annotated-html",
+    version: "0.1",
+    source: input,
+    blocks: [],
+    comments: [],
+    suggestions: [],
+    warnings: [],
+  };
+
+  if (input.length === 0 || input.trim().length === 0) {
+    return doc;
+  }
+
+  const roots = parseToNodes(input);
+  doc.blocks = extractBlocks(roots);
+  assignPositions(doc.blocks);
+
+  const { comments, anchorIds, anchorIdOrder } = collectAnnotations(doc.blocks);
+  doc.comments = comments;
+  doc.suggestions = collectSuggestions(doc.blocks);
+  doc.warnings = computeAnnotationWarnings(comments, anchorIds, anchorIdOrder);
+  return doc;
+}
+
+function assignPositions(blocks: HtmlNode[]): void {
+  let next = 0;
+  const walk = (nodes: HtmlNode[]): void => {
+    for (const node of nodes) {
+      node.position = next;
+      next += 1;
+      if (node.type === "element") walk(node.children);
+    }
+  };
+  walk(blocks);
+}
+
+function collectSuggestions(blocks: HtmlNode[]): HtmlAnnotationSuggestion[] {
+  const suggestions: HtmlAnnotationSuggestion[] = [];
+
+  const walk = (nodes: HtmlNode[]): void => {
+    let index = 0;
+    while (index < nodes.length) {
+      const node = nodes[index];
+      if (!node || node.type !== "element") {
+        index += 1;
+        continue;
+      }
+
+      if (isProtectedZone(node)) {
+        index += 1;
+        continue;
+      }
+
+      const isSuggestionElement =
+        (node.tag === "ins" || node.tag === "del") &&
+        Object.hasOwn(node.attrs, "data-rd-suggestion-id");
+
+      if (!isSuggestionElement) {
+        walk(node.children);
+        index += 1;
+        continue;
+      }
+
+      if (node.tag === "del") {
+        const partnerIndex = findAdjacentInsIndex(nodes, index);
+        if (partnerIndex !== -1) {
+          const partner = nodes[partnerIndex] as HtmlElementNode;
+          const delId = node.attrs["data-rd-suggestion-id"] ?? "";
+          const insId = partner.attrs["data-rd-suggestion-id"] ?? "";
+          if (delId.length > 0 && delId === insId) {
+            suggestions.push({
+              id: delId,
+              kind: "substitution",
+              author:
+                node.attrs["data-rd-author"] ??
+                partner.attrs["data-rd-author"] ??
+                null,
+              createdAt:
+                node.attrs["data-rd-created-at"] ??
+                partner.attrs["data-rd-created-at"] ??
+                null,
+              status: normalizeSuggestionStatus(
+                node.attrs["data-rd-status"] ?? partner.attrs["data-rd-status"],
+              ),
+              deletedText: nodeTextContent(node),
+              insertedText: nodeTextContent(partner),
+              position: node.position,
+            });
+            walk(node.children);
+            walk(partner.children);
+            index = partnerIndex + 1;
+            continue;
+          }
+        }
+      }
+
+      const id = node.attrs["data-rd-suggestion-id"] ?? "";
+      if (id.length > 0) {
+        const kind = node.tag === "ins" ? "insertion" : "deletion";
+        const suggestion: HtmlAnnotationSuggestion = {
+          id,
+          kind,
+          author: node.attrs["data-rd-author"] ?? null,
+          createdAt: node.attrs["data-rd-created-at"] ?? null,
+          status: normalizeSuggestionStatus(node.attrs["data-rd-status"]),
+          position: node.position,
+        };
+        if (kind === "insertion") {
+          suggestion.insertedText = nodeTextContent(node);
+        } else {
+          suggestion.deletedText = nodeTextContent(node);
+        }
+        suggestions.push(suggestion);
+      }
+
+      walk(node.children);
+      index += 1;
+    }
+  };
+
+  walk(blocks);
+  return suggestions;
+}
+
+function findAdjacentInsIndex(nodes: HtmlNode[], delIndex: number): number {
+  for (let cursor = delIndex + 1; cursor < nodes.length; cursor += 1) {
+    const sibling = nodes[cursor];
+    if (!sibling) return -1;
+    if (sibling.type === "text") {
+      if (sibling.value.trim().length === 0) continue;
+      return -1;
+    }
+    if (sibling.type === "element" && sibling.tag === "ins") {
+      return Object.hasOwn(sibling.attrs, "data-rd-suggestion-id")
+        ? cursor
+        : -1;
+    }
+    return -1;
+  }
+  return -1;
+}
+
+function normalizeSuggestionStatus(
+  value: string | undefined,
+): HtmlSuggestionStatus {
+  if (value === "open" || value === "accepted" || value === "rejected") {
+    return value;
+  }
+  return "open";
+}
+
+function collectAnnotations(blocks: HtmlNode[]): {
+  comments: HtmlAnnotationComment[];
+  anchorIds: Set<string>;
+  anchorIdOrder: string[];
+} {
+  const comments: HtmlAnnotationComment[] = [];
+  const anchorIds = new Set<string>();
+  const anchorIdOrder: string[] = [];
+
+  const walk = (nodes: HtmlNode[]): void => {
+    for (const node of nodes) {
+      if (node.type !== "element") continue;
+      if (isProtectedZone(node)) continue;
+
+      if (
+        node.tag === "mark" &&
+        Object.hasOwn(node.attrs, "data-rd-comment-ids")
+      ) {
+        const ids = splitIds(node.attrs["data-rd-comment-ids"] ?? "");
+        for (const id of ids) {
+          if (!anchorIds.has(id)) {
+            anchorIds.add(id);
+            anchorIdOrder.push(id);
+          }
+        }
+      }
+
+      if (node.tag === "rd-comment") {
+        comments.push(toAnnotationComment(node));
+        continue;
+      }
+
+      walk(node.children);
+    }
+  };
+
+  walk(blocks);
+  return { comments, anchorIds, anchorIdOrder };
+}
+
+function toAnnotationComment(node: HtmlElementNode): HtmlAnnotationComment {
+  const id = node.attrs.id ?? "";
+  const rawAnchorIds = node.attrs["data-rd-anchor-ids"];
+  const anchorIds = rawAnchorIds === undefined ? [] : splitIds(rawAnchorIds);
+
+  return {
+    id,
+    anchorIds,
+    author: node.attrs["data-rd-author"] ?? null,
+    createdAt: node.attrs["data-rd-created-at"] ?? null,
+    updatedAt: node.attrs["data-rd-updated-at"] ?? null,
+    status: normalizeStatus(node.attrs["data-rd-status"]),
+    replyTo: node.attrs["data-rd-reply-to"] ?? null,
+    body: nodeTextContent(node),
+    position: node.position,
+  };
+}
+
+function normalizeStatus(value: string | undefined): HtmlCommentStatus | null {
+  if (value === "open" || value === "resolved") return value;
+  return null;
+}
+
+function splitIds(value: string): string[] {
+  return value.split(/\s+/).filter((id) => id.length > 0);
+}
+
+function nodeTextContent(node: HtmlNode): string {
+  if (node.type === "text") return node.value;
+  return node.children.map(nodeTextContent).join("");
+}
+
+function computeAnnotationWarnings(
+  comments: HtmlAnnotationComment[],
+  anchorIds: Set<string>,
+  anchorIdOrder: string[],
+): HtmlAnnotationWarning[] {
+  const warnings: HtmlAnnotationWarning[] = [];
+  const recordIds = new Set(comments.map((comment) => comment.id));
+
+  for (const anchorId of anchorIdOrder) {
+    if (!recordIds.has(anchorId)) {
+      warnings.push({
+        code: "orphan-anchor",
+        message: `Anchor references comment id "${anchorId}" but no matching <rd-comment> record was found.`,
+      });
+    }
+  }
+
+  for (const comment of comments) {
+    if (comment.replyTo) continue;
+    if (anchorIds.has(comment.id)) continue;
+    warnings.push({
+      code: "orphan-record",
+      message: `Comment record "${comment.id}" has no matching anchor.`,
+    });
+  }
+
+  return warnings;
+}
+
+function extractBlocks(nodes: HtmlNode[]): HtmlNode[] {
+  const body = findFirstElement(nodes, "body");
+  const source = body ? body.children : nodes;
+  return source.filter((node) => node.type === "element");
+}
+
+function findFirstElement(
+  nodes: HtmlNode[],
+  tag: string,
+): HtmlElementNode | null {
+  for (const node of nodes) {
+    if (node.type !== "element") continue;
+    if (node.tag === tag) return node;
+    const nested = findFirstElement(node.children, tag);
+    if (nested) return nested;
+  }
+  return null;
+}
+
+function parseToNodes(input: string): HtmlNode[] {
+  const tokens = tokenize(input);
+  const root: HtmlElementNode = {
+    type: "element",
+    tag: ROOT_TAG,
+    attrs: {},
+    children: [],
+    position: 0,
+  };
+  const stack: HtmlElementNode[] = [root];
+
+  const current = (): HtmlElementNode => {
+    const top = stack[stack.length - 1];
+    if (!top) throw new Error("HTML parser stack underflow");
+    return top;
+  };
+
+  for (const token of tokens) {
+    if (token.kind === "doctype" || token.kind === "comment") {
+      continue;
+    }
+    if (token.kind === "text") {
+      current().children.push({
+        type: "text",
+        value: token.value,
+        position: 0,
+      });
+      continue;
+    }
+    if (token.kind === "open") {
+      const element: HtmlElementNode = {
+        type: "element",
+        tag: token.tag,
+        attrs: token.attrs,
+        children: [],
+        position: 0,
+      };
+      current().children.push(element);
+      if (!token.selfClosing && !VOID_ELEMENTS.has(token.tag)) {
+        stack.push(element);
+      }
+      continue;
+    }
+    if (token.kind === "close") {
+      for (let i = stack.length - 1; i >= 1; i -= 1) {
+        if (stack[i]?.tag === token.tag) {
+          stack.length = i;
+          break;
+        }
+      }
+    }
+  }
+
+  return root.children;
+}
+
+function tokenize(input: string): Token[] {
+  const tokens: Token[] = [];
+  let cursor = 0;
+
+  while (cursor < input.length) {
+    if (input[cursor] !== "<") {
+      const nextTag = input.indexOf("<", cursor);
+      const end = nextTag === -1 ? input.length : nextTag;
+      tokens.push({ kind: "text", value: input.slice(cursor, end) });
+      cursor = end;
+      continue;
+    }
+
+    if (input.startsWith("<!--", cursor)) {
+      const end = input.indexOf("-->", cursor + 4);
+      if (end === -1) {
+        tokens.push({ kind: "text", value: input.slice(cursor) });
+        cursor = input.length;
+        continue;
+      }
+      tokens.push({ kind: "comment" });
+      cursor = end + 3;
+      continue;
+    }
+
+    if (input.startsWith("<!", cursor)) {
+      const end = input.indexOf(">", cursor + 2);
+      if (end === -1) {
+        tokens.push({ kind: "text", value: input.slice(cursor) });
+        cursor = input.length;
+        continue;
+      }
+      tokens.push({ kind: "doctype" });
+      cursor = end + 1;
+      continue;
+    }
+
+    if (input[cursor + 1] === "/") {
+      const end = input.indexOf(">", cursor + 2);
+      if (end === -1) {
+        tokens.push({ kind: "text", value: input.slice(cursor) });
+        cursor = input.length;
+        continue;
+      }
+      const tag = input
+        .slice(cursor + 2, end)
+        .trim()
+        .toLowerCase();
+      tokens.push({ kind: "close", tag });
+      cursor = end + 1;
+      continue;
+    }
+
+    const tagResult = readOpenTag(input, cursor);
+    if (!tagResult) {
+      tokens.push({ kind: "text", value: "<" });
+      cursor += 1;
+      continue;
+    }
+
+    tokens.push(tagResult.token);
+    cursor = tagResult.next;
+
+    if (
+      tagResult.token.kind === "open" &&
+      RAW_TEXT_ELEMENTS.has(tagResult.token.tag) &&
+      !tagResult.token.selfClosing
+    ) {
+      const tag = tagResult.token.tag;
+      const closingPattern = new RegExp(`</${tag}\\b[^>]*>`, "i");
+      const closingMatch = closingPattern.exec(input.slice(cursor));
+      if (closingMatch) {
+        const raw = input.slice(cursor, cursor + closingMatch.index);
+        if (raw.length > 0) {
+          tokens.push({ kind: "text", value: raw });
+        }
+        tokens.push({ kind: "close", tag });
+        cursor = cursor + closingMatch.index + closingMatch[0].length;
+      } else {
+        const raw = input.slice(cursor);
+        if (raw.length > 0) {
+          tokens.push({ kind: "text", value: raw });
+        }
+        cursor = input.length;
+      }
+    }
+  }
+
+  return tokens;
+}
+
+function readOpenTag(
+  input: string,
+  start: number,
+): { token: Token; next: number } | null {
+  let cursor = start + 1;
+  const nameStart = cursor;
+  while (
+    cursor < input.length &&
+    isTagNameChar(input.charCodeAt(cursor), cursor === nameStart)
+  ) {
+    cursor += 1;
+  }
+  if (cursor === nameStart) return null;
+  const tag = input.slice(nameStart, cursor).toLowerCase();
+  const attrs: Record<string, string> = {};
+
+  while (cursor < input.length) {
+    while (cursor < input.length && isWhitespace(input.charCodeAt(cursor))) {
+      cursor += 1;
+    }
+    if (input[cursor] === "/" && input[cursor + 1] === ">") {
+      return {
+        token: { kind: "open", tag, attrs, selfClosing: true },
+        next: cursor + 2,
+      };
+    }
+    if (input[cursor] === ">") {
+      return {
+        token: { kind: "open", tag, attrs, selfClosing: false },
+        next: cursor + 1,
+      };
+    }
+    const attrNameStart = cursor;
+    while (cursor < input.length && isAttrNameChar(input.charCodeAt(cursor))) {
+      cursor += 1;
+    }
+    if (cursor === attrNameStart) {
+      return null;
+    }
+    const attrName = input.slice(attrNameStart, cursor).toLowerCase();
+    let value = "";
+    if (input[cursor] === "=") {
+      cursor += 1;
+      const quote = input[cursor];
+      if (quote === '"' || quote === "'") {
+        cursor += 1;
+        const valueEnd = input.indexOf(quote, cursor);
+        if (valueEnd === -1) return null;
+        value = input.slice(cursor, valueEnd);
+        cursor = valueEnd + 1;
+      } else {
+        const valueStart = cursor;
+        while (
+          cursor < input.length &&
+          !isWhitespace(input.charCodeAt(cursor)) &&
+          input[cursor] !== ">" &&
+          input[cursor] !== "/"
+        ) {
+          cursor += 1;
+        }
+        value = input.slice(valueStart, cursor);
+      }
+    }
+    attrs[attrName] = value;
+  }
+
+  return null;
+}
+
+function isWhitespace(code: number): boolean {
+  return code === 0x20 || code === 0x09 || code === 0x0a || code === 0x0d;
+}
+
+function isTagNameChar(code: number, first: boolean): boolean {
+  if (first) {
+    return (code >= 0x41 && code <= 0x5a) || (code >= 0x61 && code <= 0x7a);
+  }
+  return (
+    (code >= 0x41 && code <= 0x5a) ||
+    (code >= 0x61 && code <= 0x7a) ||
+    (code >= 0x30 && code <= 0x39) ||
+    code === 0x2d
+  );
+}
+
+function isAttrNameChar(code: number): boolean {
+  return (
+    (code >= 0x41 && code <= 0x5a) ||
+    (code >= 0x61 && code <= 0x7a) ||
+    (code >= 0x30 && code <= 0x39) ||
+    code === 0x2d ||
+    code === 0x5f ||
+    code === 0x3a
+  );
+}

--- a/packages/rfm/src/html/sanitize.ts
+++ b/packages/rfm/src/html/sanitize.ts
@@ -1,0 +1,520 @@
+export interface HtmlSanitizerWarning {
+  code: string;
+  message: string;
+}
+
+export interface SanitizeAnnotatedHtmlResult {
+  html: string;
+  warnings: HtmlSanitizerWarning[];
+}
+
+const DISALLOWED_ELEMENTS = new Set([
+  "script",
+  "iframe",
+  "object",
+  "embed",
+  "form",
+  "input",
+  "button",
+  "select",
+  "textarea",
+]);
+
+const ALLOWED_ELEMENTS = new Set([
+  "html",
+  "head",
+  "body",
+  "meta",
+  "title",
+  "link",
+  "style",
+  "article",
+  "section",
+  "header",
+  "footer",
+  "nav",
+  "main",
+  "aside",
+  "div",
+  "p",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "ul",
+  "ol",
+  "li",
+  "dl",
+  "dt",
+  "dd",
+  "blockquote",
+  "figure",
+  "figcaption",
+  "hr",
+  "table",
+  "thead",
+  "tbody",
+  "tfoot",
+  "tr",
+  "th",
+  "td",
+  "pre",
+  "a",
+  "span",
+  "strong",
+  "em",
+  "b",
+  "i",
+  "u",
+  "s",
+  "code",
+  "kbd",
+  "samp",
+  "var",
+  "sub",
+  "sup",
+  "br",
+  "img",
+  "mark",
+  "ins",
+  "del",
+  "rd-comment",
+]);
+
+const GLOBAL_ALLOWED_ATTRS = new Set([
+  "id",
+  "class",
+  "lang",
+  "title",
+  "dir",
+  "hidden",
+]);
+
+const ELEMENT_ALLOWED_ATTRS: Record<string, Set<string>> = {
+  a: new Set(["href"]),
+  img: new Set(["src", "alt"]),
+  link: new Set(["rel", "href"]),
+  meta: new Set(["charset", "name", "content"]),
+};
+
+const VOID_ELEMENTS = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+]);
+
+const PROTECTED_ELEMENTS = new Set(["pre", "code", "script", "style"]);
+
+interface ParsedAttr {
+  name: string;
+  hasValue: boolean;
+  value: string;
+  quote: '"' | "'" | "";
+}
+
+interface OpenTag {
+  kind: "open";
+  tagName: string;
+  attrs: ParsedAttr[];
+  selfClosing: boolean;
+  endOffset: number;
+}
+
+interface CloseTag {
+  kind: "close";
+  tagName: string;
+  endOffset: number;
+}
+
+interface CommentTag {
+  kind: "comment";
+  endOffset: number;
+}
+
+interface DoctypeTag {
+  kind: "doctype";
+  endOffset: number;
+}
+
+type ParsedTag = OpenTag | CloseTag | CommentTag | DoctypeTag;
+
+export function sanitizeAnnotatedHtml(
+  input: string,
+): SanitizeAnnotatedHtmlResult {
+  const warnings: HtmlSanitizerWarning[] = [];
+  let output = "";
+  let i = 0;
+
+  while (i < input.length) {
+    if (input[i] !== "<") {
+      output += input[i];
+      i += 1;
+      continue;
+    }
+
+    const tag = parseTag(input, i);
+    if (!tag) {
+      output += input[i];
+      i += 1;
+      continue;
+    }
+
+    if (tag.kind === "comment" || tag.kind === "doctype") {
+      output += input.slice(i, tag.endOffset);
+      i = tag.endOffset;
+      continue;
+    }
+
+    if (tag.kind === "close") {
+      const lcName = tag.tagName.toLowerCase();
+      if (DISALLOWED_ELEMENTS.has(lcName) || !ALLOWED_ELEMENTS.has(lcName)) {
+        i = tag.endOffset;
+        continue;
+      }
+      output += input.slice(i, tag.endOffset);
+      i = tag.endOffset;
+      continue;
+    }
+
+    const lcName = tag.tagName.toLowerCase();
+
+    if (DISALLOWED_ELEMENTS.has(lcName)) {
+      warnings.push({
+        code: "disallowed-element",
+        message: `Removed disallowed <${lcName}> element.`,
+      });
+      if (tag.selfClosing || VOID_ELEMENTS.has(lcName)) {
+        i = tag.endOffset;
+        continue;
+      }
+      const close = findCloseTag(input, tag.endOffset, lcName);
+      i = close === null ? input.length : close.tagEnd;
+      continue;
+    }
+
+    if (!ALLOWED_ELEMENTS.has(lcName)) {
+      warnings.push({
+        code: "disallowed-element",
+        message: `Removed unknown <${lcName}> element.`,
+      });
+      i = tag.endOffset;
+      continue;
+    }
+
+    const sanitizedAttrs = sanitizeAttributes(lcName, tag.attrs, warnings);
+    const hasLiteral = tag.attrs.some(
+      (attr) => attr.name.toLowerCase() === "data-rd-literal",
+    );
+    const isVoid = tag.selfClosing || VOID_ELEMENTS.has(lcName);
+    const isProtected =
+      !isVoid && (PROTECTED_ELEMENTS.has(lcName) || hasLiteral);
+
+    output += buildOpenTag(tag.tagName, sanitizedAttrs, tag.selfClosing);
+
+    if (isProtected) {
+      const close = findCloseTag(input, tag.endOffset, lcName);
+      if (close === null) {
+        output += input.slice(tag.endOffset);
+        i = input.length;
+      } else {
+        output += input.slice(tag.endOffset, close.tagEnd);
+        i = close.tagEnd;
+      }
+      continue;
+    }
+
+    i = tag.endOffset;
+  }
+
+  return { html: output, warnings };
+}
+
+function parseTag(input: string, start: number): ParsedTag | null {
+  if (input[start] !== "<") return null;
+
+  if (input.startsWith("<!--", start)) {
+    const end = input.indexOf("-->", start + 4);
+    if (end === -1) return null;
+    return { kind: "comment", endOffset: end + 3 };
+  }
+
+  if (input.startsWith("<!", start) || input.startsWith("<?", start)) {
+    const end = input.indexOf(">", start + 2);
+    if (end === -1) return null;
+    return { kind: "doctype", endOffset: end + 1 };
+  }
+
+  if (input.startsWith("</", start)) {
+    let i = start + 2;
+    if (!isNameStart(input[i])) return null;
+    const nameStart = i;
+    while (i < input.length && isNameChar(input[i])) i += 1;
+    const tagName = input.slice(nameStart, i);
+    while (i < input.length && isWhitespace(input[i])) i += 1;
+    if (input[i] !== ">") return null;
+    return { kind: "close", tagName, endOffset: i + 1 };
+  }
+
+  let i = start + 1;
+  if (!isNameStart(input[i])) return null;
+  const nameStart = i;
+  while (i < input.length && isNameChar(input[i])) i += 1;
+  const tagName = input.slice(nameStart, i);
+
+  const attrs: ParsedAttr[] = [];
+  let selfClosing = false;
+
+  while (i < input.length) {
+    while (i < input.length && isWhitespace(input[i])) i += 1;
+
+    if (input[i] === ">") {
+      return { kind: "open", tagName, attrs, selfClosing, endOffset: i + 1 };
+    }
+
+    if (input[i] === "/" && input[i + 1] === ">") {
+      selfClosing = true;
+      return { kind: "open", tagName, attrs, selfClosing, endOffset: i + 2 };
+    }
+
+    if (!isAttrNameStart(input[i])) {
+      i += 1;
+      continue;
+    }
+
+    const attrNameStart = i;
+    while (i < input.length && isAttrNameChar(input[i])) i += 1;
+    const attrName = input.slice(attrNameStart, i);
+
+    let cursor = i;
+    while (cursor < input.length && isWhitespace(input[cursor])) cursor += 1;
+
+    if (input[cursor] !== "=") {
+      attrs.push({ name: attrName, hasValue: false, value: "", quote: "" });
+      continue;
+    }
+
+    cursor += 1;
+    while (cursor < input.length && isWhitespace(input[cursor])) cursor += 1;
+
+    let value = "";
+    let quote: '"' | "'" | "" = "";
+
+    if (input[cursor] === '"' || input[cursor] === "'") {
+      quote = input[cursor] as '"' | "'";
+      cursor += 1;
+      const valueStart = cursor;
+      while (cursor < input.length && input[cursor] !== quote) cursor += 1;
+      value = input.slice(valueStart, cursor);
+      if (input[cursor] === quote) cursor += 1;
+    } else {
+      const valueStart = cursor;
+      while (
+        cursor < input.length &&
+        !isWhitespace(input[cursor]) &&
+        input[cursor] !== ">" &&
+        !(input[cursor] === "/" && input[cursor + 1] === ">")
+      ) {
+        cursor += 1;
+      }
+      value = input.slice(valueStart, cursor);
+    }
+
+    attrs.push({ name: attrName, hasValue: true, value, quote });
+    i = cursor;
+  }
+
+  return null;
+}
+
+function sanitizeAttributes(
+  elementLower: string,
+  attrs: ParsedAttr[],
+  warnings: HtmlSanitizerWarning[],
+): ParsedAttr[] {
+  const result: ParsedAttr[] = [];
+
+  for (const attr of attrs) {
+    const nameLower = attr.name.toLowerCase();
+
+    if (isEventHandlerName(nameLower)) {
+      warnings.push({
+        code: "disallowed-attribute",
+        message: `Removed event handler attribute "${attr.name}".`,
+      });
+      continue;
+    }
+
+    if (nameLower === "style") {
+      warnings.push({
+        code: "disallowed-attribute",
+        message: "Removed inline style attribute.",
+      });
+      continue;
+    }
+
+    if (attr.hasValue && isUrlAttribute(elementLower, nameLower)) {
+      if (!isAllowedUrlValue(attr.value, elementLower, nameLower)) {
+        warnings.push({
+          code: "disallowed-url",
+          message: `Removed disallowed URL in <${elementLower} ${nameLower}>.`,
+        });
+        continue;
+      }
+    }
+
+    if (!isAttrAllowed(elementLower, nameLower)) {
+      warnings.push({
+        code: "disallowed-attribute",
+        message: `Removed disallowed attribute "${attr.name}" on <${elementLower}>.`,
+      });
+      continue;
+    }
+
+    result.push(attr);
+  }
+
+  return result;
+}
+
+function isAttrAllowed(elementLower: string, attrLower: string): boolean {
+  if (attrLower.startsWith("data-rd-")) return true;
+  if (GLOBAL_ALLOWED_ATTRS.has(attrLower)) return true;
+  const specific = ELEMENT_ALLOWED_ATTRS[elementLower];
+  if (specific?.has(attrLower)) return true;
+  return false;
+}
+
+function isEventHandlerName(nameLower: string): boolean {
+  if (!nameLower.startsWith("on")) return false;
+  if (nameLower.length < 3) return false;
+  const third = nameLower.charCodeAt(2);
+  return third >= 97 && third <= 122;
+}
+
+function isUrlAttribute(elementLower: string, attrLower: string): boolean {
+  if (
+    attrLower === "href" &&
+    (elementLower === "a" || elementLower === "link")
+  ) {
+    return true;
+  }
+  if (
+    attrLower === "src" &&
+    (elementLower === "img" || elementLower === "iframe")
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function isAllowedUrlValue(
+  value: string,
+  elementLower: string,
+  attrLower: string,
+): boolean {
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed.startsWith("javascript:")) return false;
+  if (trimmed.startsWith("data:")) {
+    if (
+      elementLower === "img" &&
+      attrLower === "src" &&
+      trimmed.startsWith("data:image/")
+    ) {
+      return true;
+    }
+    return false;
+  }
+  return true;
+}
+
+function buildOpenTag(
+  tagName: string,
+  attrs: ParsedAttr[],
+  selfClosing: boolean,
+): string {
+  let result = `<${tagName}`;
+  for (const attr of attrs) {
+    if (!attr.hasValue) {
+      result += ` ${attr.name}`;
+      continue;
+    }
+    const quote = attr.quote || '"';
+    result += ` ${attr.name}=${quote}${attr.value}${quote}`;
+  }
+  result += selfClosing ? "/>" : ">";
+  return result;
+}
+
+function findCloseTag(
+  input: string,
+  start: number,
+  tagNameLower: string,
+): { tagStart: number; tagEnd: number } | null {
+  let cursor = start;
+  while (cursor < input.length) {
+    const next = input.indexOf("</", cursor);
+    if (next === -1) return null;
+
+    let j = next + 2;
+    const nameStart = j;
+    while (j < input.length && isNameChar(input[j])) j += 1;
+    const name = input.slice(nameStart, j).toLowerCase();
+
+    if (name !== tagNameLower) {
+      cursor = next + 1;
+      continue;
+    }
+
+    while (j < input.length && isWhitespace(input[j])) j += 1;
+    if (input[j] !== ">") {
+      cursor = next + 1;
+      continue;
+    }
+
+    return { tagStart: next, tagEnd: j + 1 };
+  }
+  return null;
+}
+
+function isWhitespace(character: string | undefined): boolean {
+  return (
+    character === " " ||
+    character === "\t" ||
+    character === "\n" ||
+    character === "\r" ||
+    character === "\f"
+  );
+}
+
+function isNameStart(character: string | undefined): boolean {
+  if (!character) return false;
+  return /[A-Za-z]/.test(character);
+}
+
+function isNameChar(character: string | undefined): boolean {
+  if (!character) return false;
+  return /[A-Za-z0-9-]/.test(character);
+}
+
+function isAttrNameStart(character: string | undefined): boolean {
+  if (!character) return false;
+  return /[A-Za-z_:]/.test(character);
+}
+
+function isAttrNameChar(character: string | undefined): boolean {
+  if (!character) return false;
+  return /[A-Za-z0-9_:.-]/.test(character);
+}

--- a/packages/rfm/src/html/serialize.ts
+++ b/packages/rfm/src/html/serialize.ts
@@ -1,0 +1,9 @@
+import type { AnnotatedHtmlDoc } from "./types.js";
+
+// G2.1: identity serializer for plain HTML. When no mutations have occurred,
+// the model still carries the original `source`, and the low-churn contract
+// (ADR 0005 §7) is satisfied by emitting it verbatim. A tree-walking
+// serializer that handles mutations lands in later chunks (G2.2+).
+export function serializeAnnotatedHtml(doc: AnnotatedHtmlDoc): string {
+  return doc.source;
+}

--- a/packages/rfm/src/html/types.ts
+++ b/packages/rfm/src/html/types.ts
@@ -1,0 +1,58 @@
+export interface HtmlElementNode {
+  type: "element";
+  tag: string;
+  attrs: Record<string, string>;
+  children: HtmlNode[];
+  position: number;
+}
+
+export interface HtmlTextNode {
+  type: "text";
+  value: string;
+  position: number;
+}
+
+export type HtmlNode = HtmlElementNode | HtmlTextNode;
+
+export type HtmlCommentStatus = "open" | "resolved";
+
+export interface HtmlAnnotationComment {
+  id: string;
+  anchorIds: string[];
+  author: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+  status: HtmlCommentStatus | null;
+  replyTo: string | null;
+  body: string;
+  position: number;
+}
+
+export type HtmlSuggestionKind = "insertion" | "deletion" | "substitution";
+export type HtmlSuggestionStatus = "open" | "accepted" | "rejected";
+
+export interface HtmlAnnotationSuggestion {
+  id: string;
+  kind: HtmlSuggestionKind;
+  author: string | null;
+  createdAt: string | null;
+  status: HtmlSuggestionStatus | null;
+  insertedText?: string;
+  deletedText?: string;
+  position: number;
+}
+
+export interface HtmlAnnotationWarning {
+  code: string;
+  message: string;
+}
+
+export interface AnnotatedHtmlDoc {
+  format: "annotated-html";
+  version: "0.1";
+  source: string;
+  blocks: HtmlNode[];
+  comments: HtmlAnnotationComment[];
+  suggestions: HtmlAnnotationSuggestion[];
+  warnings: HtmlAnnotationWarning[];
+}

--- a/packages/rfm/src/index.ts
+++ b/packages/rfm/src/index.ts
@@ -1,3 +1,37 @@
+export { parseAnnotatedHtml } from "./html/parse.js";
+export { serializeAnnotatedHtml } from "./html/serialize.js";
+export { sanitizeAnnotatedHtml } from "./html/sanitize.js";
+export type {
+  HtmlSanitizerWarning,
+  SanitizeAnnotatedHtmlResult,
+} from "./html/sanitize.js";
+export {
+  acceptHtmlSuggestion,
+  addHtmlComment,
+  editHtmlComment,
+  rejectHtmlSuggestion,
+  removeHtmlComment,
+} from "./html/mutate.js";
+export type {
+  AddHtmlCommentAnchor,
+  AddHtmlCommentInput,
+  EditHtmlCommentInput,
+  RemoveHtmlCommentInput,
+  SuggestionMutationInput,
+} from "./html/mutate.js";
+export type {
+  AnnotatedHtmlDoc,
+  HtmlAnnotationComment,
+  HtmlAnnotationSuggestion,
+  HtmlAnnotationWarning,
+  HtmlCommentStatus,
+  HtmlElementNode,
+  HtmlNode,
+  HtmlSuggestionKind,
+  HtmlSuggestionStatus,
+  HtmlTextNode,
+} from "./html/types.js";
+
 export type RfmDiagnosticSeverity = "error" | "warning";
 
 export interface RfmDiagnostic {

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -403,6 +403,39 @@ describe("cli", () => {
     expect(test.getLastOpenedUrl()).toBeNull();
   });
 
+  it("opens local HTML files from the CLI", async () => {
+    const test = createTestDependencies();
+    const documentPath = path.join(projectDir, "draft.html");
+    fs.writeFileSync(
+      documentPath,
+      "<!doctype html><html><body>Draft</body></html>",
+    );
+
+    const exitCode = await runCli(
+      ["open", documentPath, "--no-watch", "--json"],
+      test.deps,
+    );
+    const persisted = JSON.parse(
+      fs.readFileSync(getServerStateFilePath(test.deps.env), "utf8"),
+    ) as { port: number };
+    const payload = parseOnlyJsonLog<{
+      opened: boolean;
+      url: string;
+      serverUrl: string;
+      path: string;
+      openMode: string;
+    }>(test.logs);
+
+    expect(exitCode).toBe(0);
+    expect(payload).toEqual({
+      opened: true,
+      url: expectedOpenUrl(`http://localhost:${persisted.port}`, documentPath),
+      serverUrl: `http://localhost:${persisted.port}`,
+      path: documentPath,
+      openMode: "disabled",
+    });
+  });
+
   it("emits JSON from open --no-watch --json without scraping human prose", async () => {
     const test = createTestDependencies();
     const documentPath = path.join(projectDir, "draft.md");
@@ -1045,7 +1078,7 @@ describe("cli", () => {
     expect(exitCode).toBe(1);
     expect(test.getSpawnCount()).toBe(0);
     expect(test.errors).toContain(
-      `Roughdraft can only open .md files: ${projectDir}`,
+      `Roughdraft can only open .md, .html, or .htm files: ${projectDir}`,
     );
     expect(test.getLastOpenedUrl()).toBeNull();
   });
@@ -1623,7 +1656,7 @@ describe("runCli open in remote mode", () => {
     expect(errors.join("\n")).toContain("Could not register remote session");
   });
 
-  it("rejects non-.md targets in remote mode without contacting the host", async () => {
+  it("rejects unsupported targets in remote mode without contacting the host", async () => {
     const filePath = path.join(projectDir, "notes.txt");
     fs.writeFileSync(filePath, "hello");
 
@@ -1651,7 +1684,9 @@ describe("runCli open in remote mode", () => {
 
     expect(exitCode).toBe(1);
     expect(fetchCalls).toBe(0);
-    expect(errors.join("\n")).toContain("can only open .md files");
+    expect(errors.join("\n")).toContain(
+      "can only open .md, .html, or .htm files",
+    );
   });
 
   it("registers a session, opens the viewer URL, and writes save events to disk", {

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -562,6 +562,8 @@ function isKnownCommand(value: string): value is KnownCommand {
 function isPathLikeInput(value: string): boolean {
   return (
     value.toLowerCase().endsWith(".md") ||
+    value.toLowerCase().endsWith(".html") ||
+    value.toLowerCase().endsWith(".htm") ||
     value.startsWith(".") ||
     value.startsWith("/") ||
     value.startsWith("~") ||
@@ -765,7 +767,9 @@ function printHelp(log: (message: string) => void) {
   log("  roughdraft <path>");
   log("");
   log("Commands:");
-  log("  open <path>        Open a Markdown file and wait for Done Reviewing");
+  log(
+    "  open <path>        Open a Markdown or HTML file and wait for Done Reviewing",
+  );
   log("  start              Start or reuse the background server");
   log("  status             Show server status");
   log("  stop               Stop the managed background server");
@@ -806,7 +810,7 @@ function printCommandHelp(
     );
     log("");
     log(
-      "Opens one Markdown file and waits for Done Reviewing. Starts Roughdraft if needed.",
+      "Opens one Markdown or HTML file and waits for Done Reviewing. Starts Roughdraft if needed.",
     );
     log("");
     log("Flags:");
@@ -1336,17 +1340,23 @@ async function sendOpenRequestToExistingWindow(
 
 function resolveTargetPath(inputPath: string): ResolvedTargetPath {
   const resolvedPath = path.resolve(inputPath);
-  const looksLikeMarkdownFile = resolvedPath.toLowerCase().endsWith(".md");
+  const extension = path.extname(resolvedPath).toLowerCase();
+  const looksLikeSupportedFile =
+    extension === ".md" || extension === ".html" || extension === ".htm";
 
   try {
     const stat = fs.statSync(resolvedPath);
     if (stat.isDirectory()) {
-      throw new Error(`Roughdraft can only open .md files: ${resolvedPath}`);
+      throw new Error(
+        `Roughdraft can only open .md, .html, or .htm files: ${resolvedPath}`,
+      );
     }
 
     if (stat.isFile()) {
-      if (!looksLikeMarkdownFile) {
-        throw new Error(`Roughdraft can only open .md files: ${resolvedPath}`);
+      if (!looksLikeSupportedFile) {
+        throw new Error(
+          `Roughdraft can only open .md, .html, or .htm files: ${resolvedPath}`,
+        );
       }
 
       return {

--- a/packages/server/src/html-read.test.ts
+++ b/packages/server/src/html-read.test.ts
@@ -1,0 +1,227 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "./index";
+
+const COMMENTED_FIXTURE = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Commented document</title>
+  </head>
+  <body>
+    <article>
+      <h1>The weather report</h1>
+      <p>
+        The
+        <mark data-rd-comment-ids="c-7uG2">sky</mark>
+        is blue today.
+      </p>
+    </article>
+    <aside class="rd-review" hidden>
+      <rd-comment
+        id="c-7uG2"
+        data-rd-author="ananth@cradlewise.com"
+        data-rd-created-at="2026-05-23T10:14:11Z"
+        data-rd-anchor-ids="c-7uG2"
+        data-rd-status="open"
+      >Consider saying clear sky for accuracy.</rd-comment>
+    </aside>
+  </body>
+</html>`;
+
+describe("GET /api/html-file", () => {
+  let projectDir: string;
+  let homeDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "roughdraft-html-"));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "roughdraft-html-home-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("reads a plain .html file and returns a parsed model", async () => {
+    fs.writeFileSync(
+      path.join(projectDir, "plain.html"),
+      `<!doctype html><html><head><title>Plain doc</title></head>` +
+        `<body><article><h1>Heading</h1><p>Body.</p></article></body></html>`,
+    );
+
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+
+    const response = await request(app).get("/api/html-file").query({
+      projectPath: projectDir,
+      path: "plain.html",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      id: "plain",
+      title: "Plain doc",
+    });
+    expect(typeof response.body.content).toBe("string");
+    expect(response.body.version).toEqual(expect.any(String));
+    expect(response.body.document).toBeDefined();
+    expect(response.body.document.format).toBe("annotated-html");
+    expect(response.body.document.source).toBe(response.body.content);
+    expect(Array.isArray(response.body.sanitizerWarnings)).toBe(true);
+    expect(response.body.sanitizerWarnings).toHaveLength(0);
+  });
+
+  it("reads a commented .html file and returns model with comments", async () => {
+    fs.writeFileSync(path.join(projectDir, "doc.html"), COMMENTED_FIXTURE);
+
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+
+    const response = await request(app).get("/api/html-file").query({
+      projectPath: projectDir,
+      path: "doc.html",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.document.comments.length).toBeGreaterThan(0);
+    const [firstComment] = response.body.document.comments;
+    expect(firstComment).toMatchObject({
+      id: "c-7uG2",
+      author: "ananth@cradlewise.com",
+    });
+    expect(firstComment.body).toContain("clear sky");
+    expect(firstComment.anchorIds).toContain("c-7uG2");
+  });
+
+  it("accepts .htm extension and strips it from the id", async () => {
+    fs.writeFileSync(
+      path.join(projectDir, "legacy.htm"),
+      `<!doctype html><html><body><h1>Legacy</h1></body></html>`,
+    );
+
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+
+    const response = await request(app).get("/api/html-file").query({
+      projectPath: projectDir,
+      path: "legacy.htm",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.id).toBe("legacy");
+    expect(response.body.title).toBe("Legacy");
+  });
+
+  it("falls back to <h1> when there is no <title>", async () => {
+    fs.writeFileSync(
+      path.join(projectDir, "h1-only.html"),
+      `<!doctype html><html><body><article><h1>Just an H1</h1></article></body></html>`,
+    );
+
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+
+    const response = await request(app).get("/api/html-file").query({
+      projectPath: projectDir,
+      path: "h1-only.html",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.title).toBe("Just an H1");
+  });
+
+  it("uses basename as title when no <title> or <h1>", async () => {
+    fs.writeFileSync(
+      path.join(projectDir, "bare.html"),
+      `<!doctype html><html><body><p>No title or heading.</p></body></html>`,
+    );
+
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+
+    const response = await request(app).get("/api/html-file").query({
+      projectPath: projectDir,
+      path: "bare.html",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.title).toBe("bare");
+  });
+
+  it("rejects non-html extensions with 400", async () => {
+    fs.writeFileSync(path.join(projectDir, "notes.md"), "# Notes\n");
+
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+
+    const response = await request(app).get("/api/html-file").query({
+      projectPath: projectDir,
+      path: "notes.md",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      error: "HTML file path must end with .html or .htm",
+    });
+  });
+
+  it("applies sanitizer on read and exposes warnings", async () => {
+    const malicious =
+      `<!doctype html><html><head><title>Mal</title></head><body>` +
+      `<p onclick="alert(1)">hello</p>` +
+      `<script>alert('xss')</script>` +
+      `<a href="javascript:alert(1)">bad</a>` +
+      `</body></html>`;
+    fs.writeFileSync(path.join(projectDir, "mal.html"), malicious);
+
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+
+    const response = await request(app).get("/api/html-file").query({
+      projectPath: projectDir,
+      path: "mal.html",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.content).not.toContain("onclick");
+    expect(response.body.content).not.toContain("<script");
+    expect(response.body.content).not.toContain("javascript:");
+    expect(response.body.document.source).toBe(response.body.content);
+
+    const codes = (
+      response.body.sanitizerWarnings as Array<{ code: string }>
+    ).map((warning) => warning.code);
+    expect(codes).toContain("disallowed-attribute");
+    expect(codes).toContain("disallowed-element");
+    expect(codes).toContain("disallowed-url");
+  });
+
+  it("returns 404 when the html file is missing", async () => {
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+
+    const response = await request(app).get("/api/html-file").query({
+      projectPath: projectDir,
+      path: "missing.html",
+    });
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: "HTML file not found" });
+  });
+
+  it("normalizes nested path ids with forward slashes", async () => {
+    const nestedDir = path.join(projectDir, "section", "sub");
+    fs.mkdirSync(nestedDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(nestedDir, "page.html"),
+      `<!doctype html><html><head><title>Nested</title></head><body><p>x</p></body></html>`,
+    );
+
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+
+    const response = await request(app).get("/api/html-file").query({
+      projectPath: projectDir,
+      path: "section/sub/page.html",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.id).toBe("section/sub/page");
+    expect(response.body.title).toBe("Nested");
+  });
+});

--- a/packages/server/src/html-write.test.ts
+++ b/packages/server/src/html-write.test.ts
@@ -1,0 +1,196 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "./index";
+
+const PLAIN_HTML = `<!doctype html><html><head><title>Plain doc</title></head><body><article><h1>Heading</h1><p>Body.</p></article></body></html>`;
+
+describe("PUT /api/html-file", () => {
+  let projectDir: string;
+  let homeDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "roughdraft-html-w-"));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "roughdraft-html-w-home-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("saves html content when expected version matches", async () => {
+    const absolutePath = path.join(projectDir, "doc.html");
+    fs.writeFileSync(absolutePath, PLAIN_HTML);
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+
+    const initial = await request(app)
+      .get("/api/html-file")
+      .query({ projectPath: projectDir, path: "doc.html" });
+    expect(initial.status).toBe(200);
+
+    const nextContent = PLAIN_HTML.replace("Body.", "Body updated.");
+    const response = await request(app)
+      .put("/api/html-file")
+      .query({ projectPath: projectDir, path: "doc.html" })
+      .send({ content: nextContent, expectedVersion: initial.body.version });
+
+    expect(response.status).toBe(200);
+    expect(response.body.content).toContain("Body updated.");
+    expect(response.body.version).not.toBe(initial.body.version);
+    expect(response.body.document.source).toBe(response.body.content);
+    expect(fs.readFileSync(absolutePath, "utf-8")).toContain("Body updated.");
+  });
+
+  it("rejects stale html writes with 409 and leaves disk unchanged", async () => {
+    const absolutePath = path.join(projectDir, "doc.html");
+    fs.writeFileSync(absolutePath, PLAIN_HTML);
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+
+    const initial = await request(app)
+      .get("/api/html-file")
+      .query({ projectPath: projectDir, path: "doc.html" });
+    expect(initial.status).toBe(200);
+
+    // External change.
+    const externalContent = PLAIN_HTML.replace("Body.", "External edit.");
+    fs.writeFileSync(absolutePath, externalContent);
+    const onDiskBefore = fs.readFileSync(absolutePath, "utf-8");
+
+    const stale = await request(app)
+      .put("/api/html-file")
+      .query({ projectPath: projectDir, path: "doc.html" })
+      .send({
+        content: PLAIN_HTML.replace("Body.", "Client edit."),
+        expectedVersion: initial.body.version,
+      });
+
+    expect(stale.status).toBe(409);
+    expect(stale.body.error).toBe("HTML file changed on disk");
+    expect(stale.body.current).toBeDefined();
+    expect(stale.body.current.content).toContain("External edit.");
+    expect(fs.readFileSync(absolutePath, "utf-8")).toBe(onDiskBefore);
+  });
+
+  it("applies sanitizer on write and exposes warnings on returned read", async () => {
+    const absolutePath = path.join(projectDir, "doc.html");
+    fs.writeFileSync(absolutePath, PLAIN_HTML);
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+
+    const initial = await request(app)
+      .get("/api/html-file")
+      .query({ projectPath: projectDir, path: "doc.html" });
+
+    const malicious =
+      `<!doctype html><html><head><title>Mal</title></head><body>` +
+      `<p onclick="alert(1)">hi</p>` +
+      `<script>alert('xss')</script>` +
+      `<a href="javascript:alert(1)">bad</a>` +
+      `</body></html>`;
+
+    const response = await request(app)
+      .put("/api/html-file")
+      .query({ projectPath: projectDir, path: "doc.html" })
+      .send({ content: malicious, expectedVersion: initial.body.version });
+
+    expect(response.status).toBe(200);
+    expect(response.body.content).not.toContain("onclick");
+    expect(response.body.content).not.toContain("<script");
+    expect(response.body.content).not.toContain("javascript:");
+
+    const codes = (
+      response.body.sanitizerWarnings as Array<{ code: string }>
+    ).map((warning) => warning.code);
+    expect(codes).toContain("disallowed-attribute");
+    expect(codes).toContain("disallowed-element");
+    expect(codes).toContain("disallowed-url");
+
+    const onDisk = fs.readFileSync(absolutePath, "utf-8");
+    expect(onDisk).not.toContain("onclick");
+    expect(onDisk).not.toContain("<script");
+    expect(onDisk).not.toContain("javascript:");
+    expect(onDisk).toBe(response.body.content);
+  });
+
+  it("writes a parsed document and re-reads with byte-stable output", async () => {
+    const absolutePath = path.join(projectDir, "doc.html");
+    fs.writeFileSync(absolutePath, PLAIN_HTML);
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+
+    const initial = await request(app)
+      .get("/api/html-file")
+      .query({ projectPath: projectDir, path: "doc.html" });
+    expect(initial.status).toBe(200);
+
+    const firstWrite = await request(app)
+      .put("/api/html-file")
+      .query({ projectPath: projectDir, path: "doc.html" })
+      .send({
+        document: initial.body.document,
+        expectedVersion: initial.body.version,
+      });
+    expect(firstWrite.status).toBe(200);
+    const bytesAfterFirst = fs.readFileSync(absolutePath);
+
+    const reread = await request(app)
+      .get("/api/html-file")
+      .query({ projectPath: projectDir, path: "doc.html" });
+    expect(reread.status).toBe(200);
+
+    const secondWrite = await request(app)
+      .put("/api/html-file")
+      .query({ projectPath: projectDir, path: "doc.html" })
+      .send({
+        document: reread.body.document,
+        expectedVersion: reread.body.version,
+      });
+    expect(secondWrite.status).toBe(200);
+    const bytesAfterSecond = fs.readFileSync(absolutePath);
+
+    expect(bytesAfterSecond.equals(bytesAfterFirst)).toBe(true);
+  });
+
+  it("rejects non-html extension with 400", async () => {
+    fs.writeFileSync(path.join(projectDir, "notes.md"), "# Notes\n");
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+
+    const response = await request(app)
+      .put("/api/html-file")
+      .query({ projectPath: projectDir, path: "notes.md" })
+      .send({ content: PLAIN_HTML });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      error: "HTML file path must end with .html or .htm",
+    });
+  });
+
+  it("returns 404 when the html file is missing", async () => {
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+
+    const response = await request(app)
+      .put("/api/html-file")
+      .query({ projectPath: projectDir, path: "missing.html" })
+      .send({ content: PLAIN_HTML });
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: "HTML file not found" });
+  });
+
+  it("rejects missing content/document body with 400", async () => {
+    const absolutePath = path.join(projectDir, "doc.html");
+    fs.writeFileSync(absolutePath, PLAIN_HTML);
+    const onDiskBefore = fs.readFileSync(absolutePath, "utf-8");
+    const { app } = createApp({ homeDir, staticDirPath: projectDir });
+
+    const response = await request(app)
+      .put("/api/html-file")
+      .query({ projectPath: projectDir, path: "doc.html" })
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(fs.readFileSync(absolutePath, "utf-8")).toBe(onDiskBefore);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,7 +5,13 @@ import { createServer as createHttpServer } from "node:http";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 import fs from "node:fs";
-import { extractRoughdraftReviewIndex } from "@roughdraft/rfm";
+import {
+  extractRoughdraftReviewIndex,
+  parseAnnotatedHtml,
+  sanitizeAnnotatedHtml,
+  serializeAnnotatedHtml,
+} from "@roughdraft/rfm";
+import type { AnnotatedHtmlDoc, HtmlSanitizerWarning } from "@roughdraft/rfm";
 import {
   ROUGHDRAFT_DEFAULT_PORT,
   ROUGHDRAFT_PUBLIC_HOST,
@@ -189,6 +195,69 @@ function markdownPageFromFile(
 
 function pageIdFromRelativePath(relativePath: string): string {
   return relativePath.replace(/\.md$/i, "").split(path.sep).join("/");
+}
+
+function htmlPageIdFromRelativePath(relativePath: string): string {
+  return relativePath
+    .replace(/\.html?$/i, "")
+    .split(path.sep)
+    .join("/");
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
+    .replaceAll("&apos;", "'")
+    .replaceAll("&amp;", "&");
+}
+
+function titleFromHtmlContent(sanitizedHtml: string, fallback: string): string {
+  const titleMatch = sanitizedHtml.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  if (titleMatch?.[1]) {
+    const text = decodeHtmlEntities(titleMatch[1]).trim();
+    if (text.length > 0) return text;
+  }
+
+  const h1Match = sanitizedHtml.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  if (h1Match?.[1]) {
+    const stripped = h1Match[1].replace(/<[^>]*>/g, "");
+    const text = decodeHtmlEntities(stripped).trim();
+    if (text.length > 0) return text;
+  }
+
+  return fallback;
+}
+
+interface HtmlFileResponse {
+  id: string;
+  title: string;
+  content: string;
+  version: string;
+  document: AnnotatedHtmlDoc;
+  sanitizerWarnings: HtmlSanitizerWarning[];
+}
+
+function htmlPageFromFile(
+  relativePath: string,
+  absolutePath: string,
+): HtmlFileResponse {
+  const raw = fs.readFileSync(absolutePath, "utf-8");
+  const stats = fs.statSync(absolutePath);
+  const sanitized = sanitizeAnnotatedHtml(raw);
+  const document = parseAnnotatedHtml(sanitized.html);
+  const fallbackTitle = path.basename(relativePath, path.extname(relativePath));
+
+  return {
+    id: htmlPageIdFromRelativePath(relativePath),
+    title: titleFromHtmlContent(sanitized.html, fallbackTitle),
+    content: sanitized.html,
+    version: fileVersionFromContent(stats, raw),
+    document,
+    sanitizerWarnings: sanitized.warnings,
+  };
 }
 
 function nextUntitledId(projectDir: string): string {
@@ -556,6 +625,91 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
     }
 
     res.json(markdownPageFromFile(relativePath, absolutePath));
+  });
+
+  app.get("/api/html-file", (req, res) => {
+    const projectDir = projectDirFromRequest(req, res);
+    if (!projectDir) return;
+
+    const relativePath =
+      typeof req.query.path === "string" ? req.query.path : "";
+    const absolutePath = ensureProjectPath(projectDir, relativePath);
+
+    if (!absolutePath || !/\.html?$/i.test(absolutePath)) {
+      res
+        .status(400)
+        .json({ error: "HTML file path must end with .html or .htm" });
+      return;
+    }
+
+    if (!fs.existsSync(absolutePath)) {
+      res.status(404).json({ error: "HTML file not found" });
+      return;
+    }
+
+    res.json(htmlPageFromFile(relativePath, absolutePath));
+  });
+
+  app.put("/api/html-file", (req, res) => {
+    const projectDir = projectDirFromRequest(req, res);
+    if (!projectDir) return;
+
+    const relativePath =
+      typeof req.query.path === "string" ? req.query.path : "";
+    const absolutePath = ensureProjectPath(projectDir, relativePath);
+
+    if (!absolutePath || !/\.html?$/i.test(absolutePath)) {
+      res
+        .status(400)
+        .json({ error: "HTML file path must end with .html or .htm" });
+      return;
+    }
+
+    if (!fs.existsSync(absolutePath)) {
+      res.status(404).json({ error: "HTML file not found" });
+      return;
+    }
+
+    const body = (req.body ?? {}) as {
+      content?: unknown;
+      document?: unknown;
+      expectedVersion?: unknown;
+    };
+
+    const hasContent = typeof body.content === "string";
+    const hasDocument =
+      body.document !== null &&
+      typeof body.document === "object" &&
+      (body.document as { format?: unknown }).format === "annotated-html" &&
+      typeof (body.document as { source?: unknown }).source === "string";
+
+    if (!hasContent && !hasDocument) {
+      res.status(400).json({
+        error: "content or document is required",
+      });
+      return;
+    }
+
+    const expectedVersion =
+      typeof body.expectedVersion === "string" ? body.expectedVersion : null;
+    const currentVersion = fileVersionFromFile(absolutePath);
+
+    if (expectedVersion && expectedVersion !== currentVersion) {
+      res.status(409).json({
+        error: "HTML file changed on disk",
+        current: htmlPageFromFile(relativePath, absolutePath),
+      });
+      return;
+    }
+
+    const incoming = hasContent
+      ? (body.content as string)
+      : serializeAnnotatedHtml(body.document as AnnotatedHtmlDoc);
+    const sanitized = sanitizeAnnotatedHtml(incoming);
+    fs.writeFileSync(absolutePath, sanitized.html);
+
+    const reread = htmlPageFromFile(relativePath, absolutePath);
+    res.json({ ...reread, sanitizerWarnings: sanitized.warnings });
   });
 
   app.get("/api/markdown-file/events", (req, res) => {

--- a/packages/server/src/mcp-html.test.ts
+++ b/packages/server/src/mcp-html.test.ts
@@ -1,0 +1,389 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { callTool } from "./mcp";
+
+const noopFetch: typeof fetch = async () => {
+  throw new Error("fetch should not be called for HTML MCP tools");
+};
+
+const PLAIN = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Plain document</title>
+  </head>
+  <body>
+    <article>
+      <h1>Plain document</h1>
+      <p>This is a paragraph of plain text.</p>
+    </article>
+  </body>
+</html>
+`;
+
+const MIXED = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Mixed</title>
+  </head>
+  <body>
+    <article>
+      <h1>Quarterly review</h1>
+      <p>Revenue grew steadily.</p>
+      <p>
+        Churn was
+        <del data-rd-suggestion-id="s-churn-1" data-rd-author="r@x" data-rd-created-at="2026-05-23T12:01:00Z">high</del><ins data-rd-suggestion-id="s-churn-1" data-rd-author="r@x" data-rd-created-at="2026-05-23T12:01:00Z">elevated but stable</ins>
+        in the SMB segment.
+      </p>
+    </article>
+    <aside class="rd-review" hidden>
+    </aside>
+  </body>
+</html>
+`;
+
+describe("mcp html tools", () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "roughdraft-mcp-html-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  describe("read_html_document", () => {
+    it("returns a parsed model for plain HTML", async () => {
+      const docPath = path.join(projectDir, "plain.html");
+      fs.writeFileSync(docPath, PLAIN);
+
+      const result = (await callTool(
+        "roughdraft_read_html_document",
+        { documentPath: docPath },
+        {},
+        noopFetch,
+      )) as {
+        documentPath: string;
+        document: {
+          format: string;
+          comments: unknown[];
+          suggestions: unknown[];
+        };
+        checksum: string;
+        sanitizerWarnings: unknown[];
+      };
+
+      expect(result.documentPath).toBe(docPath);
+      expect(result.document.format).toBe("annotated-html");
+      expect(result.document.comments).toHaveLength(0);
+      expect(result.document.suggestions).toHaveLength(0);
+      expect(typeof result.checksum).toBe("string");
+      expect(result.checksum.length).toBeGreaterThan(0);
+    });
+
+    it("returns comments and suggestions for an annotated HTML doc", async () => {
+      const docPath = path.join(projectDir, "mixed.html");
+      fs.writeFileSync(docPath, MIXED);
+
+      const result = (await callTool(
+        "roughdraft_read_html_document",
+        { documentPath: docPath },
+        {},
+        noopFetch,
+      )) as {
+        document: {
+          comments: Array<{ id: string }>;
+          suggestions: Array<{ id: string; kind: string }>;
+        };
+      };
+
+      expect(result.document.suggestions.length).toBe(1);
+      expect(result.document.suggestions[0]?.id).toBe("s-churn-1");
+      expect(result.document.suggestions[0]?.kind).toBe("substitution");
+    });
+
+    it("rejects non-html extensions", async () => {
+      const docPath = path.join(projectDir, "notes.md");
+      fs.writeFileSync(docPath, "# Notes\n");
+
+      await expect(
+        callTool(
+          "roughdraft_read_html_document",
+          { documentPath: docPath },
+          {},
+          noopFetch,
+        ),
+      ).rejects.toThrow(/\.html?\s*files?/i);
+    });
+
+    it("rejects paths outside the configured root", async () => {
+      const outsideDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "roughdraft-outside-"),
+      );
+      const outsidePath = path.join(outsideDir, "outside.html");
+      fs.writeFileSync(outsidePath, PLAIN);
+
+      try {
+        await expect(
+          callTool(
+            "roughdraft_read_html_document",
+            { documentPath: outsidePath, projectRoot: projectDir },
+            {},
+            noopFetch,
+          ),
+        ).rejects.toThrow(/outside.*root/i);
+      } finally {
+        fs.rmSync(outsideDir, { recursive: true, force: true });
+      }
+    });
+
+    it("rejects paths that try to traverse out of the configured root", async () => {
+      const docPath = path.join(projectDir, "page.html");
+      fs.writeFileSync(docPath, PLAIN);
+
+      await expect(
+        callTool(
+          "roughdraft_read_html_document",
+          { documentPath: "../outside.html", projectRoot: projectDir },
+          {},
+          noopFetch,
+        ),
+      ).rejects.toThrow(/outside.*root/i);
+    });
+  });
+
+  describe("add_comment", () => {
+    it("wraps the anchor text with a mark and inserts an rd-comment record", async () => {
+      const docPath = path.join(projectDir, "doc.html");
+      fs.writeFileSync(docPath, PLAIN);
+      const before = fs.readFileSync(docPath, "utf8");
+
+      const result = (await callTool(
+        "roughdraft_add_comment",
+        {
+          documentPath: docPath,
+          id: "c-mcp-1",
+          anchorText: "plain text",
+          author: "agent@example.com",
+          createdAt: "2026-05-23T18:00:00Z",
+          body: "Tighten this phrase.",
+        },
+        {},
+        noopFetch,
+      )) as { documentPath: string; commentId: string };
+
+      expect(result.commentId).toBe("c-mcp-1");
+      const after = fs.readFileSync(docPath, "utf8");
+      expect(after).not.toBe(before);
+      expect(after).toContain('data-rd-comment-ids="c-mcp-1"');
+      expect(after).toContain("<rd-comment");
+      expect(after).toContain("Tighten this phrase.");
+      expect(after).toContain(
+        '<mark data-rd-comment-ids="c-mcp-1">plain text</mark>',
+      );
+    });
+
+    it("rejects an anchor selector that matches zero nodes", async () => {
+      const docPath = path.join(projectDir, "doc.html");
+      fs.writeFileSync(docPath, PLAIN);
+
+      await expect(
+        callTool(
+          "roughdraft_add_comment",
+          {
+            documentPath: docPath,
+            id: "c-miss",
+            anchorText: "not present anywhere",
+            author: "agent@example.com",
+            createdAt: "2026-05-23T18:00:00Z",
+            body: "x",
+          },
+          {},
+          noopFetch,
+        ),
+      ).rejects.toThrow(/not found|anchor/i);
+    });
+
+    it("rejects when anchor occurrence is ambiguous and no occurrence is specified", async () => {
+      const docPath = path.join(projectDir, "doc.html");
+      fs.writeFileSync(
+        docPath,
+        `<!doctype html><html><head><title>T</title></head><body>` +
+          `<article><p>alpha alpha alpha</p></article>` +
+          `</body></html>`,
+      );
+
+      await expect(
+        callTool(
+          "roughdraft_add_comment",
+          {
+            documentPath: docPath,
+            id: "c-amb",
+            anchorText: "alpha",
+            author: "agent@example.com",
+            createdAt: "2026-05-23T18:00:00Z",
+            body: "x",
+            requireUnique: true,
+          },
+          {},
+          noopFetch,
+        ),
+      ).rejects.toThrow(/ambiguous|multiple/i);
+    });
+
+    it("supports occurrence to disambiguate", async () => {
+      const docPath = path.join(projectDir, "doc.html");
+      fs.writeFileSync(
+        docPath,
+        `<!doctype html><html><head><title>T</title></head><body>` +
+          `<article><p>alpha alpha alpha</p></article>` +
+          `</body></html>`,
+      );
+
+      await callTool(
+        "roughdraft_add_comment",
+        {
+          documentPath: docPath,
+          id: "c-occ2",
+          anchorText: "alpha",
+          occurrence: 2,
+          author: "agent@example.com",
+          createdAt: "2026-05-23T18:00:00Z",
+          body: "second one",
+        },
+        {},
+        noopFetch,
+      );
+
+      const after = fs.readFileSync(docPath, "utf8");
+      expect(after).toContain(
+        '<mark data-rd-comment-ids="c-occ2">alpha</mark>',
+      );
+    });
+  });
+
+  describe("accept_suggestion / reject_suggestion", () => {
+    it("accept replaces a substitution with the ins content", async () => {
+      const docPath = path.join(projectDir, "mixed.html");
+      fs.writeFileSync(docPath, MIXED);
+
+      const result = (await callTool(
+        "roughdraft_accept_suggestion",
+        { documentPath: docPath, id: "s-churn-1" },
+        {},
+        noopFetch,
+      )) as { documentPath: string };
+
+      expect(result.documentPath).toBe(docPath);
+      const after = fs.readFileSync(docPath, "utf8");
+      expect(after).toContain("elevated but stable");
+      expect(after).not.toContain('data-rd-suggestion-id="s-churn-1"');
+      expect(after).not.toContain('<del data-rd-suggestion-id="s-churn-1"');
+    });
+
+    it("reject restores the del content for a substitution", async () => {
+      const docPath = path.join(projectDir, "mixed.html");
+      fs.writeFileSync(docPath, MIXED);
+
+      await callTool(
+        "roughdraft_reject_suggestion",
+        { documentPath: docPath, id: "s-churn-1" },
+        {},
+        noopFetch,
+      );
+
+      const after = fs.readFileSync(docPath, "utf8");
+      expect(after).toMatch(/\bhigh\b/);
+      expect(after).not.toContain("elevated but stable");
+      expect(after).not.toContain('data-rd-suggestion-id="s-churn-1"');
+    });
+
+    it("both refuse an unknown suggestion id", async () => {
+      const docPath = path.join(projectDir, "mixed.html");
+      fs.writeFileSync(docPath, MIXED);
+
+      await expect(
+        callTool(
+          "roughdraft_accept_suggestion",
+          { documentPath: docPath, id: "s-does-not-exist" },
+          {},
+          noopFetch,
+        ),
+      ).rejects.toThrow(/not found/i);
+
+      await expect(
+        callTool(
+          "roughdraft_reject_suggestion",
+          { documentPath: docPath, id: "s-does-not-exist" },
+          {},
+          noopFetch,
+        ),
+      ).rejects.toThrow(/not found/i);
+    });
+  });
+
+  describe("end-to-end agent flow", () => {
+    it("read -> add comment -> accept suggestion -> re-read", async () => {
+      const docPath = path.join(projectDir, "flow.html");
+      fs.writeFileSync(docPath, MIXED);
+
+      const initial = (await callTool(
+        "roughdraft_read_html_document",
+        { documentPath: docPath },
+        {},
+        noopFetch,
+      )) as {
+        document: {
+          suggestions: Array<{ id: string }>;
+          comments: Array<{ id: string }>;
+        };
+      };
+      expect(initial.document.suggestions).toHaveLength(1);
+      expect(initial.document.comments).toHaveLength(0);
+
+      await callTool(
+        "roughdraft_add_comment",
+        {
+          documentPath: docPath,
+          id: "c-flow-1",
+          anchorText: "Revenue grew",
+          author: "agent@example.com",
+          createdAt: "2026-05-23T19:00:00Z",
+          body: "Add the percentage.",
+        },
+        {},
+        noopFetch,
+      );
+
+      await callTool(
+        "roughdraft_accept_suggestion",
+        { documentPath: docPath, id: "s-churn-1" },
+        {},
+        noopFetch,
+      );
+
+      const final = (await callTool(
+        "roughdraft_read_html_document",
+        { documentPath: docPath },
+        {},
+        noopFetch,
+      )) as {
+        document: {
+          suggestions: Array<{ id: string }>;
+          comments: Array<{ id: string }>;
+        };
+      };
+      expect(final.document.suggestions).toHaveLength(0);
+      expect(final.document.comments.some((c) => c.id === "c-flow-1")).toBe(
+        true,
+      );
+      const onDisk = fs.readFileSync(docPath, "utf8");
+      expect(onDisk).toContain("elevated but stable");
+      expect(onDisk).toContain('data-rd-comment-ids="c-flow-1"');
+    });
+  });
+});

--- a/packages/server/src/mcp.ts
+++ b/packages/server/src/mcp.ts
@@ -1,10 +1,16 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
+  acceptHtmlSuggestion,
+  addHtmlComment,
   appendRoughdraftReply,
   extractRoughdraftReviewIndex,
   markRoughdraftResolved,
+  parseAnnotatedHtml,
+  rejectHtmlSuggestion,
+  sanitizeAnnotatedHtml,
 } from "@roughdraft/rfm";
 
 interface JsonRpcRequest {
@@ -95,6 +101,78 @@ const tools: ToolDefinition[] = [
         parentId: { type: "string" },
         message: { type: "string" },
         author: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "roughdraft_read_html_document",
+    description:
+      "Read a local annotated HTML (.html / .htm) file from disk, sanitize it, and return the parsed AnnotatedHtmlDoc model plus a content checksum. Pass projectRoot to constrain the documentPath to a directory.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["documentPath"],
+      properties: {
+        documentPath: { type: "string" },
+        projectRoot: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "roughdraft_add_comment",
+    description:
+      "Add a comment to a local annotated HTML file by selecting an anchor text span. The span is identified by anchorText plus an optional 1-based occurrence; set requireUnique to refuse when the anchor matches multiple occurrences.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        "documentPath",
+        "id",
+        "anchorText",
+        "author",
+        "createdAt",
+        "body",
+      ],
+      properties: {
+        documentPath: { type: "string" },
+        projectRoot: { type: "string" },
+        id: { type: "string" },
+        anchorText: { type: "string" },
+        occurrence: { type: "number" },
+        requireUnique: { type: "boolean" },
+        author: { type: "string" },
+        createdAt: { type: "string" },
+        body: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "roughdraft_accept_suggestion",
+    description:
+      "Accept a suggestion in a local annotated HTML file by id. Substitutions become their ins content; insertions are kept; deletions are removed.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["documentPath", "id"],
+      properties: {
+        documentPath: { type: "string" },
+        projectRoot: { type: "string" },
+        id: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "roughdraft_reject_suggestion",
+    description:
+      "Reject a suggestion in a local annotated HTML file by id. Substitutions restore their del content; insertions are removed; deletions are kept.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["documentPath", "id"],
+      properties: {
+        documentPath: { type: "string" },
+        projectRoot: { type: "string" },
+        id: { type: "string" },
       },
     },
   },
@@ -318,6 +396,133 @@ export async function callTool(
     return { ok: true, documentPath };
   }
 
+  if (name === "roughdraft_read_html_document") {
+    const documentPath = requireHtmlPath(args);
+    const raw = fs.readFileSync(documentPath, "utf8");
+    const sanitized = sanitizeAnnotatedHtml(raw);
+    const document = parseAnnotatedHtml(sanitized.html);
+    return {
+      documentPath,
+      document,
+      checksum: contentChecksum(sanitized.html),
+      sanitizerWarnings: sanitized.warnings,
+    };
+  }
+
+  if (name === "roughdraft_add_comment") {
+    const documentPath = requireHtmlPath(args);
+    const id = requireString(args, "id");
+    const anchorText = requireString(args, "anchorText");
+    const author = requireString(args, "author");
+    const createdAt = requireString(args, "createdAt");
+    const body = requireString(args, "body");
+    const occurrence =
+      typeof args.occurrence === "number" ? args.occurrence : undefined;
+    const requireUnique =
+      typeof args.requireUnique === "boolean" ? args.requireUnique : false;
+
+    const raw = fs.readFileSync(documentPath, "utf8");
+    const sanitized = sanitizeAnnotatedHtml(raw);
+    const baseDoc = parseAnnotatedHtml(sanitized.html);
+
+    if (requireUnique && occurrence === undefined) {
+      const matches = countPlainTextOccurrences(sanitized.html, anchorText);
+      if (matches > 1) {
+        throw new Error(
+          `add_comment: anchorText "${anchorText}" is ambiguous (matched ${matches} occurrences); pass occurrence to disambiguate`,
+        );
+      }
+      if (matches === 0) {
+        throw new Error(
+          `add_comment: anchorText "${anchorText}" not found in document`,
+        );
+      }
+    }
+
+    const updated = addHtmlComment(baseDoc, {
+      id,
+      anchor: { text: anchorText, occurrence },
+      author,
+      createdAt,
+      body,
+    });
+
+    const reSanitized = sanitizeAnnotatedHtml(updated.source);
+    fs.writeFileSync(documentPath, reSanitized.html);
+    const finalDoc = parseAnnotatedHtml(reSanitized.html);
+    return {
+      documentPath,
+      commentId: id,
+      checksum: contentChecksum(reSanitized.html),
+      sanitizerWarnings: reSanitized.warnings,
+      summary: {
+        comments: finalDoc.comments.length,
+        suggestions: finalDoc.suggestions.length,
+      },
+      warnings: finalDoc.warnings,
+    };
+  }
+
+  if (name === "roughdraft_accept_suggestion") {
+    const documentPath = requireHtmlPath(args);
+    const id = requireString(args, "id");
+    const raw = fs.readFileSync(documentPath, "utf8");
+    const sanitized = sanitizeAnnotatedHtml(raw);
+    const baseDoc = parseAnnotatedHtml(sanitized.html);
+    let updated: ReturnType<typeof acceptHtmlSuggestion>;
+    try {
+      updated = acceptHtmlSuggestion(baseDoc, { id });
+    } catch {
+      throw new Error(
+        `accept_suggestion: suggestion id "${id}" not found in ${documentPath}`,
+      );
+    }
+    const reSanitized = sanitizeAnnotatedHtml(updated.source);
+    fs.writeFileSync(documentPath, reSanitized.html);
+    const finalDoc = parseAnnotatedHtml(reSanitized.html);
+    return {
+      documentPath,
+      suggestionId: id,
+      action: "accepted",
+      checksum: contentChecksum(reSanitized.html),
+      sanitizerWarnings: reSanitized.warnings,
+      summary: {
+        comments: finalDoc.comments.length,
+        suggestions: finalDoc.suggestions.length,
+      },
+    };
+  }
+
+  if (name === "roughdraft_reject_suggestion") {
+    const documentPath = requireHtmlPath(args);
+    const id = requireString(args, "id");
+    const raw = fs.readFileSync(documentPath, "utf8");
+    const sanitized = sanitizeAnnotatedHtml(raw);
+    const baseDoc = parseAnnotatedHtml(sanitized.html);
+    let updated: ReturnType<typeof rejectHtmlSuggestion>;
+    try {
+      updated = rejectHtmlSuggestion(baseDoc, { id });
+    } catch {
+      throw new Error(
+        `reject_suggestion: suggestion id "${id}" not found in ${documentPath}`,
+      );
+    }
+    const reSanitized = sanitizeAnnotatedHtml(updated.source);
+    fs.writeFileSync(documentPath, reSanitized.html);
+    const finalDoc = parseAnnotatedHtml(reSanitized.html);
+    return {
+      documentPath,
+      suggestionId: id,
+      action: "rejected",
+      checksum: contentChecksum(reSanitized.html),
+      sanitizerWarnings: reSanitized.warnings,
+      summary: {
+        comments: finalDoc.comments.length,
+        suggestions: finalDoc.suggestions.length,
+      },
+    };
+  }
+
   if (name === "roughdraft_mark_resolved") {
     const documentPath = requireDocumentPath(args);
     const targetId = requireString(args, "targetId");
@@ -355,6 +560,67 @@ function requireDocumentPath(args: Record<string, unknown>): string {
     throw new Error(`Markdown file not found: ${absolutePath}`);
   }
   return absolutePath;
+}
+
+function requireHtmlPath(args: Record<string, unknown>): string {
+  const documentPath = requireString(args, "documentPath");
+  const projectRoot =
+    typeof args.projectRoot === "string" && args.projectRoot.trim().length > 0
+      ? path.resolve(args.projectRoot)
+      : null;
+  const absolutePath = projectRoot
+    ? path.resolve(projectRoot, documentPath)
+    : path.resolve(documentPath);
+
+  if (projectRoot) {
+    const rel = path.relative(projectRoot, absolutePath);
+    if (rel.startsWith("..") || path.isAbsolute(rel)) {
+      throw new Error(
+        `Document path is outside the configured projectRoot: ${absolutePath}`,
+      );
+    }
+  }
+
+  if (!/\.html?$/i.test(absolutePath)) {
+    throw new Error(
+      `Roughdraft can only read .html or .htm files: ${absolutePath}`,
+    );
+  }
+  if (!fs.existsSync(absolutePath) || !fs.statSync(absolutePath).isFile()) {
+    throw new Error(`HTML file not found: ${absolutePath}`);
+  }
+  return absolutePath;
+}
+
+function contentChecksum(content: string): string {
+  return `sha256:${crypto.createHash("sha256").update(content, "utf8").digest("hex")}`;
+}
+
+function countPlainTextOccurrences(source: string, target: string): number {
+  if (target.length === 0) return 0;
+  let count = 0;
+  let cursor = 0;
+  let inTag = false;
+  while (cursor < source.length) {
+    const ch = source[cursor];
+    if (inTag) {
+      if (ch === ">") inTag = false;
+      cursor += 1;
+      continue;
+    }
+    if (ch === "<") {
+      inTag = true;
+      cursor += 1;
+      continue;
+    }
+    if (source.startsWith(target, cursor)) {
+      count += 1;
+      cursor += target.length;
+      continue;
+    }
+    cursor += 1;
+  }
+  return count;
 }
 
 function requireString(args: Record<string, unknown>, key: string): string {

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -31,7 +31,7 @@ console.log(`Using app port ${appPort}.`);
 console.log(`Using API port ${apiPort}.`);
 console.log(`Open Roughdraft in dev at http://localhost:${appPort}`);
 console.log(
-  `Open files directly with http://localhost:${appPort}/?path=/absolute/path/to/file.md`,
+  `Open files directly with http://localhost:${appPort}/?path=/absolute/path/to/file.md or .html`,
 );
 console.log(
   `API port ${apiPort} is internal; don't use it as the browser URL.`,

--- a/scripts/mcp-html-evidence.mjs
+++ b/scripts/mcp-html-evidence.mjs
@@ -1,0 +1,421 @@
+#!/usr/bin/env node
+/**
+ * Drive the stdio MCP server end-to-end against a fresh scratch HTML fixture
+ * to produce real JSON-RPC evidence under .context/mcp-evidence/.
+ *
+ * Steps:
+ *   1) initialize
+ *   2) tools/list
+ *   3) read_html_document
+ *   4) add_comment
+ *   5) accept_suggestion
+ *   6) reject_suggestion on a second suggestion
+ *   7) re-read
+ *
+ * Evidence emitted:
+ *   .context/mcp-evidence/G6.1-read-html-document.json
+ *   .context/mcp-evidence/G6.2-add-comment.json
+ *   .context/mcp-evidence/G6.3-accept-suggestion.json
+ *   .context/mcp-evidence/G6.3-reject-suggestion.json
+ *   .context/mcp-evidence/G6.4-agent-flow.transcript.md
+ *   .context/mcp-evidence/G6.4-fixture-before.html
+ *   .context/mcp-evidence/G6.4-fixture-after.html
+ *   .context/mcp-evidence/G6.4-fixture.diff
+ */
+import { spawn } from "node:child_process";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const evidenceDir = path.join(repoRoot, ".context", "mcp-evidence");
+fs.mkdirSync(evidenceDir, { recursive: true });
+
+const cliPath = path.join(
+  repoRoot,
+  "packages",
+  "server",
+  "bin",
+  "roughdraft.mjs",
+);
+
+const scratchDir = fs.mkdtempSync(
+  path.join(os.tmpdir(), "roughdraft-mcp-evidence-"),
+);
+const docPath = path.join(scratchDir, "scratch.html");
+
+const FIXTURE = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Scratch evidence fixture</title>
+  </head>
+  <body>
+    <article>
+      <h1>Quarterly review</h1>
+      <p>Revenue grew steadily.</p>
+      <p>
+        Churn was
+        <del data-rd-suggestion-id="s-churn-1" data-rd-author="r@x" data-rd-created-at="2026-05-23T12:01:00Z">high</del><ins data-rd-suggestion-id="s-churn-1" data-rd-author="r@x" data-rd-created-at="2026-05-23T12:01:00Z">elevated but stable</ins>
+        in the SMB segment.
+      </p>
+      <p>
+        Pipeline coverage improved to
+        <ins data-rd-suggestion-id="s-pipe-1" data-rd-author="r@x" data-rd-created-at="2026-05-23T12:02:00Z">2.4x</ins>
+        for the next quarter.
+      </p>
+    </article>
+    <aside class="rd-review" hidden>
+    </aside>
+  </body>
+</html>
+`;
+
+fs.writeFileSync(docPath, FIXTURE);
+fs.writeFileSync(
+  path.join(evidenceDir, "G6.4-fixture-before.html"),
+  fs.readFileSync(docPath, "utf8"),
+);
+
+const child = spawn(process.execPath, [cliPath, "mcp"], {
+  cwd: scratchDir,
+  stdio: ["pipe", "pipe", "pipe"],
+});
+
+let buffer = Buffer.alloc(0);
+const pending = new Map();
+let nextId = 1;
+
+child.stderr.on("data", (chunk) => {
+  process.stderr.write(chunk);
+});
+
+child.stdout.on("data", (chunk) => {
+  buffer = Buffer.concat([buffer, chunk]);
+  while (true) {
+    const headerEnd = buffer.indexOf("\r\n\r\n");
+    if (headerEnd === -1) break;
+    const header = buffer.subarray(0, headerEnd).toString("utf8");
+    const lenMatch = header.match(/content-length:\s*(\d+)/i);
+    if (!lenMatch) {
+      console.error("Bad header:", header);
+      process.exit(1);
+    }
+    const length = Number.parseInt(lenMatch[1], 10);
+    const bodyStart = headerEnd + 4;
+    const bodyEnd = bodyStart + length;
+    if (buffer.length < bodyEnd) break;
+    const body = buffer.subarray(bodyStart, bodyEnd).toString("utf8");
+    buffer = buffer.subarray(bodyEnd);
+    const message = JSON.parse(body);
+    const resolver = pending.get(message.id);
+    if (resolver) {
+      pending.delete(message.id);
+      resolver(message);
+    }
+  }
+});
+
+function send(method, params) {
+  const id = nextId++;
+  const message = { jsonrpc: "2.0", id, method, params };
+  const body = Buffer.from(JSON.stringify(message), "utf8");
+  child.stdin.write(`Content-Length: ${body.byteLength}\r\n\r\n`);
+  child.stdin.write(body);
+  return new Promise((resolve) => {
+    pending.set(id, resolve);
+  });
+}
+
+function unwrapResult(response) {
+  const text = response.result?.content?.[0]?.text;
+  if (typeof text !== "string") return response.result;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+const transcript = [];
+
+function record(label, request, response, extra = {}) {
+  transcript.push({
+    label,
+    timestamp: new Date().toISOString(),
+    request,
+    response,
+    ...extra,
+  });
+}
+
+try {
+  const initRequest = {
+    method: "initialize",
+    params: { protocolVersion: "2025-06-18", capabilities: {} },
+  };
+  const initResponse = await send(initRequest.method, initRequest.params);
+  record("initialize", initRequest, initResponse);
+
+  const listRequest = { method: "tools/list", params: {} };
+  const listResponse = await send(listRequest.method, listRequest.params);
+  record("tools/list", listRequest, listResponse, {
+    toolCount: listResponse.result?.tools?.length,
+    htmlToolNames: (listResponse.result?.tools ?? [])
+      .map((t) => t.name)
+      .filter(
+        (n) =>
+          n.startsWith("roughdraft_") &&
+          (n.includes("html") ||
+            n.includes("comment") ||
+            n.includes("suggestion")),
+      ),
+  });
+
+  // Step 1: read_html_document
+  const readArgs = { documentPath: docPath, projectRoot: scratchDir };
+  const readRequest = {
+    method: "tools/call",
+    params: { name: "roughdraft_read_html_document", arguments: readArgs },
+  };
+  const readResponse = await send(readRequest.method, readRequest.params);
+  const readResult = unwrapResult(readResponse);
+  record("read_html_document (initial)", readRequest, readResponse, {
+    parsed: {
+      checksum: readResult?.checksum,
+      commentCount: readResult?.document?.comments?.length,
+      suggestionCount: readResult?.document?.suggestions?.length,
+    },
+  });
+  fs.writeFileSync(
+    path.join(evidenceDir, "G6.1-read-html-document.json"),
+    JSON.stringify(
+      { request: readRequest, response: readResponse, parsed: readResult },
+      null,
+      2,
+    ),
+  );
+
+  // Step 2: add_comment
+  const addArgs = {
+    documentPath: docPath,
+    projectRoot: scratchDir,
+    id: "c-evidence-1",
+    anchorText: "Revenue grew steadily",
+    author: "agent@example.com",
+    createdAt: "2026-05-23T19:00:00Z",
+    body: "Add the exact percentage and source row.",
+  };
+  const addRequest = {
+    method: "tools/call",
+    params: { name: "roughdraft_add_comment", arguments: addArgs },
+  };
+  const addResponse = await send(addRequest.method, addRequest.params);
+  const addResult = unwrapResult(addResponse);
+  record("add_comment", addRequest, addResponse, { parsed: addResult });
+  fs.writeFileSync(
+    path.join(evidenceDir, "G6.2-add-comment.json"),
+    JSON.stringify(
+      { request: addRequest, response: addResponse, parsed: addResult },
+      null,
+      2,
+    ),
+  );
+
+  // Step 3: accept_suggestion (substitution)
+  const acceptArgs = {
+    documentPath: docPath,
+    projectRoot: scratchDir,
+    id: "s-churn-1",
+  };
+  const acceptRequest = {
+    method: "tools/call",
+    params: { name: "roughdraft_accept_suggestion", arguments: acceptArgs },
+  };
+  const acceptResponse = await send(acceptRequest.method, acceptRequest.params);
+  const acceptResult = unwrapResult(acceptResponse);
+  record("accept_suggestion", acceptRequest, acceptResponse, {
+    parsed: acceptResult,
+  });
+  fs.writeFileSync(
+    path.join(evidenceDir, "G6.3-accept-suggestion.json"),
+    JSON.stringify(
+      {
+        request: acceptRequest,
+        response: acceptResponse,
+        parsed: acceptResult,
+      },
+      null,
+      2,
+    ),
+  );
+
+  // Step 4: reject_suggestion (insertion)
+  const rejectArgs = {
+    documentPath: docPath,
+    projectRoot: scratchDir,
+    id: "s-pipe-1",
+  };
+  const rejectRequest = {
+    method: "tools/call",
+    params: { name: "roughdraft_reject_suggestion", arguments: rejectArgs },
+  };
+  const rejectResponse = await send(rejectRequest.method, rejectRequest.params);
+  const rejectResult = unwrapResult(rejectResponse);
+  record("reject_suggestion", rejectRequest, rejectResponse, {
+    parsed: rejectResult,
+  });
+  fs.writeFileSync(
+    path.join(evidenceDir, "G6.3-reject-suggestion.json"),
+    JSON.stringify(
+      {
+        request: rejectRequest,
+        response: rejectResponse,
+        parsed: rejectResult,
+      },
+      null,
+      2,
+    ),
+  );
+
+  // Step 5: re-read
+  const rereadRequest = {
+    method: "tools/call",
+    params: { name: "roughdraft_read_html_document", arguments: readArgs },
+  };
+  const rereadResponse = await send(rereadRequest.method, rereadRequest.params);
+  const rereadResult = unwrapResult(rereadResponse);
+  record("read_html_document (final)", rereadRequest, rereadResponse, {
+    parsed: {
+      checksum: rereadResult?.checksum,
+      commentCount: rereadResult?.document?.comments?.length,
+      suggestionCount: rereadResult?.document?.suggestions?.length,
+    },
+  });
+
+  // Capture after disk content and diff
+  fs.writeFileSync(
+    path.join(evidenceDir, "G6.4-fixture-after.html"),
+    fs.readFileSync(docPath, "utf8"),
+  );
+
+  let diff = "";
+  try {
+    const out = execFileSync(
+      "diff",
+      [
+        "-u",
+        path.join(evidenceDir, "G6.4-fixture-before.html"),
+        path.join(evidenceDir, "G6.4-fixture-after.html"),
+      ],
+      { encoding: "utf8" },
+    );
+    diff = out;
+  } catch (error) {
+    diff = error.stdout?.toString() ?? String(error);
+  }
+  fs.writeFileSync(path.join(evidenceDir, "G6.4-fixture.diff"), diff);
+
+  // Sanity check assertions
+  const finalDisk = fs.readFileSync(docPath, "utf8");
+  const assertions = [
+    {
+      name: "added comment id appears on disk",
+      ok: finalDisk.includes('data-rd-comment-ids="c-evidence-1"'),
+    },
+    {
+      name: "accepted substitution leaves ins text on disk",
+      ok:
+        finalDisk.includes("elevated but stable") &&
+        !finalDisk.includes('data-rd-suggestion-id="s-churn-1"'),
+    },
+    {
+      name: "rejected insertion removed from disk",
+      ok:
+        !finalDisk.includes('data-rd-suggestion-id="s-pipe-1"') &&
+        !finalDisk.includes("2.4x"),
+    },
+    {
+      name: "final re-read has 1 comment and 0 suggestions",
+      ok:
+        rereadResult?.document?.comments?.length === 1 &&
+        rereadResult?.document?.suggestions?.length === 0,
+    },
+  ];
+
+  const transcriptMd = [
+    "# G6.4 — Real MCP Agent Flow Transcript",
+    "",
+    `Captured: ${new Date().toISOString()}`,
+    "",
+    `Scratch fixture: \`${docPath}\``,
+    "",
+    "Flow: initialize → tools/list → read → add_comment → accept_suggestion → reject_suggestion → re-read",
+    "",
+    "## Steps",
+    "",
+    ...transcript.map((entry) => {
+      return [
+        `### ${entry.label} — ${entry.timestamp}`,
+        "",
+        "Request:",
+        "",
+        "```json",
+        JSON.stringify(entry.request, null, 2),
+        "```",
+        "",
+        "Response (unwrapped tool result if applicable):",
+        "",
+        "```json",
+        JSON.stringify(entry.response, null, 2),
+        "```",
+        "",
+        entry.parsed
+          ? [
+              "Parsed:",
+              "",
+              "```json",
+              JSON.stringify(entry.parsed, null, 2),
+              "```",
+              "",
+            ].join("\n")
+          : "",
+      ].join("\n");
+    }),
+    "",
+    "## Assertions",
+    "",
+    ...assertions.map((a) => `- ${a.ok ? "[x]" : "[ ]"} ${a.name}`),
+    "",
+    "## Disk diff (before → after)",
+    "",
+    "```diff",
+    diff,
+    "```",
+    "",
+  ].join("\n");
+
+  fs.writeFileSync(
+    path.join(evidenceDir, "G6.4-agent-flow.transcript.md"),
+    transcriptMd,
+  );
+
+  child.stdin.end();
+  child.kill("SIGTERM");
+
+  const failures = assertions.filter((a) => !a.ok);
+  if (failures.length > 0) {
+    console.error("Assertion failures:", failures);
+    process.exit(1);
+  }
+  console.log("MCP evidence captured under", evidenceDir);
+} catch (error) {
+  console.error("MCP evidence capture failed:", error);
+  child.kill("SIGTERM");
+  process.exit(1);
+} finally {
+  fs.rmSync(scratchDir, { recursive: true, force: true });
+}

--- a/scripts/prod-flow-screenshots.mjs
+++ b/scripts/prod-flow-screenshots.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/**
+ * Drive the production-built Roughdraft server through a real-user HTML
+ * review flow with a headless Chromium browser. Saves screenshots under
+ * .context/ui-state-screenshots/final-production-flow/ and asserts no
+ * console errors fire during the flow.
+ *
+ * The production server must be running at PROD_URL (default
+ * http://localhost:7375) with PROJECT_DIR set to the directory that contains
+ * the scratch HTML file at SCRATCH_FILE.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const baseUrl = process.env.PROD_URL ?? "http://localhost:7375";
+const projectDir = process.env.PROJECT_DIR ?? "/tmp/roughdraft-prod-test";
+const scratchFile =
+  process.env.SCRATCH_FILE ?? path.join(projectDir, "scratch.html");
+const outDir = path.join(
+  repoRoot,
+  ".context",
+  "ui-state-screenshots",
+  "final-production-flow",
+);
+fs.mkdirSync(outDir, { recursive: true });
+
+// Use a fixture that exercises both authoring and suggestion accept/reject in
+// the browser. This mirrors the e2e fixture from html-authoring.spec.ts and is
+// reset on every run so the test is deterministic.
+const SCRATCH_FIXTURE = `<!doctype html>
+<html lang="en">
+  <head><title>Production flow fixture</title></head>
+  <body>
+    <article>
+      <h1>Quarterly review</h1>
+      <p>We expanded the team in Berlin and Bangalore.</p>
+      <p>We shipped <ins data-rd-suggestion-id="s-ins" data-rd-author="reviewer@example.com" data-rd-created-at="2026-05-23T12:00:00Z" data-rd-status="open">three new</ins> features this week.</p>
+      <p>We will replace <del data-rd-suggestion-id="s-sub" data-rd-author="reviewer@example.com" data-rd-created-at="2026-05-23T12:01:00Z" data-rd-status="open">the legacy parser</del><ins data-rd-suggestion-id="s-sub" data-rd-author="reviewer@example.com" data-rd-created-at="2026-05-23T12:01:00Z" data-rd-status="open">the new streaming parser</ins> next sprint.</p>
+    </article>
+  </body>
+</html>
+`;
+fs.writeFileSync(scratchFile, SCRATCH_FIXTURE);
+
+const browser = await chromium.launch();
+const context = await browser.newContext({
+  viewport: { width: 1440, height: 900 },
+});
+const page = await context.newPage();
+
+const consoleErrors = [];
+const pageErrors = [];
+page.on("console", (msg) => {
+  if (msg.type() === "error") consoleErrors.push(msg.text());
+});
+page.on("response", async (response) => {
+  if (response.status() >= 400) {
+    consoleErrors.push(`HTTP ${response.status()} ${response.url()}`);
+  }
+});
+page.on("pageerror", (err) => pageErrors.push(err.message));
+
+const url = `${baseUrl}/?path=${encodeURIComponent(scratchFile)}`;
+console.log("Opening", url);
+async function waitForWorkspaceLoaded() {
+  await page.waitForFunction(
+    () => {
+      const el = document.querySelector(
+        '[data-testid="html-document-workspace"]',
+      );
+      return el && el.getAttribute("data-state") === "loaded";
+    },
+    { timeout: 15_000 },
+  );
+}
+
+await page.goto(url, { waitUntil: "domcontentloaded" });
+await waitForWorkspaceLoaded();
+await page.screenshot({
+  path: path.join(outDir, "01-html-doc-loaded.png"),
+  fullPage: true,
+});
+
+// Capture mobile viewport snapshot of the loaded doc.
+const mobilePage = await context.newPage();
+mobilePage.on("console", (msg) => {
+  if (msg.type() === "error") consoleErrors.push(`mobile: ${msg.text()}`);
+});
+await mobilePage.setViewportSize({ width: 414, height: 896 });
+await mobilePage.goto(url, { waitUntil: "domcontentloaded" });
+await mobilePage
+  .waitForFunction(
+    () => {
+      const el = document.querySelector(
+        '[data-testid="html-document-workspace"]',
+      );
+      return el && el.getAttribute("data-state") === "loaded";
+    },
+    { timeout: 15_000 },
+  )
+  .catch(() => {});
+await mobilePage.screenshot({
+  path: path.join(outDir, "02-html-doc-mobile.png"),
+  fullPage: true,
+});
+await mobilePage.close();
+
+// --- Step A: Add a comment via the UI ---
+await page.evaluate((targetText) => {
+  const root = document.querySelector('[data-testid="html-readonly-view"]');
+  if (!root) throw new Error("Could not find HTML readonly view");
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let node = walker.nextNode();
+  while (node) {
+    const index = node.textContent?.indexOf(targetText) ?? -1;
+    if (index >= 0) {
+      const range = document.createRange();
+      range.setStart(node, index);
+      range.setEnd(node, index + targetText.length);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      document.dispatchEvent(new Event("selectionchange", { bubbles: true }));
+      return;
+    }
+    node = walker.nextNode();
+  }
+  throw new Error(`Could not find text "${targetText}"`);
+}, "Berlin and Bangalore");
+
+await page.getByTestId("html-add-comment-button").click();
+await page.getByTestId("add-comment-composer").waitFor({ state: "visible" });
+await page
+  .getByTestId("add-comment-body")
+  .fill("Split by office in the next report.");
+await page.screenshot({
+  path: path.join(outDir, "03-add-comment-composer.png"),
+  fullPage: true,
+});
+await page.getByTestId("add-comment-save").click();
+await page.waitForFunction(
+  () => {
+    return (
+      document.querySelectorAll('[data-testid="html-review-card"]').length >= 1
+    );
+  },
+  { timeout: 10_000 },
+);
+await page.screenshot({
+  path: path.join(outDir, "04-comment-added.png"),
+  fullPage: true,
+});
+
+// --- Step B: Accept the substitution suggestion ---
+const acceptBtn = page.locator('[data-testid="suggestion-accept"]').first();
+await acceptBtn.click();
+await page
+  .waitForFunction(
+    () =>
+      (!document.body.innerHTML.includes('data-rd-suggestion-id="s-sub"') &&
+        !document.body.innerHTML.includes('data-rd-suggestion-id="s-ins"')) ||
+      document.querySelectorAll('[data-testid="suggestion-accept"]').length <
+        document.querySelectorAll('[data-testid="suggestion-reject"]').length +
+          1,
+    { timeout: 10_000 },
+  )
+  .catch(() => {});
+await page.screenshot({
+  path: path.join(outDir, "05-after-accept.png"),
+  fullPage: true,
+});
+
+// --- Step C: Reject remaining suggestion ---
+const rejectBtn = page.locator('[data-testid="suggestion-reject"]').first();
+if (await rejectBtn.count()) {
+  await rejectBtn.click();
+  await page.waitForTimeout(500);
+}
+await page.screenshot({
+  path: path.join(outDir, "06-after-reject.png"),
+  fullPage: true,
+});
+
+// --- Step D: Reload and verify disk persistence ---
+const afterActionsDisk = fs.readFileSync(scratchFile, "utf8");
+fs.writeFileSync(
+  path.join(outDir, "00-scratch-html-after-actions.html"),
+  afterActionsDisk,
+);
+
+const diskAssertions = [
+  {
+    name: "comment anchor persisted",
+    ok:
+      afterActionsDisk.includes("data-rd-comment-ids") &&
+      afterActionsDisk.includes("Split by office in the next report."),
+  },
+  {
+    name: "accepted substitution persisted",
+    ok:
+      afterActionsDisk.includes("the new streaming parser") &&
+      !afterActionsDisk.includes('data-rd-suggestion-id="s-sub"'),
+  },
+  {
+    name: "rejected insertion removed",
+    ok:
+      !afterActionsDisk.includes('data-rd-suggestion-id="s-ins"') &&
+      !afterActionsDisk.includes("three new"),
+  },
+];
+
+await page.goto(url, { waitUntil: "domcontentloaded" });
+await waitForWorkspaceLoaded();
+await page.screenshot({
+  path: path.join(outDir, "07-after-reload.png"),
+  fullPage: true,
+});
+
+const beforeBytes = SCRATCH_FIXTURE.length;
+
+const summary = {
+  baseUrl,
+  scratchFile,
+  beforeBytes,
+  afterBytes: afterActionsDisk.length,
+  diskAssertions,
+  consoleErrors,
+  pageErrors,
+  capturedAt: new Date().toISOString(),
+};
+fs.writeFileSync(
+  path.join(outDir, "summary.json"),
+  JSON.stringify(summary, null, 2),
+);
+
+await context.close();
+await browser.close();
+
+console.log("Screenshots written to", outDir);
+console.log("Console errors:", consoleErrors.length);
+console.log("Page errors:", pageErrors.length);
+const failedDiskAssertions = diskAssertions.filter(
+  (assertion) => !assertion.ok,
+);
+console.log(
+  "Disk assertions:",
+  `${diskAssertions.length - failedDiskAssertions.length}/${diskAssertions.length}`,
+);
+if (
+  consoleErrors.length > 0 ||
+  pageErrors.length > 0 ||
+  failedDiskAssertions.length > 0
+) {
+  console.error("Console errors:", consoleErrors);
+  console.error("Page errors:", pageErrors);
+  console.error("Failed disk assertions:", failedDiskAssertions);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Adds local-first HTML review MVP: open .html/.htm files, rendered HTML workspace, review rail, comments, accept/reject suggestions, and disk/reload persistence.
- Adds annotated HTML parse/serialize/sanitize/mutate support, server GET/PUT HTML backend, CLI HTML support, and HTML MCP tools.
- Adds Playwright smoke coverage, unit/integration tests, ADR, README docs, and evidence scripts.

## Verification
- PATH="/tmp/pnpm-bin:/home/ananth/.hermes/node/bin:$PATH" pnpm check ✅
- PATH="/tmp/pnpm-bin:/home/ananth/.hermes/node/bin:$PATH" pnpm test:smoke ✅ — 15/15 passed
- Claude Code user-acceptance flow ✅ — rendered HTML, added comment, accepted substitution, rejected insertion, reloaded from disk, 0 console/page errors

## Evidence
- Claude Code acceptance summary: .context/ui-state-screenshots/acceptance-20260524-091756/summary.json
- Screenshots: .context/ui-state-screenshots/acceptance-20260524-091756/*.png

Note: This PR is from Dab's fork because the current shell account has READ-only access to Lex-Inc/roughdraft.