### PR TITLE
fix(app): polish homepage and control labels

### DIFF
--- a/packages/app/e2e/homepage-storyboard.spec.ts
+++ b/packages/app/e2e/homepage-storyboard.spec.ts
@@ -119,6 +119,18 @@ test.describe("homepage workflow storyboard", () => {
     await expect(roughdraftPopup).toHaveAttribute("data-popup-visible", "true");
     await expect(roughdraftPopup).not.toHaveAttribute("aria-hidden", "true");
     await expect(
+      roughdraftPopup.getByTestId("homepage-workflow-popup-traffic-lights"),
+    ).toHaveCount(1);
+    await expect(
+      roughdraftPopup
+        .getByTestId("homepage-workflow-popup-traffic-lights")
+        .locator("span"),
+    ).toHaveCount(3);
+    await expect(roughdraftPopup.locator("> div").first()).toHaveCSS(
+      "background-color",
+      "rgb(255, 255, 255)",
+    );
+    await expect(
       storyboard.getByTestId("homepage-workflow-document-title"),
     ).toBeVisible();
     await expect(

--- a/packages/app/e2e/homepage-storyboard.spec.ts
+++ b/packages/app/e2e/homepage-storyboard.spec.ts
@@ -124,12 +124,11 @@ test.describe("homepage workflow storyboard", () => {
     await expect(
       roughdraftPopup
         .getByTestId("homepage-workflow-popup-traffic-lights")
-        .locator("span"),
+        .getByTestId("homepage-workflow-popup-traffic-light"),
     ).toHaveCount(3);
-    await expect(roughdraftPopup.locator("> div").first()).toHaveCSS(
-      "background-color",
-      "rgb(255, 255, 255)",
-    );
+    await expect(
+      roughdraftPopup.getByTestId("homepage-workflow-popup-header"),
+    ).toHaveCSS("background-color", "rgb(255, 255, 255)");
     await expect(
       storyboard.getByTestId("homepage-workflow-document-title"),
     ).toBeVisible();

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -919,9 +919,19 @@ function RoughdraftPopupMock({ workflowStage }: { workflowStage: number }) {
       data-popup-visible={visible ? "true" : "false"}
       data-testid="homepage-workflow-popup"
     >
-      <div className="flex h-10 items-center gap-1.5 border-b border-slate-200 px-4 text-xs font-bold text-stone-500 dark:border-slate-700 dark:text-slate-400 max-[520px]:px-3">
-        <FileText className="size-3.5" aria-hidden="true" />
-        homepage-conversion-plan.md
+      <div className="flex h-10 items-center justify-between gap-4 border-b border-slate-200 bg-white px-4 text-xs font-bold text-stone-500 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-400 max-[520px]:px-3">
+        <div
+          className="flex items-center gap-1.5"
+          aria-hidden="true"
+          data-testid="homepage-workflow-popup-traffic-lights"
+        >
+          <span className="inline-flex size-[0.65rem] rounded-full bg-rose-500" />
+          <span className="inline-flex size-[0.65rem] rounded-full bg-amber-400" />
+          <span className="inline-flex size-[0.65rem] rounded-full bg-emerald-500" />
+        </div>
+        <div className="flex min-w-0 items-center gap-1.5">
+          <FileText className="size-3.5 shrink-0" aria-hidden="true" />
+        </div>
       </div>
       <div
         className="relative min-h-[28rem] overflow-hidden bg-stone-50 p-4 [--homepage-workflow-document-offset-y:0rem] [--homepage-workflow-document-scale:1] dark:bg-slate-900 min-[780px]:min-h-[25.5rem] min-[780px]:[--homepage-workflow-document-scale:0.6] max-[899px]:min-h-[14.5rem] max-[899px]:p-2.5 max-[899px]:[--homepage-workflow-document-offset-y:clamp(1rem,5svh,2.75rem)] max-[899px]:[--homepage-workflow-document-scale:0.66] max-[520px]:p-3 max-[520px]:[--homepage-workflow-document-scale:0.6]"
@@ -937,12 +947,12 @@ function RoughdraftPopupMock({ workflowStage }: { workflowStage: number }) {
         >
           {showDoneButton ? (
             <Button
-              className="absolute top-3 right-3 z-[3] h-8 rounded-[7px] bg-black px-3 text-xs font-bold text-white shadow-[0_10px_28px_rgba(0,0,0,0.18)] hover:bg-black/85"
+              className="absolute top-3 right-3 z-[3] h-12 rounded-[7px] bg-black px-4.5 text-base font-bold text-white shadow-[0_10px_28px_rgba(0,0,0,0.18)] hover:bg-black/85"
               data-testid="homepage-workflow-handoff-button"
               type="button"
               size="sm"
             >
-              <Check className="size-4" aria-hidden="true" />
+              <Check className="size-6" aria-hidden="true" />
               I'm done
             </Button>
           ) : null}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -420,11 +420,11 @@ export function Homepage({
                 <DialogTrigger
                   render={
                     <Button
-                      className="h-14 gap-2 px-5 text-[clamp(1.25rem,1rem+0.6vw,1.5rem)]"
+                      className="h-14 cursor-pointer gap-2 px-5 text-[clamp(1.25rem,1rem+0.6vw,1.5rem)]"
                       data-testid="homepage-install-button"
                       size="lg"
                     >
-                      Install Now
+                      Install now
                     </Button>
                   }
                 />

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -919,15 +919,27 @@ function RoughdraftPopupMock({ workflowStage }: { workflowStage: number }) {
       data-popup-visible={visible ? "true" : "false"}
       data-testid="homepage-workflow-popup"
     >
-      <div className="flex h-10 items-center justify-between gap-4 border-b border-slate-200 bg-white px-4 text-xs font-bold text-stone-500 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-400 max-[520px]:px-3">
+      <div
+        className="flex h-10 items-center justify-between gap-4 border-b border-slate-200 bg-white px-4 text-xs font-bold text-stone-500 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-400 max-[520px]:px-3"
+        data-testid="homepage-workflow-popup-header"
+      >
         <div
           className="flex items-center gap-1.5"
           aria-hidden="true"
           data-testid="homepage-workflow-popup-traffic-lights"
         >
-          <span className="inline-flex size-[0.65rem] rounded-full bg-rose-500" />
-          <span className="inline-flex size-[0.65rem] rounded-full bg-amber-400" />
-          <span className="inline-flex size-[0.65rem] rounded-full bg-emerald-500" />
+          <span
+            className="inline-flex size-[0.65rem] rounded-full bg-rose-500"
+            data-testid="homepage-workflow-popup-traffic-light"
+          />
+          <span
+            className="inline-flex size-[0.65rem] rounded-full bg-amber-400"
+            data-testid="homepage-workflow-popup-traffic-light"
+          />
+          <span
+            className="inline-flex size-[0.65rem] rounded-full bg-emerald-500"
+            data-testid="homepage-workflow-popup-traffic-light"
+          />
         </div>
         <div className="flex min-w-0 items-center gap-1.5">
           <FileText className="size-3.5 shrink-0" aria-hidden="true" />

--- a/packages/app/src/CommentEditorList.tsx
+++ b/packages/app/src/CommentEditorList.tsx
@@ -360,33 +360,35 @@ function CommentActionButton({
   className?: string;
   onClick: (event: MouseEvent) => void;
 }) {
+  const button = (
+    <Button
+      type="button"
+      aria-label={compact ? label : undefined}
+      data-testid={testId}
+      variant="ghost"
+      size={compact ? "icon-xs" : "sm"}
+      className={cn(
+        compact
+          ? "rounded-full border border-transparent transition-colors duration-150"
+          : "h-7 rounded-full border border-transparent px-2.5 text-[11px] font-medium tracking-[0.08em] uppercase transition-colors duration-150",
+        tone === "danger"
+          ? "text-stone-400 hover:bg-rose-100 hover:text-rose-700 dark:text-stone-500 dark:hover:bg-rose-900/40 dark:hover:text-rose-400"
+          : "text-stone-400 hover:bg-[#DED8CE]/45 hover:text-stone-600 dark:text-stone-500 dark:hover:bg-slate-700 dark:hover:text-stone-300",
+        className,
+      )}
+      onPointerDown={(event) => event.stopPropagation()}
+      onClick={onClick}
+    >
+      {icon}
+      {compact ? null : <span>{label}</span>}
+    </Button>
+  );
+
+  if (!compact) return button;
+
   return (
     <Tooltip>
-      <TooltipTrigger
-        render={
-          <Button
-            type="button"
-            data-testid={testId}
-            variant="ghost"
-            size={compact ? "icon-xs" : "sm"}
-            className={cn(
-              compact
-                ? "rounded-full border border-transparent transition-colors duration-150"
-                : "h-7 rounded-full border border-transparent px-2.5 text-[11px] font-medium tracking-[0.08em] uppercase transition-colors duration-150",
-              tone === "danger"
-                ? "text-stone-400 hover:bg-rose-100 hover:text-rose-700 dark:text-stone-500 dark:hover:bg-rose-900/40 dark:hover:text-rose-400"
-                : "text-stone-400 hover:bg-[#DED8CE]/45 hover:text-stone-600 dark:text-stone-500 dark:hover:bg-slate-700 dark:hover:text-stone-300",
-              className,
-            )}
-          >
-            {icon}
-            {compact ? null : <span>{label}</span>}
-          </Button>
-        }
-        aria-label={label}
-        onPointerDown={(event) => event.stopPropagation()}
-        onClick={onClick}
-      />
+      <TooltipTrigger render={button} />
       <TooltipContent>{label}</TooltipContent>
     </Tooltip>
   );

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -15,11 +15,6 @@ import type { DocumentEditorViewMode } from "./app-navigation";
 import { RemoteSessionBanner } from "./components/RemoteSessionBanner";
 import { Button } from "./components/ui/button";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "./components/ui/popover";
-import {
   Select,
   SelectContent,
   SelectItem,
@@ -393,18 +388,6 @@ export function DocumentWorkspace({
       : reviewHandoffState === "error" || reviewHandoffState === "undelivered"
         ? AlertTriangle
         : CheckCheck;
-  const reviewHandoffStatusTitle =
-    reviewHandoffState === "undelivered"
-      ? "No agent is watching now"
-      : reviewHandoffState === "error"
-        ? "Could not notify agent"
-        : "Your agent is now working";
-  const reviewHandoffStatusBody =
-    reviewHandoffState === "undelivered"
-      ? "The handoff was not delivered because the watcher is no longer connected."
-      : reviewHandoffState === "error"
-        ? "Roughdraft could not send the handoff. Check that the local server is still running."
-        : "It will take the appropriate next action, including replying to comments, questions, and suggestions, and/or directly editing the doc.";
 
   return (
     <div
@@ -422,59 +405,30 @@ export function DocumentWorkspace({
         data-testid="document-status-stack"
         data-document-status-stack="true"
       >
-        {showReviewHandoffButton ? (
-          <Popover>
-            <PopoverTrigger
-              render={
-                <Button
-                  type="button"
-                  data-testid="review-handoff-button"
-                  size="lg"
-                  className="h-9 rounded-[7px] bg-black px-3 text-sm font-bold text-white shadow-[0_10px_28px_rgba(0,0,0,0.18)] hover:bg-black/85 focus-visible:ring-black/25 dark:bg-black dark:text-white dark:hover:bg-black/85 dark:focus-visible:ring-white/30"
-                  disabled={isReviewHandoffDisabled({
-                    saveState,
-                    documentDiskChangeState,
-                    reviewHandoffState,
-                  })}
-                  onClick={() => void handleCompleteReview()}
-                >
-                  <ReviewHandoffButtonIcon
-                    className={cn(
-                      "size-4",
-                      reviewHandoffState === "notifying" && "animate-spin",
-                    )}
-                  />
-                  {reviewHandoffButtonLabel}
-                </Button>
-              }
-            />
-            <PopoverContent
-              aria-label="Review handoff status"
-              data-testid="review-handoff-status"
+        <div className="flex max-w-full items-center justify-end gap-1.5">
+          {showReviewHandoffButton ? (
+            <Button
+              type="button"
+              data-testid="review-handoff-button"
+              size="lg"
+              className="h-9 rounded-[7px] bg-black px-3 text-sm font-bold text-white shadow-[0_10px_28px_rgba(0,0,0,0.18)] hover:bg-black/85 focus-visible:ring-black/25 dark:bg-black dark:text-white dark:hover:bg-black/85 dark:focus-visible:ring-white/30"
+              disabled={isReviewHandoffDisabled({
+                saveState,
+                documentDiskChangeState,
+                reviewHandoffState,
+              })}
+              onClick={() => void handleCompleteReview()}
             >
-              <div className="flex items-start gap-3">
-                <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-black text-white dark:bg-white dark:text-black">
-                  {reviewHandoffState === "notifying" ? (
-                    <Loader2 className="size-4 animate-spin" />
-                  ) : reviewHandoffState === "error" ||
-                    reviewHandoffState === "undelivered" ? (
-                    <AlertTriangle className="size-4" />
-                  ) : (
-                    <CheckCheck className="size-4" />
-                  )}
-                </span>
-                <div>
-                  <div className="text-sm font-semibold text-stone-950 dark:text-slate-50">
-                    {reviewHandoffStatusTitle}
-                  </div>
-                  <p className="mt-1 text-sm leading-6 text-stone-600 dark:text-slate-300">
-                    {reviewHandoffStatusBody}
-                  </p>
-                </div>
-              </div>
-            </PopoverContent>
-          </Popover>
-        ) : null}
+              <ReviewHandoffButtonIcon
+                className={cn(
+                  "size-4",
+                  reviewHandoffState === "notifying" && "animate-spin",
+                )}
+              />
+              {reviewHandoffButtonLabel}
+            </Button>
+          ) : null}
+        </div>
         {documentPage ? (
           <DocumentSaveStatusIndicator
             saveState={saveState}
@@ -599,37 +553,7 @@ export function DocumentWorkspace({
                 >
                   {documentFilenameLabel}
                 </div>
-                {activeDocumentPath ? (
-                  <div className="ml-auto flex shrink-0 items-center gap-1.5">
-                    {reviewHandoffState !== "notified" &&
-                    (reviewHandoffState !== "idle" ||
-                      reviewWatcherCount > 0) ? (
-                      <span
-                        role="status"
-                        aria-label="Review handoff"
-                        className="inline-flex shrink-0 items-center gap-1 font-mono text-[0.6rem] tracking-[0.01em] text-stone-400 dark:text-stone-500"
-                      >
-                        {reviewHandoffState === "notifying" ? (
-                          <Loader2 className="size-[0.6rem] animate-spin" />
-                        ) : reviewHandoffState === "error" ||
-                          reviewHandoffState === "undelivered" ? (
-                          <AlertTriangle className="size-[0.6rem]" />
-                        ) : reviewWatcherCount > 0 ? (
-                          <CheckCheck className="size-[0.6rem]" />
-                        ) : (
-                          <CheckCheck className="size-[0.6rem]" />
-                        )}
-                        {reviewHandoffState === "notifying"
-                          ? "Notifying"
-                          : reviewHandoffState === "error" ||
-                              reviewHandoffState === "undelivered"
-                            ? "Review not sent"
-                            : "Agent watching"}
-                      </span>
-                    ) : null}
-                  </div>
-                ) : null}
-                <div className="inline-flex h-[1.25rem] shrink-0 items-center">
+                <div className="ml-auto inline-flex h-[1.25rem] shrink-0 items-center">
                   <Select<DocumentInteractionMode>
                     value={documentInteractionMode}
                     onValueChange={(value) => {

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -301,7 +301,9 @@ describe("Homepage", () => {
       container,
       "homepage-install-button",
     );
+    expect(cta.textContent).toBe("Install now");
     expect(cta.className).toContain("h-14");
+    expect(cta.className).toContain("cursor-pointer");
     expect(cta.className).toContain("px-5");
     expect(cta.className).toContain("text-[clamp(");
     const githubLink = container.querySelector(

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -436,6 +436,10 @@ describe("Homepage", () => {
       storyboard.querySelectorAll('[data-testid="homepage-workflow-popup"]'),
     ).toHaveLength(1);
     expect(
+      getByTestId(storyboard, "homepage-workflow-popup-traffic-lights")
+        .children,
+    ).toHaveLength(3);
+    expect(
       getByTestId(storyboard, "homepage-workflow-popup").getAttribute(
         "data-popup-visible",
       ),

--- a/packages/app/test/view-toggle-bugs.test.tsx
+++ b/packages/app/test/view-toggle-bugs.test.tsx
@@ -592,7 +592,8 @@ describe("review handoff watcher affordance", () => {
       "review-handoff-button",
     );
     expect(doneReviewingButton).toBeDefined();
-    expect(container.textContent).toContain("Agent watching");
+    expect(container.textContent).not.toContain("Agent waiting");
+    expect(queryByTestId(container, "review-handoff-status")).toBeNull();
 
     if (!doneReviewingButton) {
       throw new Error("I'm done button not found");
@@ -601,6 +602,7 @@ describe("review handoff watcher affordance", () => {
 
     expect(onCompleteReview).toHaveBeenCalledOnce();
     expect(container.textContent).toContain("Sent");
+    expect(queryByTestId(container, "review-handoff-status")).toBeNull();
     expect(container.textContent).not.toContain("Agent notified");
     expect(container.textContent).not.toContain("Review ready");
     expect(container.textContent).not.toContain("Copy prompt");


### PR DESCRIPTION
## Summary

The homepage storyboard popup now reads more like the real Roughdraft window, with traffic-light chrome, a larger handoff button, and a polished install CTA.

The main document interface no longer shows redundant popovers or visible watcher labels for controls that already have text; only icon-only comment actions keep tooltips. The document mode selector is anchored back to the right edge of the page header.

## Test Plan

- `pnpm check`
- `pnpm test:smoke`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
