### PR TITLE
feat: return overall handoff comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ Before finalizing test work, check that the tests are:
 
 Prefer the fastest test that remains predictive. Escalate to integration or e2e coverage when the boundary itself is the behavior under test, and make any meaningful tradeoff explicit in the final summary.
 
+`docs/solutions/` contains documented solutions to past problems, organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). It is relevant context when implementing, debugging, or choosing tests in documented areas.
+
 ## Bug Fix Workflow
 
 When the user asks you to fix something, first have a subagent reproduce the bug with a failing test case before implementing the fix. The subagent should focus on the smallest behavioral test that demonstrates the problem, and should report the failing command, changed test files, and why the failure captures the requested bug.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Agents can watch that handoff directly:
 roughdraft open ./path/to/my-essay/draft.md --json
 ```
 
-`roughdraft open` starts or reuses the local server, opens the document, registers a fresh watcher, blocks until the next `review.completed` event, then prints event JSON with the document path, file version, and feedback counts. By default there is no watch timeout; pass `--timeout <seconds>` when you want one. Use `--no-watch` when you only want to open the document and return immediately. If no watcher is active when you click **Done Reviewing**, Roughdraft shows a fallback prompt you can copy into the agent.
+`roughdraft open` starts or reuses the local server, opens the document, registers a fresh watcher, blocks until the next `review.completed` event, then prints event JSON with the document path, file version, feedback counts, and any optional `overallComment` you submit at handoff. By default there is no watch timeout; pass `--timeout <seconds>` when you want one. Use `--no-watch` when you only want to open the document and return immediately. If no watcher is active when you click **Done Reviewing**, Roughdraft shows a fallback prompt you can copy into the agent. Overall comments are returned in the handoff event and are not written to Markdown; inline feedback remains CriticMarkup in the document.
 
 Experimental MCP clients can start the stdio server with:
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Agents can watch that handoff directly:
 roughdraft open ./path/to/my-essay/draft.md --json
 ```
 
-`roughdraft open` starts or reuses the local server, opens the document, registers a fresh watcher, blocks until the next `review.completed` event, then prints event JSON with the document path, file version, feedback counts, and any optional `overallComment` you submit at handoff. By default there is no watch timeout; pass `--timeout <seconds>` when you want one. Use `--no-watch` when you only want to open the document and return immediately. If no watcher is active when you click **Done Reviewing**, Roughdraft shows a fallback prompt you can copy into the agent. Overall comments are returned in the handoff event and are not written to Markdown; inline feedback remains CriticMarkup in the document.
+`roughdraft open` starts or reuses the local server, opens the document, registers a fresh watcher, blocks until the next `review.completed` event, then prints event JSON with the document path, file version, feedback counts, and any optional `overallComment` you submit at handoff. By default there is no watch timeout; pass `--timeout <seconds>` when you want one. Use `--no-watch` when you only want to open the document and return immediately. If no watcher is active when you click **Done Reviewing**, Roughdraft shows a fallback prompt you can copy into the agent. Overall comments are written to Markdown as document-level YAML endmatter comments before the handoff event is emitted, so Markdown remains the durable source of truth.
 
 Experimental MCP clients can start the stdio server with:
 

--- a/docs/solutions/ui-bugs/verify-exact-ui-submit-path-for-cross-boundary-handoffs.md
+++ b/docs/solutions/ui-bugs/verify-exact-ui-submit-path-for-cross-boundary-handoffs.md
@@ -1,0 +1,98 @@
+---
+title: Verify Exact UI Submit Path For Cross-Boundary Handoffs
+date: 2026-05-24
+category: ui-bugs
+module: Roughdraft review handoff
+problem_type: ui_bug
+component: tooling
+symptoms:
+  - "Server tests passed, but a manually submitted overall handoff comment did not appear in the review event or Markdown file"
+  - "Typing in the handoff dropdown and clicking the primary I'm done button silently dropped the comment"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags: [handoff, e2e, ui-paths, markdown, review-events]
+---
+
+# Verify Exact UI Submit Path For Cross-Boundary Handoffs
+
+## Problem
+
+Roughdraft added support for overall handoff comments, first as `review.completed` event metadata and then as durable YAML endmatter comments. Server and parser tests passed, but a live review still lost the overall comment when the user typed it in the dropdown and clicked the primary **I'm done** button.
+
+The data crossed several boundaries: browser state, split-button UI behavior, API request body, server persistence, file versioning, event delivery, and Markdown reread. Tests that only covered the server POST path were not predictive enough.
+
+## Symptoms
+
+- `roughdraft open <file> --json` returned `review.completed` without `overallComment`.
+- The event summary still counted only the existing inline comment.
+- The Markdown file had no YAML `comments:` endmatter after Done Reviewing.
+- Direct server tests passed when `overallComment` was posted manually.
+
+## What Didn't Work
+
+- Testing only `/api/review-events` with an explicit `overallComment` proved server persistence but missed whether the UI sent the field.
+- Treating `overallComment` as event-only metadata made failed handoffs unrecoverable, because the Markdown file remained unchanged.
+- Verifying the dropdown submit button was not enough, because the real manual flow typed in the dropdown and then clicked the primary handoff button.
+
+## Solution
+
+Add an e2e regression that exercises the exact user path:
+
+1. Create a real Markdown file on disk.
+2. Open it through the app with a real local API server.
+3. Start a real review-event watcher.
+4. Open the handoff dropdown.
+5. Type an overall comment.
+6. Click the primary **I'm done** button.
+7. Verify the Markdown file now contains a document-level YAML `comments.cN.body` entry.
+8. Verify the event reflects the persisted comment.
+
+The fix was to pass the trimmed textarea value through the primary button path when present. The split control had two completion paths:
+
+```tsx
+// Broken: primary path ignored the textarea state.
+onClick={() => void handleCompleteReview()}
+```
+
+```tsx
+// Fixed: primary path forwards the draft overall comment when present.
+onClick={() =>
+  void handleCompleteReview(
+    trimmedOverallComment
+      ? { overallComment: trimmedOverallComment }
+      : undefined,
+  )
+}
+```
+
+The durable representation is a root document-level YAML comment:
+
+```yaml
+comments:
+  c2:
+    body: Please focus on the CLI contract first.
+    by: user
+    at: 2026-05-24T20:08:52.429Z
+```
+
+`body` without `re` represents document-level feedback. Inline comments still use anchored CriticMarkup, and replies still use `re`.
+
+## Why This Works
+
+The e2e test matches the real workflow that failed. It does not assume the API request is correct; it proves the browser control, API call, server write, filesystem state, and watcher response line up.
+
+Persisting the comment in Markdown also makes the file the source of truth. Even if a watcher misses event metadata, the next agent can recover the document-level comment by reading the file.
+
+## Prevention
+
+- When a feature crosses browser, API, CLI/watch, and filesystem boundaries, add one e2e test for the exact human workflow before calling the fix complete.
+- For split buttons, menus, keyboard shortcuts, and alternate submit controls, test every control that can complete the same action.
+- Prefer assertions against durable artifacts, such as the Markdown file, over event-only assertions when the product contract is file-backed.
+- If a user says they performed a step that tests say should work, trust the report and add a reproduction around the exact path they used.
+
+## Related Issues
+
+- New regression coverage: `packages/app/e2e/review-handoff.spec.ts`
+- Component coverage: `packages/app/test/view-toggle-bugs.test.tsx`
+- Runtime path involved: `packages/app/src/DocumentWorkspace.tsx`, `packages/server/src/index.ts`, `packages/rfm/src/index.ts`

--- a/docs/spec/ui-state-screenshot-guide.md
+++ b/docs/spec/ui-state-screenshot-guide.md
@@ -124,6 +124,7 @@ suggestions:
 | Document | Save conflict | Edit in browser, then modify file externally before autosave resolves | `file-conflict-notice`, `file-conflict-action-keep-editing` | Banner title: `Save conflict`; autosave pauses. |
 | Document | Autosave paused | Keep editing after conflict | `file-conflict-notice`, `file-conflict-action-overwrite` | Banner title: `Autosave paused`; no keep-editing action. |
 | Document | Review handoff idle | Open a local file while a watcher is connected | `review-handoff-button` | Header text: `Agent watching`. |
+| Document | Review handoff comment popover | Open a local file while a watcher is connected, then click the handoff dropdown trigger | `review-handoff-comment-trigger`, `review-handoff-comment-popover`, `review-handoff-overall-comment` | Capture the split handoff control and textarea before submission. |
 | Document | Review handoff sending | Click handoff button while watcher is connected | `review-handoff-button` | Button label: `Sending`. |
 | Document | Review handoff sent | Successful handoff | `review-handoff-status` | Popover title: `Your agent is now working`. |
 | Document | Review handoff undelivered | Watcher disconnects before handoff | `review-handoff-status` | Popover title: `No agent is watching now`. |

--- a/packages/app/e2e/review-handoff.spec.ts
+++ b/packages/app/e2e/review-handoff.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "@playwright/test";
+import {
+  createMarkdownProject,
+  openMarkdownFile,
+  readProjectFile,
+  removeMarkdownProject,
+  writeProjectFile,
+} from "./helpers";
+
+test.describe("review handoff", () => {
+  let projectDir: string;
+  let pendingWatch: Promise<unknown> | null = null;
+
+  test.beforeEach(() => {
+    projectDir = createMarkdownProject("review-handoff");
+    pendingWatch = null;
+  });
+
+  test.afterEach(async () => {
+    await pendingWatch?.catch(() => undefined);
+    removeMarkdownProject(projectDir);
+  });
+
+  test("persists an overall handoff comment from the primary done button to YAML endmatter @smoke", async ({
+    page,
+    request,
+  }) => {
+    const filePath = writeProjectFile(
+      projectDir,
+      "handoff-comment.md",
+      ["# Handoff Comment", "", "Review this document.", ""].join("\n"),
+    );
+    const relativePath = "handoff-comment.md";
+    const overallComment = "Please prioritize the CLI contract.";
+
+    pendingWatch = request.post("/api/review-events/watch", {
+      data: {
+        projectPath: projectDir,
+        path: relativePath,
+        timeoutSeconds: 10,
+      },
+    });
+
+    await openMarkdownFile(page, filePath);
+    await expect(page.getByTestId("review-handoff-button")).toBeVisible();
+
+    await page.getByTestId("review-handoff-comment-trigger").click();
+    await page
+      .getByTestId("review-handoff-overall-comment")
+      .fill(overallComment);
+    await page.getByTestId("review-handoff-button").click();
+
+    await expect(page.getByTestId("review-handoff-status")).toContainText(
+      "Your agent is now working",
+    );
+
+    await expect
+      .poll(() => readProjectFile(projectDir, relativePath))
+      .toMatch(
+        /---\ncomments:\n {2}c1:\n {4}body: Please prioritize the CLI contract\.\n {4}by: user\n {4}at: [^\n]+\n?$/,
+      );
+
+    const watchResponse = await pendingWatch;
+    const payload = await watchResponse.json();
+    expect(payload.events).toHaveLength(1);
+    expect(payload.events[0]).toMatchObject({
+      type: "review.completed",
+      overallComment,
+      summary: {
+        comments: 1,
+      },
+    });
+  });
+});

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -4,8 +4,8 @@ import {
   Check,
   CodeXml,
   Copy,
-  Eye,
   ExternalLink,
+  Eye,
   FileText,
   MessageSquare,
   PencilLine,
@@ -44,24 +44,25 @@ import {
   DialogTrigger,
 } from "./components/ui/dialog";
 import { DocumentWorkspace } from "./DocumentWorkspace";
+import { detectBackend } from "./detect-backend";
 import {
   getCommentAnchorMeasurements,
   groupCommentAnchorMeasurements,
   normalizeCommentMeasurement,
   resolveAnchoredRailLayouts,
 } from "./document-comments";
-import { detectBackend } from "./detect-backend";
+import { cn } from "./lib/utils";
 import type { DocumentSaveState } from "./PageCard";
 import { PreviewBackend } from "./preview-backend";
 import { RoughdraftFormatDemo } from "./RoughdraftFormatDemo";
 import {
+  type CompleteReviewOptions,
   MarkdownFileConflictError,
   type Page,
   type StorageBackend,
 } from "./storage";
 import { UpdateNotice } from "./UpdateNotice";
 import { fetchUpdateStatus, type UpdateStatus } from "./update-status";
-import { cn } from "./lib/utils";
 
 export type DocumentDiskChangeState =
   | "clean"
@@ -1436,11 +1437,14 @@ export function PreviewPage() {
     setPreviewForceResetKey(`preview-reset:${Date.now()}`);
   }, [backend]);
 
-  const handleCompletePreviewReview = useCallback(async () => {
-    return backend.completeReview
-      ? backend.completeReview(PREVIEW_DOCUMENT_PATH)
-      : { delivered: false };
-  }, [backend]);
+  const handleCompletePreviewReview = useCallback(
+    async (options?: CompleteReviewOptions) => {
+      return backend.completeReview
+        ? backend.completeReview(PREVIEW_DOCUMENT_PATH, options)
+        : { delivered: false };
+    },
+    [backend],
+  );
 
   return (
     <main className="relative flex h-screen min-w-0 flex-col overflow-hidden bg-[#FCFCFC] dark:bg-background text-slate-950 dark:text-slate-50">
@@ -1785,39 +1789,43 @@ export function App() {
     );
   }, [applyDocumentPage, handleDocumentSaveStateChange]);
 
-  const handleCompleteReview = useCallback(async () => {
-    const currentBackend = backendRef.current;
-    const currentPath = activeDocumentPathRef.current;
-    const currentDocument = documentPageRef.current;
-    if (!currentBackend || !currentPath || !currentDocument) {
-      return { delivered: false };
-    }
+  const handleCompleteReview = useCallback(
+    async (options?: CompleteReviewOptions) => {
+      const currentBackend = backendRef.current;
+      const currentPath = activeDocumentPathRef.current;
+      const currentDocument = documentPageRef.current;
+      if (!currentBackend || !currentPath || !currentDocument) {
+        return { delivered: false };
+      }
 
-    const content = documentDraftContentRef.current ?? currentDocument.content;
-    const expectedVersion = currentDocument.version;
-    const firstLine = content.split("\n")[0] || "";
-    const fallbackTitle =
-      currentDocument.id.split("/").at(-1) || currentDocument.id;
-    const title = firstLine.replace(/^#*\s*/, "") || fallbackTitle;
+      const content =
+        documentDraftContentRef.current ?? currentDocument.content;
+      const expectedVersion = currentDocument.version;
+      const firstLine = content.split("\n")[0] || "";
+      const fallbackTitle =
+        currentDocument.id.split("/").at(-1) || currentDocument.id;
+      const title = firstLine.replace(/^#*\s*/, "") || fallbackTitle;
 
-    const savedDocument = (await currentBackend.saveMarkdownFile(
-      currentPath,
-      content,
-      expectedVersion,
-    )) ?? {
-      ...currentDocument,
-      content,
-      title,
-    };
+      const savedDocument = (await currentBackend.saveMarkdownFile(
+        currentPath,
+        content,
+        expectedVersion,
+      )) ?? {
+        ...currentDocument,
+        content,
+        title,
+      };
 
-    applyDocumentPage(savedDocument);
-    documentDirtyRef.current = false;
-    setDocumentDiskChangeState("clean");
+      applyDocumentPage(savedDocument);
+      documentDirtyRef.current = false;
+      setDocumentDiskChangeState("clean");
 
-    return currentBackend.completeReview
-      ? currentBackend.completeReview(currentPath)
-      : { delivered: false };
-  }, [applyDocumentPage]);
+      return currentBackend.completeReview
+        ? currentBackend.completeReview(currentPath, options)
+        : { delivered: false };
+    },
+    [applyDocumentPage],
+  );
 
   useEffect(() => {
     if (!backend?.watchMarkdownFile || !activeDocumentPath) return;

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -2,6 +2,7 @@ import {
   AlertTriangle,
   Check,
   CheckCheck,
+  ChevronDown,
   CodeXml,
   Eye,
   Loader2,
@@ -15,6 +16,11 @@ import type { DocumentEditorViewMode } from "./app-navigation";
 import { RemoteSessionBanner } from "./components/RemoteSessionBanner";
 import { Button } from "./components/ui/button";
 import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "./components/ui/popover";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -22,6 +28,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "./components/ui/select";
+import { Textarea } from "./components/ui/textarea";
 import {
   Tooltip,
   TooltipContent,
@@ -35,7 +42,7 @@ import {
   type DocumentSaveState,
   PageCard,
 } from "./PageCard";
-import type { Page, StorageBackend } from "./storage";
+import type { CompleteReviewOptions, Page, StorageBackend } from "./storage";
 
 type DiskChangeState = "clean" | "changed" | "conflict" | "paused";
 type ReviewHandoffState =
@@ -206,7 +213,9 @@ interface DocumentWorkspaceProps {
   onReloadDocumentFromDisk: () => void | Promise<void>;
   onKeepEditingWithoutAutosave: () => void;
   onOverwriteDocumentOnDisk: () => void | Promise<void>;
-  onCompleteReview: () => Promise<{ delivered: boolean }>;
+  onCompleteReview: (
+    options?: CompleteReviewOptions,
+  ) => Promise<{ delivered: boolean }>;
   backend: StorageBackend | null;
 }
 
@@ -234,6 +243,9 @@ export function DocumentWorkspace({
   const [reviewHandoffState, setReviewHandoffState] =
     useState<ReviewHandoffState>("idle");
   const [reviewWatcherCount, setReviewWatcherCount] = useState(0);
+  const [reviewHandoffPopoverOpen, setReviewHandoffPopoverOpen] =
+    useState(false);
+  const [overallComment, setOverallComment] = useState("");
   const sawNoWatcherAfterNotifiedRef = useRef(false);
   const saveControllerRef = useRef<DocumentSaveController | null>(null);
 
@@ -339,24 +351,31 @@ export function DocumentWorkspace({
     };
   }, [documentDiskChangeState, documentPage]);
 
-  const handleCompleteReview = useCallback(async () => {
-    if (!activeDocumentPath || reviewHandoffState === "notifying") return;
+  const handleCompleteReview = useCallback(
+    async (options?: CompleteReviewOptions) => {
+      if (!activeDocumentPath || reviewHandoffState === "notifying") return;
 
-    setReviewHandoffState("notifying");
-    try {
-      const result = await onCompleteReview();
-      if (result.delivered) {
-        setReviewWatcherCount(0);
-        setReviewHandoffState("notified");
-      } else {
-        setReviewWatcherCount(0);
-        setReviewHandoffState("undelivered");
+      setReviewHandoffState("notifying");
+      try {
+        const result = await onCompleteReview(options);
+        if (result.delivered) {
+          setReviewWatcherCount(0);
+          setReviewHandoffState("notified");
+          setOverallComment("");
+          setReviewHandoffPopoverOpen(true);
+        } else {
+          setReviewWatcherCount(0);
+          setReviewHandoffState("undelivered");
+          setReviewHandoffPopoverOpen(true);
+        }
+      } catch (error) {
+        console.error("Failed to complete review:", error);
+        setReviewHandoffState("error");
+        setReviewHandoffPopoverOpen(true);
       }
-    } catch (error) {
-      console.error("Failed to complete review:", error);
-      setReviewHandoffState("error");
-    }
-  }, [activeDocumentPath, onCompleteReview, reviewHandoffState]);
+    },
+    [activeDocumentPath, onCompleteReview, reviewHandoffState],
+  );
 
   const editorViewModeToggleLabel =
     documentEditorViewMode === "rich-text"
@@ -388,6 +407,24 @@ export function DocumentWorkspace({
       : reviewHandoffState === "error" || reviewHandoffState === "undelivered"
         ? AlertTriangle
         : CheckCheck;
+  const reviewHandoffStatusTitle =
+    reviewHandoffState === "undelivered"
+      ? "No agent is watching now"
+      : reviewHandoffState === "error"
+        ? "Could not notify agent"
+        : "Your agent is now working";
+  const reviewHandoffStatusBody =
+    reviewHandoffState === "undelivered"
+      ? "The handoff was not delivered because the watcher is no longer connected."
+      : reviewHandoffState === "error"
+        ? "Roughdraft could not send the handoff. Check that the local server is still running."
+        : "It will take the appropriate next action, including replying to comments, questions, and suggestions, and/or directly editing the doc.";
+  const reviewHandoffDisabled = isReviewHandoffDisabled({
+    saveState,
+    documentDiskChangeState,
+    reviewHandoffState,
+  });
+  const trimmedOverallComment = overallComment.trim();
 
   return (
     <div
@@ -407,26 +444,126 @@ export function DocumentWorkspace({
       >
         <div className="flex max-w-full items-center justify-end gap-1.5">
           {showReviewHandoffButton ? (
-            <Button
-              type="button"
-              data-testid="review-handoff-button"
-              size="lg"
-              className="h-9 rounded-[7px] bg-black px-3 text-sm font-bold text-white shadow-[0_10px_28px_rgba(0,0,0,0.18)] hover:bg-black/85 focus-visible:ring-black/25 dark:bg-black dark:text-white dark:hover:bg-black/85 dark:focus-visible:ring-white/30"
-              disabled={isReviewHandoffDisabled({
-                saveState,
-                documentDiskChangeState,
-                reviewHandoffState,
-              })}
-              onClick={() => void handleCompleteReview()}
+            <Popover
+              open={reviewHandoffPopoverOpen}
+              onOpenChange={setReviewHandoffPopoverOpen}
             >
-              <ReviewHandoffButtonIcon
-                className={cn(
-                  "size-4",
-                  reviewHandoffState === "notifying" && "animate-spin",
+              <div className="flex items-center rounded-[7px] shadow-[0_10px_28px_rgba(0,0,0,0.18)]">
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        type="button"
+                        data-testid="review-handoff-button"
+                        size="lg"
+                        className="h-9 rounded-r-none rounded-l-[7px] bg-black px-3 text-sm font-bold text-white hover:bg-black/85 focus-visible:ring-black/25 dark:bg-black dark:text-white dark:hover:bg-black/85 dark:focus-visible:ring-white/30"
+                        disabled={reviewHandoffDisabled}
+                        onClick={() => void handleCompleteReview()}
+                      >
+                        <ReviewHandoffButtonIcon
+                          className={cn(
+                            "size-4",
+                            reviewHandoffState === "notifying" &&
+                              "animate-spin",
+                          )}
+                        />
+                        {reviewHandoffButtonLabel}
+                      </Button>
+                    }
+                  />
+                  <TooltipContent>Finish review</TooltipContent>
+                </Tooltip>
+                <PopoverTrigger
+                  render={
+                    <Button
+                      type="button"
+                      data-testid="review-handoff-comment-trigger"
+                      size="icon-lg"
+                      className="h-9 w-8 rounded-l-none rounded-r-[7px] border-l border-white/20 bg-black text-white hover:bg-black/85 focus-visible:ring-black/25 dark:bg-black dark:text-white dark:hover:bg-black/85 dark:focus-visible:ring-white/30"
+                      disabled={reviewHandoffDisabled}
+                      aria-label="Add overall handoff comment"
+                    >
+                      <ChevronDown className="size-4" />
+                    </Button>
+                  }
+                />
+              </div>
+              <PopoverContent
+                aria-label={
+                  reviewHandoffState === "idle"
+                    ? "Review handoff comment"
+                    : "Review handoff status"
+                }
+                data-testid={
+                  reviewHandoffState === "idle"
+                    ? "review-handoff-comment-popover"
+                    : "review-handoff-status"
+                }
+              >
+                {reviewHandoffState === "idle" ? (
+                  <form
+                    className="space-y-3"
+                    onSubmit={(event) => {
+                      event.preventDefault();
+                      void handleCompleteReview({
+                        overallComment: trimmedOverallComment,
+                      });
+                    }}
+                  >
+                    <div>
+                      <label
+                        htmlFor="review-handoff-overall-comment"
+                        className="text-sm font-semibold text-stone-950 dark:text-slate-50"
+                      >
+                        Overall comment
+                      </label>
+                      <Textarea
+                        id="review-handoff-overall-comment"
+                        data-testid="review-handoff-overall-comment"
+                        value={overallComment}
+                        onChange={(event) =>
+                          setOverallComment(event.currentTarget.value)
+                        }
+                        maxLength={4000}
+                        rows={4}
+                        className="mt-2 min-h-24 resize-y"
+                      />
+                    </div>
+                    <Button
+                      type="submit"
+                      data-testid="review-handoff-submit-comment"
+                      size="lg"
+                      className="w-full rounded-[7px] bg-black text-sm font-bold text-white hover:bg-black/85 focus-visible:ring-black/25 dark:bg-white dark:text-black dark:hover:bg-white/90"
+                      disabled={!trimmedOverallComment}
+                    >
+                      <CheckCheck className="size-4" />
+                      Submit with comment
+                    </Button>
+                  </form>
+                ) : (
+                  <div className="flex items-start gap-3">
+                    <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-black text-white dark:bg-white dark:text-black">
+                      {reviewHandoffState === "notifying" ? (
+                        <Loader2 className="size-4 animate-spin" />
+                      ) : reviewHandoffState === "error" ||
+                        reviewHandoffState === "undelivered" ? (
+                        <AlertTriangle className="size-4" />
+                      ) : (
+                        <CheckCheck className="size-4" />
+                      )}
+                    </span>
+                    <div>
+                      <div className="text-sm font-semibold text-stone-950 dark:text-slate-50">
+                        {reviewHandoffStatusTitle}
+                      </div>
+                      <p className="mt-1 text-sm leading-6 text-stone-600 dark:text-slate-300">
+                        {reviewHandoffStatusBody}
+                      </p>
+                    </div>
+                  </div>
                 )}
-              />
-              {reviewHandoffButtonLabel}
-            </Button>
+              </PopoverContent>
+            </Popover>
           ) : null}
         </div>
         {documentPage ? (

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -406,7 +406,7 @@ export function DocumentWorkspace({
       ? Loader2
       : reviewHandoffState === "error" || reviewHandoffState === "undelivered"
         ? AlertTriangle
-        : CheckCheck;
+        : null;
   const reviewHandoffStatusTitle =
     reviewHandoffState === "undelivered"
       ? "No agent is watching now"
@@ -448,44 +448,38 @@ export function DocumentWorkspace({
               open={reviewHandoffPopoverOpen}
               onOpenChange={setReviewHandoffPopoverOpen}
             >
-              <div className="flex items-center rounded-[7px] shadow-[0_10px_28px_rgba(0,0,0,0.18)]">
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <Button
-                        type="button"
-                        data-testid="review-handoff-button"
-                        size="lg"
-                        className="h-9 rounded-r-none rounded-l-[7px] bg-black px-3 text-sm font-bold text-white hover:bg-black/85 focus-visible:ring-black/25 dark:bg-black dark:text-white dark:hover:bg-black/85 dark:focus-visible:ring-white/30"
-                        disabled={reviewHandoffDisabled}
-                        onClick={() =>
-                          void handleCompleteReview(
-                            trimmedOverallComment
-                              ? { overallComment: trimmedOverallComment }
-                              : undefined,
-                          )
-                        }
-                      >
-                        <ReviewHandoffButtonIcon
-                          className={cn(
-                            "size-4",
-                            reviewHandoffState === "notifying" &&
-                              "animate-spin",
-                          )}
-                        />
-                        {reviewHandoffButtonLabel}
-                      </Button>
-                    }
-                  />
-                  <TooltipContent>Finish review</TooltipContent>
-                </Tooltip>
+              <div className="relative flex items-center overflow-hidden rounded-[7px] shadow-[0_10px_28px_rgba(0,0,0,0.18)] after:pointer-events-none after:absolute after:top-px after:right-8 after:bottom-px after:z-10 after:w-px after:bg-slate-700 after:content-[''] dark:after:bg-slate-700">
+                <Button
+                  type="button"
+                  data-testid="review-handoff-button"
+                  size="lg"
+                  className="h-9 rounded-r-none rounded-l-[7px] border-0 bg-black px-3 text-sm font-bold text-white hover:bg-black/85 focus-visible:ring-black/25 dark:bg-black dark:text-white dark:hover:bg-black/85 dark:focus-visible:ring-white/30"
+                  disabled={reviewHandoffDisabled}
+                  onClick={() =>
+                    void handleCompleteReview(
+                      trimmedOverallComment
+                        ? { overallComment: trimmedOverallComment }
+                        : undefined,
+                    )
+                  }
+                >
+                  {ReviewHandoffButtonIcon ? (
+                    <ReviewHandoffButtonIcon
+                      className={cn(
+                        "size-4",
+                        reviewHandoffState === "notifying" && "animate-spin",
+                      )}
+                    />
+                  ) : null}
+                  {reviewHandoffButtonLabel}
+                </Button>
                 <PopoverTrigger
                   render={
                     <Button
                       type="button"
                       data-testid="review-handoff-comment-trigger"
                       size="icon-lg"
-                      className="h-9 w-8 rounded-l-none rounded-r-[7px] border-l border-white/20 bg-black text-white hover:bg-black/85 focus-visible:ring-black/25 dark:bg-black dark:text-white dark:hover:bg-black/85 dark:focus-visible:ring-white/30"
+                      className="h-9 w-8 rounded-l-none rounded-r-[7px] border-0 bg-black text-white hover:bg-black/85 focus-visible:ring-black/25 dark:bg-black dark:text-white dark:hover:bg-black/85 dark:focus-visible:ring-white/30"
                       disabled={reviewHandoffDisabled}
                       aria-label="Add overall handoff comment"
                     >

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -458,7 +458,13 @@ export function DocumentWorkspace({
                         size="lg"
                         className="h-9 rounded-r-none rounded-l-[7px] bg-black px-3 text-sm font-bold text-white hover:bg-black/85 focus-visible:ring-black/25 dark:bg-black dark:text-white dark:hover:bg-black/85 dark:focus-visible:ring-white/30"
                         disabled={reviewHandoffDisabled}
-                        onClick={() => void handleCompleteReview()}
+                        onClick={() =>
+                          void handleCompleteReview(
+                            trimmedOverallComment
+                              ? { overallComment: trimmedOverallComment }
+                              : undefined,
+                          )
+                        }
                       >
                         <ReviewHandoffButtonIcon
                           className={cn(

--- a/packages/app/src/api-backend.ts
+++ b/packages/app/src/api-backend.ts
@@ -1,8 +1,9 @@
 import {
-  MarkdownFileConflictError,
   type BackendInfo,
+  type CompleteReviewOptions,
   type CompleteReviewResult,
   type MarkdownFileChangeEvent,
+  MarkdownFileConflictError,
   type Page,
   type ReviewWatchStatus,
   type StorageBackend,
@@ -110,7 +111,11 @@ export class ApiBackend implements StorageBackend {
     };
   }
 
-  async completeReview(relativePath: string): Promise<CompleteReviewResult> {
+  async completeReview(
+    relativePath: string,
+    options: CompleteReviewOptions = {},
+  ): Promise<CompleteReviewResult> {
+    const overallComment = options.overallComment?.trim();
     const res = await fetch(
       this.buildUrl("/api/review-events", { path: relativePath }),
       {
@@ -119,6 +124,7 @@ export class ApiBackend implements StorageBackend {
         body: JSON.stringify({
           projectPath: this.info.projectPath,
           path: relativePath,
+          ...(overallComment ? { overallComment } : {}),
         }),
       },
     );

--- a/packages/app/src/critic-markup/index.ts
+++ b/packages/app/src/critic-markup/index.ts
@@ -32,6 +32,7 @@ export interface CriticComment {
   authorType?: "user" | "ai";
   authorId?: string | null;
   parentCommentId?: string | null;
+  scope?: "document";
 }
 
 export interface CriticCommentThread {
@@ -263,12 +264,12 @@ function parseEndmatterMap(
   );
 }
 
-function addEndmatterReplies(
+function addEndmatterFeedback(
   comments: Map<string, CriticComment>,
   endmatter: ParsedEndmatter,
 ) {
   for (const [id, entry] of endmatter.comments) {
-    if (typeof entry.body !== "string" || typeof entry.re !== "string") {
+    if (typeof entry.body !== "string") {
       continue;
     }
     if (comments.has(id)) {
@@ -280,6 +281,8 @@ function addEndmatterReplies(
       createCommentWithContext({
         ...commentPartialFromEndmatterEntry(id, entry),
         content: entry.body,
+        parentCommentId: typeof entry.re === "string" ? entry.re : null,
+        scope: typeof entry.re === "string" ? undefined : "document",
       }),
     );
   }
@@ -325,7 +328,10 @@ function endmatterEntryForComment(
     at: comment.createdAt,
   };
 
-  if (comment.parentCommentId) {
+  if (comment.scope === "document") {
+    next.body = comment.content;
+    delete next.re;
+  } else if (comment.parentCommentId) {
     next.body = comment.content;
     next.re = comment.parentCommentId;
   } else {
@@ -447,6 +453,7 @@ function createCommentWithContext(
     authorType,
     authorId: partial?.authorId ?? (authorType === "ai" ? null : "user"),
     parentCommentId: partial?.parentCommentId ?? null,
+    scope: partial?.scope,
   };
 }
 
@@ -1391,7 +1398,7 @@ export function criticMarkdownHasReviewRail(
     parsedEndmatter,
   );
   parser.parse(protectRichTextRoundTripMarkdown(body));
-  addEndmatterReplies(comments, parsedEndmatter);
+  addEndmatterFeedback(comments, parsedEndmatter);
   return comments.size > 0 || changes.size > 0;
 }
 
@@ -1412,7 +1419,7 @@ export function criticMarkdownToRenderedHtml(
     parsedEndmatter,
   );
   const html = parser.parse(protectRichTextRoundTripMarkdown(body)) as string;
-  addEndmatterReplies(comments, parsedEndmatter);
+  addEndmatterFeedback(comments, parsedEndmatter);
 
   return { html, comments, changes, frontmatter, endmatter };
 }
@@ -1434,7 +1441,7 @@ export function criticMarkdownToEditorState(
     yamlFrontmatter?: string;
     yamlEndmatter?: string;
   };
-  addEndmatterReplies(comments, parsedEndmatter);
+  addEndmatterFeedback(comments, parsedEndmatter);
   if (frontmatter) {
     doc.yamlFrontmatter = frontmatter;
   }

--- a/packages/app/src/local-storage-backend.ts
+++ b/packages/app/src/local-storage-backend.ts
@@ -113,7 +113,10 @@ export class LocalStorageBackend implements StorageBackend {
     return undefined;
   }
 
-  async completeReview(_relativePath: string): Promise<{ delivered: boolean }> {
+  async completeReview(
+    _relativePath: string,
+    _options?: { overallComment?: string },
+  ): Promise<{ delivered: boolean }> {
     return { delivered: false };
   }
 

--- a/packages/app/src/markdown.ts
+++ b/packages/app/src/markdown.ts
@@ -180,6 +180,21 @@ function isReviewEndmatterMap(value: unknown): boolean {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
+function hasDocumentLevelComment(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+
+  return Object.values(value as Record<string, unknown>).some(
+    (entry) =>
+      Boolean(entry) &&
+      typeof entry === "object" &&
+      !Array.isArray(entry) &&
+      typeof (entry as Record<string, unknown>).body === "string" &&
+      typeof (entry as Record<string, unknown>).by === "string" &&
+      typeof (entry as Record<string, unknown>).at === "string" &&
+      typeof (entry as Record<string, unknown>).re !== "string",
+  );
+}
+
 function isRoughdraftReviewEndmatter(endmatter: string): boolean {
   const yamlText = endmatter.replace(/^---[ \t]*(?:\r\n|\n)/, "");
   let parsed: unknown;
@@ -264,11 +279,16 @@ export function splitYamlDocumentMetadata(
   const endmatter = body.slice(match.index);
   const candidate = endmatter.replace(/^\n/, "");
 
-  if (
-    !body.slice(0, match.index).includes("{#") ||
-    !isRoughdraftReviewEndmatter(candidate)
-  ) {
+  const precedingBody = body.slice(0, match.index);
+  if (!isRoughdraftReviewEndmatter(candidate)) {
     return { frontmatter, body, endmatter: null };
+  }
+  if (!precedingBody.includes("{#")) {
+    const yamlText = candidate.replace(/^---[ \t]*(?:\r\n|\n)/, "");
+    const parsed = parseYaml(yamlText) as Record<string, unknown> | null;
+    if (!hasDocumentLevelComment(parsed?.comments)) {
+      return { frontmatter, body, endmatter: null };
+    }
   }
 
   return {

--- a/packages/app/src/preview-backend.ts
+++ b/packages/app/src/preview-backend.ts
@@ -62,7 +62,10 @@ export class PreviewBackend implements StorageBackend {
     return this.page;
   }
 
-  async completeReview(_relativePath: string): Promise<{ delivered: boolean }> {
+  async completeReview(
+    _relativePath: string,
+    _options?: { overallComment?: string },
+  ): Promise<{ delivered: boolean }> {
     return { delivered: false };
   }
 

--- a/packages/app/src/storage.ts
+++ b/packages/app/src/storage.ts
@@ -31,6 +31,10 @@ export interface CompleteReviewResult {
   delivered: boolean;
 }
 
+export interface CompleteReviewOptions {
+  overallComment?: string;
+}
+
 export interface ReviewWatchStatus {
   watching: boolean;
   watcherCount: number;
@@ -58,7 +62,10 @@ export interface StorageBackend {
     relativePath: string,
     onChange: (event: MarkdownFileChangeEvent) => void,
   ): () => void;
-  completeReview?(relativePath: string): Promise<CompleteReviewResult>;
+  completeReview?(
+    relativePath: string,
+    options?: CompleteReviewOptions,
+  ): Promise<CompleteReviewResult>;
   getReviewWatchStatus?(relativePath: string): Promise<ReviewWatchStatus>;
   saveAsset(file: File): Promise<StoredAsset>;
   resolveFileUrl(path: string): string | null;

--- a/packages/app/test/critic-markup.test.ts
+++ b/packages/app/test/critic-markup.test.ts
@@ -321,6 +321,38 @@ describe("CriticMarkup comments", () => {
     expect(output).not.toContain("{==\u2060==}");
   });
 
+  it("renders and preserves YAML endmatter-backed document-level comments", () => {
+    const input = [
+      "# Draft",
+      "",
+      "---",
+      "comments:",
+      "  c1:",
+      "    body: Please address the risk section.",
+      "    by: user",
+      '    at: "2026-05-24T12:00:00.000Z"',
+      "",
+    ].join("\n");
+
+    expect(criticMarkdownHasReviewRail(input)).toBe(true);
+
+    const parsed = criticMarkdownToEditorState(input);
+    const output = editorStateToCriticMarkdown(parsed.doc, parsed.comments);
+
+    expect(parsed.comments.get("c1")).toMatchObject({
+      id: "c1",
+      content: "Please address the risk section.",
+      authorType: "user",
+      createdAt: "2026-05-24T12:00:00.000Z",
+      parentCommentId: null,
+      scope: "document",
+    });
+    expect(output).toContain("comments:");
+    expect(output).toContain("  c1:");
+    expect(output).toContain("    body: Please address the risk section.");
+    expect(output).not.toContain("{#c1}");
+  });
+
   it("reserves YAML endmatter-backed unanchored comment ids for new replies", () => {
     const input = [
       "Please revisit {==this claim==}{>>This needs a source.<<}{#c1}.",

--- a/packages/app/test/view-toggle-bugs.test.tsx
+++ b/packages/app/test/view-toggle-bugs.test.tsx
@@ -13,6 +13,7 @@ import {
 } from "../src/DocumentWorkspace";
 import type { DocumentSaveState } from "../src/PageCard";
 import type {
+  CompleteReviewOptions,
   CompleteReviewResult,
   Page,
   StorageBackend,
@@ -172,6 +173,19 @@ function setupDomMocks() {
 async function click(element: Element) {
   await act(async () => {
     element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
+async function change(element: HTMLTextAreaElement, value: string) {
+  await act(async () => {
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+    valueSetter?.call(element, value);
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
     await Promise.resolve();
   });
 }
@@ -540,7 +554,9 @@ describe("review handoff watcher affordance", () => {
     onCompleteReview = async () => ({ delivered: false }),
   }: {
     getWatcherCount: () => number;
-    onCompleteReview?: () => Promise<CompleteReviewResult>;
+    onCompleteReview?: (
+      options?: CompleteReviewOptions,
+    ) => Promise<CompleteReviewResult>;
   }) {
     await act(async () => {
       root.render(
@@ -601,6 +617,7 @@ describe("review handoff watcher affordance", () => {
     await click(doneReviewingButton);
 
     expect(onCompleteReview).toHaveBeenCalledOnce();
+    expect(onCompleteReview).toHaveBeenCalledWith(undefined);
     expect(container.textContent).toContain("Sent");
     expect(queryByTestId(container, "review-handoff-status")).toBeNull();
     expect(container.textContent).not.toContain("Agent notified");
@@ -627,6 +644,50 @@ describe("review handoff watcher affordance", () => {
     expect(onCompleteReview).toHaveBeenCalledOnce();
     expect(container.textContent).toContain("Not sent");
     expect(container.textContent).not.toContain("I'm done");
+  });
+
+  it("submits an overall comment from the handoff popover", async () => {
+    const onCompleteReview = vi
+      .fn<(options?: CompleteReviewOptions) => Promise<CompleteReviewResult>>()
+      .mockResolvedValue({ delivered: true });
+
+    await renderWorkspace({ getWatcherCount: () => 1, onCompleteReview });
+
+    const commentTrigger = queryByTestId<HTMLButtonElement>(
+      container,
+      "review-handoff-comment-trigger",
+    );
+    if (!commentTrigger) {
+      throw new Error("Review handoff comment trigger not found");
+    }
+
+    await click(commentTrigger);
+
+    const textarea = queryByTestId<HTMLTextAreaElement>(
+      document.body,
+      "review-handoff-overall-comment",
+    );
+    if (!textarea) {
+      throw new Error("Overall comment textarea not found");
+    }
+
+    await change(textarea, "  Please prioritize the CLI contract.  ");
+
+    const submitButton = queryByTestId<HTMLButtonElement>(
+      document.body,
+      "review-handoff-submit-comment",
+    );
+    if (!submitButton) {
+      throw new Error("Submit with comment button not found");
+    }
+    await click(submitButton);
+
+    expect(onCompleteReview).toHaveBeenCalledWith({
+      overallComment: "Please prioritize the CLI contract.",
+    });
+    expect(document.body.textContent).not.toContain(
+      "Please prioritize the CLI contract.",
+    );
   });
 
   it("keeps visible sent feedback after the watcher receives the event", async () => {

--- a/packages/app/test/view-toggle-bugs.test.tsx
+++ b/packages/app/test/view-toggle-bugs.test.tsx
@@ -690,6 +690,47 @@ describe("review handoff watcher affordance", () => {
     );
   });
 
+  it("includes an overall comment when finishing from the primary handoff button", async () => {
+    const onCompleteReview = vi
+      .fn<(options?: CompleteReviewOptions) => Promise<CompleteReviewResult>>()
+      .mockResolvedValue({ delivered: true });
+
+    await renderWorkspace({ getWatcherCount: () => 1, onCompleteReview });
+
+    const commentTrigger = queryByTestId<HTMLButtonElement>(
+      container,
+      "review-handoff-comment-trigger",
+    );
+    if (!commentTrigger) {
+      throw new Error("Review handoff comment trigger not found");
+    }
+
+    await click(commentTrigger);
+
+    const textarea = queryByTestId<HTMLTextAreaElement>(
+      document.body,
+      "review-handoff-overall-comment",
+    );
+    if (!textarea) {
+      throw new Error("Overall comment textarea not found");
+    }
+
+    await change(textarea, "  Please prioritize the CLI contract.  ");
+
+    const doneReviewingButton = queryByTestId<HTMLButtonElement>(
+      container,
+      "review-handoff-button",
+    );
+    if (!doneReviewingButton) {
+      throw new Error("I'm done button not found");
+    }
+    await click(doneReviewingButton);
+
+    expect(onCompleteReview).toHaveBeenCalledWith({
+      overallComment: "Please prioritize the CLI contract.",
+    });
+  });
+
   it("keeps visible sent feedback after the watcher receives the event", async () => {
     let watcherCount = 1;
     const onCompleteReview = vi

--- a/packages/rfm/src/index.test.ts
+++ b/packages/rfm/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   appendRoughdraftReply,
+  appendRoughdraftDocumentComment,
   extractRoughdraftReviewIndex,
   markRoughdraftResolved,
   validateRoughdraftMarkdown,
@@ -95,7 +96,7 @@ describe("validateRoughdraftMarkdown", () => {
     );
   });
 
-  it("reports invalid endmatter-only replies", () => {
+  it("accepts body-only endmatter comments as document-level feedback", () => {
     const result = validateRoughdraftMarkdown(
       [
         "{>>Root<<}{#c1}",
@@ -113,10 +114,9 @@ describe("validateRoughdraftMarkdown", () => {
       ].join("\n"),
     );
 
-    expect(result.errors.map((diagnostic) => diagnostic.code)).toContain(
-      "missing-reply-target",
-    );
-    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual([]);
+    expect(result.ok).toBe(true);
+    expect(result.summary).toMatchObject({ comments: 2 });
   });
 
   it("ignores review markers inside fenced code blocks and inline code spans", () => {
@@ -180,6 +180,29 @@ describe("validateRoughdraftMarkdown", () => {
     expect(result.diagnostics).toEqual([]);
     expect(result.summary).toMatchObject({
       comments: 0,
+      suggestions: 0,
+    });
+  });
+
+  it("accepts document-level comments backed only by YAML endmatter", () => {
+    const result = validateRoughdraftMarkdown(
+      [
+        "# Draft",
+        "",
+        "---",
+        "comments:",
+        "  c1:",
+        "    body: Please address the risk section.",
+        "    by: user",
+        '    at: "2026-05-24T12:00:00.000Z"',
+        "",
+      ].join("\n"),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.summary).toMatchObject({
+      comments: 1,
       suggestions: 0,
     });
   });
@@ -341,6 +364,37 @@ describe("extractRoughdraftReviewIndex", () => {
     });
   });
 
+  it("extracts document-level comments backed only by YAML endmatter", () => {
+    const index = extractRoughdraftReviewIndex(
+      [
+        "# Draft",
+        "",
+        "---",
+        "comments:",
+        "  c1:",
+        "    body: Please address the risk section.",
+        "    by: user",
+        '    at: "2026-05-24T12:00:00.000Z"',
+        "",
+      ].join("\n"),
+    );
+
+    expect(index.summary).toMatchObject({
+      comments: 1,
+      replies: 0,
+      suggestions: 0,
+      unresolved: 1,
+    });
+    expect(index.items[0]).toMatchObject({
+      id: "c1",
+      kind: "comment",
+      parentId: null,
+      author: "user",
+      createdAt: "2026-05-24T12:00:00.000Z",
+      text: "Please address the risk section.",
+    });
+  });
+
   it("does not extract CriticMarkup-looking text inside YAML endmatter bodies", () => {
     const index = extractRoughdraftReviewIndex(
       [
@@ -474,6 +528,36 @@ describe("RFM mutation helpers", () => {
         }),
       ]),
     );
+  });
+
+  it("appends a document-level comment to YAML endmatter with the next comment id", () => {
+    const output = appendRoughdraftDocumentComment(
+      [
+        "# Draft",
+        "",
+        "Needs {==support==}{>>Add a source<<}{#c1}.",
+        "",
+        "---",
+        "comments:",
+        "  c1:",
+        "    by: user",
+        '    at: "2026-04-28T12:00:00.000Z"',
+        "workflow:",
+        "  owner: editorial",
+        "",
+      ].join("\n"),
+      {
+        message: "Please address the risk section.",
+        author: "user",
+        at: "2026-05-24T12:00:00.000Z",
+      },
+    );
+
+    expect(output).toContain("workflow:\n  owner: editorial");
+    expect(output).toContain("  c2:");
+    expect(output).toContain("    body: Please address the risk section.");
+    expect(output).toContain("    by: user");
+    expect(output).toContain("    at: 2026-05-24T12:00:00.000Z");
   });
 
   it("rejects reply text that would close CriticMarkup early", () => {

--- a/packages/rfm/src/index.ts
+++ b/packages/rfm/src/index.ts
@@ -69,6 +69,13 @@ export interface AppendRoughdraftReplyOptions {
   id?: string;
 }
 
+export interface AppendRoughdraftDocumentCommentOptions {
+  message: string;
+  author?: string;
+  at?: string;
+  id?: string;
+}
+
 export interface MarkRoughdraftResolvedOptions {
   targetId: string;
   summary?: string;
@@ -379,13 +386,15 @@ export function validateRoughdraftMarkdown(
       entry,
       endmatter.offset ?? 0,
       addDiagnostic,
-      true,
+      Boolean(entry.re),
     );
-    replies.push({
-      id,
-      parentId: String(entry.re ?? ""),
-      offset: endmatter.offset ?? 0,
-    });
+    if (entry.re) {
+      replies.push({
+        id,
+        parentId: String(entry.re),
+        offset: endmatter.offset ?? 0,
+      });
+    }
   }
 
   for (const reply of replies) {
@@ -558,12 +567,12 @@ export function extractRoughdraftReviewIndex(markdown: string): RfmReviewIndex {
   }
 
   for (const [id, entry] of endmatter.comments) {
-    if (!entry.body || !entry.re) continue;
+    if (!entry.body) continue;
 
     items.push({
       id,
-      kind: "reply",
-      parentId: String(entry.re),
+      kind: entry.re ? "reply" : "comment",
+      parentId: entry.re ? String(entry.re) : null,
       author: typeof entry.by === "string" ? entry.by : null,
       createdAt: typeof entry.at === "string" ? entry.at : null,
       status: typeof entry.status === "string" ? entry.status : null,
@@ -586,6 +595,28 @@ export function extractRoughdraftReviewIndex(markdown: string): RfmReviewIndex {
       unresolved: items.filter((item) => item.status !== "resolved").length,
     },
   };
+}
+
+export function appendRoughdraftDocumentComment(
+  markdown: string,
+  options: AppendRoughdraftDocumentCommentOptions,
+): string {
+  assertSafeCommentBodyText(options.message);
+
+  const index = extractRoughdraftReviewIndex(markdown);
+  const endmatter = parseRoughdraftEndmatter(markdown);
+  const commentId = options.id ?? nextCommentId(index.items);
+  const comments = new Map(endmatter.comments);
+  comments.set(commentId, {
+    body: options.message,
+    by: options.author ?? "user",
+    at: options.at ?? new Date().toISOString(),
+  });
+
+  return writeRoughdraftEndmatter(markdown, {
+    comments,
+    suggestions: endmatter.suggestions,
+  });
 }
 
 export function appendRoughdraftReply(
@@ -1078,7 +1109,6 @@ function parseRoughdraftEndmatter(markdown: string): RoughdraftEndmatter {
   };
   const match = findFinalYamlEndmatter(markdown);
   if (!match) return empty;
-  if (!markdown.slice(0, match.offset).includes("{#")) return empty;
 
   let parsed: unknown;
   try {
@@ -1103,6 +1133,12 @@ function parseRoughdraftEndmatter(markdown: string): RoughdraftEndmatter {
   if (!isPlainObject(parsed)) return empty;
   const hasRoughdraftKeys = "comments" in parsed || "suggestions" in parsed;
   if (!hasRoughdraftKeys) return empty;
+  if (
+    !markdown.slice(0, match.offset).includes("{#") &&
+    !hasDocumentLevelComment(parsed)
+  ) {
+    return empty;
+  }
 
   return {
     comments: readEndmatterEntries(parsed.comments),
@@ -1112,6 +1148,22 @@ function parseRoughdraftEndmatter(markdown: string): RoughdraftEndmatter {
     offset: match.offset,
     diagnostics: [],
   };
+}
+
+function hasDocumentLevelComment(parsed: Record<string, unknown>): boolean {
+  const comments = readEndmatterEntries(parsed.comments);
+  for (const entry of comments.values()) {
+    if (
+      typeof entry.body === "string" &&
+      typeof entry.by === "string" &&
+      typeof entry.at === "string" &&
+      !entry.re
+    ) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function findFinalYamlEndmatter(

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -1,11 +1,10 @@
 import fs from "node:fs";
+import { createServer as createHttpServer, type Server } from "node:http";
 import os from "node:os";
 import path from "node:path";
-import { createServer as createHttpServer, type Server } from "node:http";
 import { fileURLToPath } from "node:url";
 import { validateRoughdraftMarkdown } from "@roughdraft/rfm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createApp } from "./index";
 import {
   createCliDependencies,
   createDefaultOpenUrl,
@@ -13,6 +12,7 @@ import {
   getServerStateFilePath,
   runCli,
 } from "./cli";
+import { createApp } from "./index";
 import { ROUGHDRAFT_DEFAULT_PORT } from "./network";
 
 interface StartedServer {
@@ -994,13 +994,21 @@ describe("cli", () => {
     await fetch(`http://localhost:${persisted?.port}/api/review-events`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ projectPath: projectDir, path: "draft.md" }),
+      body: JSON.stringify({
+        projectPath: projectDir,
+        path: "draft.md",
+        overallComment: "Please prioritize the CLI contract.",
+      }),
     });
 
     const exitCode = await watchPromise;
     const payload = parseOnlyJsonLog<{
       timedOut: boolean;
-      events: Array<{ documentPath: string; type: string }>;
+      events: Array<{
+        documentPath: string;
+        overallComment?: string;
+        type: string;
+      }>;
     }>(test.logs);
 
     expect(exitCode).toBe(0);
@@ -1008,6 +1016,7 @@ describe("cli", () => {
     expect(payload.events).toHaveLength(1);
     expect(payload.events[0]).toMatchObject({
       documentPath,
+      overallComment: "Please prioritize the CLI contract.",
       type: "review.completed",
     });
   });

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -1,5 +1,5 @@
-import type { AddressInfo } from "node:net";
 import fs from "node:fs";
+import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -265,9 +265,11 @@ describe("createApp", () => {
       staticDirPath: projectDir,
     });
 
-    const response = await request(app)
-      .post("/api/review-events")
-      .send({ projectPath: projectDir, path: "draft.md" });
+    const response = await request(app).post("/api/review-events").send({
+      projectPath: projectDir,
+      path: "draft.md",
+      overallComment: "Please address the risk section.",
+    });
 
     expect(response.status).toBe(201);
     expect(response.body).toMatchObject({
@@ -278,6 +280,7 @@ describe("createApp", () => {
         projectPath: projectDir,
         relativePath: "draft.md",
         sequence: 1,
+        overallComment: "Please address the risk section.",
         summary: {
           comments: 1,
           replies: 0,
@@ -288,6 +291,44 @@ describe("createApp", () => {
     });
     expect(response.body.event.version).toEqual(expect.any(String));
     expect(response.body.event.createdAt).toEqual(expect.any(String));
+  });
+
+  it("omits whitespace-only overall comments from review events", async () => {
+    fs.writeFileSync(path.join(projectDir, "draft.md"), "# Draft\n");
+    const { app } = createApp({
+      homeDir,
+      staticDirPath: projectDir,
+    });
+
+    const response = await request(app).post("/api/review-events").send({
+      projectPath: projectDir,
+      path: "draft.md",
+      overallComment: "   \n\t  ",
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.event).not.toHaveProperty("overallComment");
+  });
+
+  it("rejects over-limit overall comments", async () => {
+    fs.writeFileSync(path.join(projectDir, "draft.md"), "# Draft\n");
+    const { app } = createApp({
+      homeDir,
+      staticDirPath: projectDir,
+    });
+
+    const response = await request(app)
+      .post("/api/review-events")
+      .send({
+        projectPath: projectDir,
+        path: "draft.md",
+        overallComment: "x".repeat(4001),
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      error: "overallComment must be 4000 characters or fewer",
+    });
   });
 
   it("rejects review events without a projectPath", async () => {

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -282,15 +282,60 @@ describe("createApp", () => {
         sequence: 1,
         overallComment: "Please address the risk section.",
         summary: {
-          comments: 1,
+          comments: 2,
           replies: 0,
           suggestions: 0,
-          unresolved: 1,
+          unresolved: 2,
         },
       },
     });
     expect(response.body.event.version).toEqual(expect.any(String));
     expect(response.body.event.createdAt).toEqual(expect.any(String));
+  });
+
+  it("persists an overall review comment as document-level YAML feedback before emitting the event", async () => {
+    const filePath = path.join(projectDir, "draft.md");
+    fs.writeFileSync(
+      filePath,
+      [
+        "# Draft",
+        "",
+        "Needs {==support==}{>>Add a source<<}{#c1}.",
+        "",
+        "---",
+        "comments:",
+        "  c1:",
+        "    by: user",
+        '    at: "2026-04-28T12:00:00.000Z"',
+        "workflow:",
+        "  owner: editorial",
+        "",
+      ].join("\n"),
+    );
+    const { app } = createApp({
+      homeDir,
+      staticDirPath: projectDir,
+    });
+
+    const response = await request(app).post("/api/review-events").send({
+      projectPath: projectDir,
+      path: "draft.md",
+      overallComment: "Please address the risk section.",
+    });
+
+    const saved = fs.readFileSync(filePath, "utf-8");
+    expect(response.status).toBe(201);
+    expect(saved).toContain("workflow:\n  owner: editorial");
+    expect(saved).toContain("  c1:");
+    expect(saved).toContain("  c2:");
+    expect(saved).toContain("    body: Please address the risk section.");
+    expect(saved).toContain("    by: user");
+    expect(response.body.event.summary).toMatchObject({
+      comments: 2,
+      replies: 0,
+      suggestions: 0,
+      unresolved: 2,
+    });
   });
 
   it("omits whitespace-only overall comments from review events", async () => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,15 +1,15 @@
-import express, { type Express, type Request, type Response } from "express";
 import crypto from "node:crypto";
-import os from "node:os";
-import { createServer as createHttpServer } from "node:http";
-import { fileURLToPath } from "node:url";
-import path from "node:path";
 import fs from "node:fs";
+import { createServer as createHttpServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { extractRoughdraftReviewIndex } from "@roughdraft/rfm";
+import express, { type Express, type Request, type Response } from "express";
 import {
+  hasNonLoopbackHost,
   ROUGHDRAFT_DEFAULT_PORT,
   ROUGHDRAFT_PUBLIC_HOST,
-  hasNonLoopbackHost,
   resolveBindHosts,
 } from "./network.js";
 import { ReviewEventQueue } from "./review-events.js";
@@ -106,6 +106,7 @@ interface RemoteDocumentSavePayload {
 const REMOTE_SESSION_TTL_MS = 5 * 60 * 1000;
 const REMOTE_SESSION_SWEEP_INTERVAL_MS = 60 * 1000;
 const REMOTE_SESSION_KEEPALIVE_MS = 15 * 1000;
+const MAX_OVERALL_COMMENT_LENGTH = 4_000;
 
 let nextOpenRequestClientId = 1;
 
@@ -164,6 +165,12 @@ function fileVersionFromFile(filePath: string): string {
   const content = fs.readFileSync(filePath);
   const stats = fs.statSync(filePath);
   return fileVersionFromContent(stats, content);
+}
+
+function normalizeOverallComment(input: unknown): string | undefined {
+  if (typeof input !== "string") return undefined;
+  const trimmed = input.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function markdownPageFromFile(
@@ -630,6 +637,17 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
     const target = markdownPathFromRequest(req, res);
     if (!target) return;
 
+    const overallComment = normalizeOverallComment(req.body?.overallComment);
+    if (
+      overallComment !== undefined &&
+      overallComment.length > MAX_OVERALL_COMMENT_LENGTH
+    ) {
+      res.status(400).json({
+        error: `overallComment must be ${MAX_OVERALL_COMMENT_LENGTH} characters or fewer`,
+      });
+      return;
+    }
+
     const markdown = fs.readFileSync(target.absolutePath, "utf-8");
     const index = extractRoughdraftReviewIndex(markdown);
     const result = reviewEvents.emit({
@@ -638,6 +656,7 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
       relativePath: target.relativePath,
       version: fileVersionFromFile(target.absolutePath),
       summary: index.summary,
+      overallComment,
     });
 
     res.status(201).json(result);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,7 +4,10 @@ import { createServer as createHttpServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { extractRoughdraftReviewIndex } from "@roughdraft/rfm";
+import {
+  appendRoughdraftDocumentComment,
+  extractRoughdraftReviewIndex,
+} from "@roughdraft/rfm";
 import express, { type Express, type Request, type Response } from "express";
 import {
   hasNonLoopbackHost,
@@ -649,7 +652,17 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
     }
 
     const markdown = fs.readFileSync(target.absolutePath, "utf-8");
-    const index = extractRoughdraftReviewIndex(markdown);
+    const persistedMarkdown = overallComment
+      ? appendRoughdraftDocumentComment(markdown, {
+          message: overallComment,
+          author: "user",
+        })
+      : markdown;
+    if (persistedMarkdown !== markdown) {
+      fs.writeFileSync(target.absolutePath, persistedMarkdown);
+    }
+
+    const index = extractRoughdraftReviewIndex(persistedMarkdown);
     const result = reviewEvents.emit({
       documentPath: target.absolutePath,
       projectPath: target.projectDir,

--- a/packages/server/src/mcp.test.ts
+++ b/packages/server/src/mcp.test.ts
@@ -63,6 +63,42 @@ describe("mcp", () => {
     });
   });
 
+  it("returns overall comments from review watch events unchanged", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response(
+        JSON.stringify({
+          events: [
+            {
+              documentPath,
+              type: "review.completed",
+              overallComment: "Please prioritize the CLI contract.",
+            },
+          ],
+          timedOut: false,
+          nextSequence: 2,
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+
+    const result = await callTool(
+      "roughdraft_watch_review_events",
+      { documentPath, projectPath: projectDir },
+      { ROUGHDRAFT_STATE_FILE: stateFile },
+      fetchImpl,
+    );
+
+    expect(result).toMatchObject({
+      events: [
+        {
+          overallComment: "Please prioritize the CLI contract.",
+        },
+      ],
+    });
+  });
+
   it("does not write a reply when the message contains a CriticMarkup close delimiter", async () => {
     const original =
       '# Draft\n\n{>>Needs proof<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z"}\n';

--- a/packages/server/src/mcp.ts
+++ b/packages/server/src/mcp.ts
@@ -69,7 +69,7 @@ const tools: ToolDefinition[] = [
   {
     name: "roughdraft_watch_review_events",
     description:
-      "Block until Roughdraft receives Done Reviewing for a Markdown file. Omit timeoutSeconds to wait indefinitely.",
+      "Block until Roughdraft receives Done Reviewing for a Markdown file. Returned events may include an ephemeral overallComment. Omit timeoutSeconds to wait indefinitely.",
     inputSchema: {
       type: "object",
       additionalProperties: false,

--- a/packages/server/src/mcp.ts
+++ b/packages/server/src/mcp.ts
@@ -69,7 +69,7 @@ const tools: ToolDefinition[] = [
   {
     name: "roughdraft_watch_review_events",
     description:
-      "Block until Roughdraft receives Done Reviewing for a Markdown file. Returned events may include an ephemeral overallComment. Omit timeoutSeconds to wait indefinitely.",
+      "Block until Roughdraft receives Done Reviewing for a Markdown file. Overall handoff comments are persisted as document-level YAML endmatter comments before the event is emitted. Omit timeoutSeconds to wait indefinitely.",
     inputSchema: {
       type: "object",
       additionalProperties: false,

--- a/packages/server/src/review-events.test.ts
+++ b/packages/server/src/review-events.test.ts
@@ -54,6 +54,41 @@ describe("ReviewEventQueue", () => {
     vi.useRealTimers();
   });
 
+  it("returns overall comments with delivered events", async () => {
+    vi.useFakeTimers();
+    const queue = new ReviewEventQueue();
+    const waiting = queue.wait({
+      documentPath: "/tmp/project/draft.md",
+      timeoutMs: 1_000,
+      batchWindowMs: 0,
+    });
+
+    queue.emit({
+      ...eventInput("/tmp/project/draft.md"),
+      overallComment: "Please prioritize the CLI contract.",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(waiting).resolves.toMatchObject({
+      timedOut: false,
+      events: [
+        {
+          overallComment: "Please prioritize the CLI contract.",
+        },
+      ],
+    });
+    vi.useRealTimers();
+  });
+
+  it("keeps events without overall comments unchanged", async () => {
+    const queue = new ReviewEventQueue();
+
+    queue.emit(eventInput("/tmp/project/draft.md"));
+
+    const result = await queue.wait();
+    expect(result.events[0]).not.toHaveProperty("overallComment");
+  });
+
   it("keeps a watcher active without a timeout until a matching event arrives", async () => {
     vi.useFakeTimers();
     const queue = new ReviewEventQueue();

--- a/packages/server/src/review-events.ts
+++ b/packages/server/src/review-events.ts
@@ -12,6 +12,7 @@ export interface ReviewCompletedEventInput {
     suggestions: number;
     unresolved: number;
   };
+  overallComment?: string;
 }
 
 export interface ReviewCompletedEvent extends ReviewCompletedEventInput {
@@ -73,6 +74,8 @@ export class ReviewEventQueue {
       documentPath: event.documentPath,
       sequence: event.sequence,
       waiters: this.waiters.size,
+      hasOverallComment: typeof event.overallComment === "string",
+      overallCommentLength: event.overallComment?.length ?? 0,
     });
 
     let delivered = false;


### PR DESCRIPTION
## Summary

Review handoffs can now carry an optional overall comment from the user, so the receiving agent gets both inline review markup and document-level intent when the user clicks done. The comment is accepted through the UI, storage backends, server API, MCP/watch payloads, and CriticMarkup YAML endmatter, with validation for empty and overlong input. The branch also tightens review-handoff UI states, documents the cross-boundary submit path, and expands unit, server, MCP, and smoke coverage around the new end-to-end behavior.

## Test Plan

- `pnpm check`
- `pnpm test:smoke`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
