### PR TITLE
fix: respect the default browser for open

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,32 @@ Prefer the fastest test that remains predictive. Escalate to integration or e2e 
 
 When the user asks you to fix something, first have a subagent reproduce the bug with a failing test case before implementing the fix. The subagent should focus on the smallest behavioral test that demonstrates the problem, and should report the failing command, changed test files, and why the failure captures the requested bug.
 
+### Prove It Pattern
+
+For every bug fix:
+
+1. Reproduce the failure before changing production code. Prefer the smallest automated test that exercises the actual buggy path and fails for the reported behavior.
+2. If the bug crosses a boundary such as the OS, browser, CLI subprocess, filesystem watcher, network, or a third-party tool, also run a realistic command or flow that exercises that boundary. A mocked unit test can cover branching logic, but it does not prove the external command syntax, output shape, permissions, launch behavior, or integration contract.
+3. Implement the fix.
+4. Rerun the failing test or realistic reproduction and confirm it now passes.
+5. Run the narrow relevant test command first, then the broader check when the change is broad enough to justify it.
+
+If a realistic reproduction is infeasible, document why before proceeding and include the remaining verification gap in the final summary.
+
+### Realistic Verification Before Handoff
+
+Before asking the user to test or review a change, verify the riskiest changed behavior with the most realistic feasible check:
+
+- For CLI behavior, run the actual worktree CLI or the exact subprocess command it will invoke.
+- For browser behavior, open the affected route in a real browser automation flow when possible.
+- For OS integration, run the target OS command directly and inspect its real output.
+- For file-backed behavior, exercise the real file path, watcher, or save/load cycle.
+- For external APIs or libraries, verify against official docs or a real local integration point rather than only mocked assumptions.
+
+Mocked tests are still useful, but they are not a substitute when the boundary itself is the product behavior.
+
+In the final response, list the verification commands run, what each proved, and any residual realism gap.
+
 ## Slog Default
 
 This repo vendors the `slog` skill at `.codex/skills/slog`.

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createApp } from "./index";
 import {
   createCliDependencies,
+  createDefaultOpenUrl,
   ensureServerRunning,
   getServerStateFilePath,
   runCli,
@@ -381,6 +382,145 @@ describe("cli", () => {
       ),
     });
     expect(lastOpenedUrl).toBeNull();
+  });
+
+  it("opens the default browser on macOS when Chrome is installed but not the default browser", () => {
+    const opened: Array<{ command: string; args: string[] }> = [];
+    const openUrl = createDefaultOpenUrl({
+      env: {},
+      platform: "darwin",
+      spawnSyncCommand: (command, args) => {
+        if (command === "plutil") {
+          expect(args?.join(" ")).toContain(
+            "com.apple.launchservices.secure.plist",
+          );
+          return {
+            status: 0,
+            stdout: JSON.stringify([
+              {
+                LSHandlerURLScheme: "http",
+                LSHandlerRoleAll: "com.apple.Safari",
+              },
+            ]),
+          } as ReturnType<typeof import("node:child_process").spawnSync>;
+        }
+
+        if (command === "open" && args?.[0] === "-Ra") {
+          return {
+            status: 0,
+            stdout: "",
+          } as ReturnType<typeof import("node:child_process").spawnSync>;
+        }
+
+        throw new Error(`unexpected spawnSync command ${command}`);
+      },
+      openDetachedCommand: (command, args) => {
+        opened.push({ command, args });
+      },
+    });
+
+    const mode = openUrl("http://localhost:4020/?file=draft.md");
+
+    expect(mode).toBe("browser");
+    expect(opened).toEqual([
+      { command: "open", args: ["http://localhost:4020/?file=draft.md"] },
+    ]);
+  });
+
+  it("opens a Chrome app window on macOS when Chrome is the default browser", () => {
+    const opened: Array<{ command: string; args: string[] }> = [];
+    const openUrl = createDefaultOpenUrl({
+      env: {},
+      platform: "darwin",
+      spawnSyncCommand: (command, args) => {
+        if (command === "plutil") {
+          return {
+            status: 0,
+            stdout: JSON.stringify([
+              {
+                LSHandlerURLScheme: "http",
+                LSHandlerRoleAll: "com.google.Chrome",
+              },
+            ]),
+          } as ReturnType<typeof import("node:child_process").spawnSync>;
+        }
+
+        if (command === "open" && args?.[0] === "-Ra") {
+          return {
+            status: 0,
+            stdout: "",
+          } as ReturnType<typeof import("node:child_process").spawnSync>;
+        }
+
+        throw new Error(`unexpected spawnSync command ${command}`);
+      },
+      openDetachedCommand: (command, args) => {
+        opened.push({ command, args });
+      },
+    });
+
+    const mode = openUrl("http://localhost:4020/?file=draft.md");
+
+    expect(mode).toBe("chrome-app");
+    expect(opened).toEqual([
+      {
+        command: "open",
+        args: [
+          "-na",
+          "Google Chrome",
+          "--args",
+          "--app=http://localhost:4020/?file=draft.md",
+        ],
+      },
+    ]);
+  });
+
+  it("opens the default browser on Windows without macOS browser detection", () => {
+    const opened: Array<{ command: string; args: string[] }> = [];
+    const openUrl = createDefaultOpenUrl({
+      env: {},
+      platform: "win32",
+      spawnSyncCommand: () => {
+        throw new Error("macOS browser detection should not run on Windows");
+      },
+      openDetachedCommand: (command, args) => {
+        opened.push({ command, args });
+      },
+    });
+
+    const mode = openUrl("http://localhost:4020/?file=draft.md");
+
+    expect(mode).toBe("browser");
+    expect(opened).toEqual([
+      {
+        command: "cmd",
+        args: ["/c", "start", "", "http://localhost:4020/?file=draft.md"],
+      },
+    ]);
+  });
+
+  it("opens the default browser on Linux without macOS browser detection", () => {
+    const opened: Array<{ command: string; args: string[] }> = [];
+    const openUrl = createDefaultOpenUrl({
+      env: {},
+      platform: "linux",
+      spawnSyncCommand: () => {
+        throw new Error("macOS browser detection should not run on Linux");
+      },
+      openDetachedCommand: (command, args) => {
+        opened.push({ command, args });
+      },
+    });
+
+    const mode = openUrl("http://localhost:4020/?file=draft.md");
+
+    expect(mode).toBe("browser");
+    expect(opened).toEqual([
+      {
+        command: "xdg-open",
+        args: ["http://localhost:4020/?file=draft.md"],
+      },
+    ]);
   });
 
   it("prints only the document URL from open --print-url", async () => {

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -599,11 +599,18 @@ function suggestCommand(command: string): string | null {
   return suggestion && suggestion.distance <= 3 ? suggestion.candidate : null;
 }
 
-function hasChromeAppMode() {
-  if (process.platform !== "darwin") return false;
+type SpawnSyncCommand = typeof spawnSync;
+type OpenDetachedCommand = typeof openDetached;
+
+function hasChromeAppMode(
+  platform: NodeJS.Platform = process.platform,
+  spawnSyncCommand: SpawnSyncCommand = spawnSync,
+) {
+  if (platform !== "darwin") return false;
   return (
-    spawnSync("open", ["-Ra", "Google Chrome"], { stdio: "ignore" }).status ===
-    0
+    spawnSyncCommand("open", ["-Ra", "Google Chrome"], {
+      stdio: "ignore",
+    }).status === 0
   );
 }
 
@@ -616,32 +623,106 @@ function openDetached(command: string, args: string[]) {
   child.unref();
 }
 
+function resolveDefaultBrowserBundleId(
+  platform: NodeJS.Platform = process.platform,
+  spawnSyncCommand: SpawnSyncCommand = spawnSync,
+): string | null {
+  if (platform !== "darwin") return null;
+
+  const result = spawnSyncCommand(
+    "plutil",
+    [
+      "-extract",
+      "LSHandlers",
+      "json",
+      "-o",
+      "-",
+      path.join(
+        os.homedir(),
+        "Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist",
+      ),
+    ],
+    {
+      encoding: "utf8",
+      windowsHide: true,
+    },
+  );
+
+  if (result.status !== 0) return null;
+
+  try {
+    const handlers = JSON.parse(result.stdout) as Array<{
+      LSHandlerRoleAll?: string;
+      LSHandlerURLScheme?: string;
+    }>;
+    return (
+      handlers
+        .find((handler) => handler.LSHandlerURLScheme === "http")
+        ?.LSHandlerRoleAll?.trim()
+        .toLowerCase() ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+function isChromeBundleId(bundleId: string | null): boolean {
+  return bundleId === "com.google.chrome";
+}
+
+export function createDefaultOpenUrl({
+  env = process.env,
+  platform = process.platform,
+  spawnSyncCommand = spawnSync,
+  openDetachedCommand = openDetached,
+}: {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  spawnSyncCommand?: SpawnSyncCommand;
+  openDetachedCommand?: OpenDetachedCommand;
+} = {}): (url: string) => OpenMode {
+  return (url: string) => {
+    if (env.ROUGHDRAFT_NO_OPEN === "1") {
+      return "disabled";
+    }
+
+    if (
+      isChromeBundleId(
+        resolveDefaultBrowserBundleId(platform, spawnSyncCommand),
+      )
+    ) {
+      if (hasChromeAppMode(platform, spawnSyncCommand)) {
+        openDetachedCommand("open", [
+          "-na",
+          "Google Chrome",
+          "--args",
+          `--app=${url}`,
+        ]);
+        return "chrome-app";
+      }
+    }
+
+    if (platform === "darwin") {
+      openDetachedCommand("open", [url]);
+      return "browser";
+    }
+
+    if (platform === "linux") {
+      openDetachedCommand("xdg-open", [url]);
+      return "browser";
+    }
+
+    if (platform === "win32") {
+      openDetachedCommand("cmd", ["/c", "start", "", url]);
+      return "browser";
+    }
+
+    return "none";
+  };
+}
+
 function defaultOpenUrl(url: string): OpenMode {
-  if (process.env.ROUGHDRAFT_NO_OPEN === "1") {
-    return "disabled";
-  }
-
-  if (hasChromeAppMode()) {
-    openDetached("open", ["-na", "Google Chrome", "--args", `--app=${url}`]);
-    return "chrome-app";
-  }
-
-  if (process.platform === "darwin") {
-    openDetached("open", [url]);
-    return "browser";
-  }
-
-  if (process.platform === "linux") {
-    openDetached("xdg-open", [url]);
-    return "browser";
-  }
-
-  if (process.platform === "win32") {
-    openDetached("cmd", ["/c", "start", "", url]);
-    return "browser";
-  }
-
-  return "none";
+  return createDefaultOpenUrl()(url);
 }
 
 function defaultIsProcessRunning(pid: number): boolean {


### PR DESCRIPTION
## Summary

Roughdraft now respects the user's default browser instead of always preferring a Chrome app window when Chrome is installed. macOS users who choose Safari, Firefox, Helium, or another default browser get the normal default-browser launch path, while Chrome-default users keep the focused Chrome app window.

This also tightens the agent workflow instructions so future OS, browser, CLI, and subprocess fixes must be verified against the most realistic feasible boundary before handoff.

Fixes #84

## Verification

- `plutil -extract LSHandlers json -o - "$HOME/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist"` confirmed the real macOS HTTP handler output shape and current Chrome default.
- `roughdraft-dev-daegu-v4 open .context/default-browser-open-implementation-notes.md` opened in a Chrome app window with Chrome as the default browser.
- `pnpm --filter @roughdraft/server test -- cli.test.ts` covered macOS Chrome/default-browser behavior plus Windows and Linux launch branches.
- `pnpm check` passed lint, selector checks, unit tests, and build after rebasing on `origin/main`.

Residual realism gap: Windows and Linux launch behavior is covered by platform-injected unit tests from macOS; I did not run the actual `cmd /c start` or `xdg-open` commands on those operating systems.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
