### PR TITLE
feat(app): refine document editing controls

### DIFF
--- a/docs/spec/ui-state-screenshot-guide.md
+++ b/docs/spec/ui-state-screenshot-guide.md
@@ -116,15 +116,15 @@ suggestions:
 | Document | Editing mode | Open mode menu and choose Editing | `document-mode-trigger` | Normal edit behavior. |
 | Document | Suggesting mode | Open mode menu and choose Suggesting | `document-mode-trigger` | Selection actions should create suggestions instead of direct edits. |
 | Document | Viewing mode | Open mode menu and choose Viewing | `document-mode-trigger` | Editing controls should look non-editable. |
-| Document | Save status: saved | Any clean document after autosave | `document-save-status` | Label should be `Saved`. |
-| Document | Save status: unsaved | Type in a local document before save completes | `document-save-status` | Transient; often easier with save throttling or network mocking. |
-| Document | Save status: saving | Type and capture during autosave | `document-save-status` | Transient; easiest with mocked delayed save. |
-| Document | Save status: failed | Force save error | `document-save-status` | Use backend/API mocking or a component harness. |
+| Document | Save status: saved | Any clean document after autosave | `document-save-status` | Checkmark should sit next to the filename and fade out over 2 seconds; accessible label remains `Saved`. |
+| Document | Save status: unsaved | Type in a local document before save completes | `document-save-status` | Spinner-only pending state; accessible label is `Unsaved changes`. Transient; often easier with save throttling or network mocking. |
+| Document | Save status: saving | Type and capture during autosave | `document-save-status` | Spinner-only pending state; accessible label is `Saving`. Transient; easiest with mocked delayed save. |
+| Document | Save status: failed | Force save error | `document-save-status` | Icon-only error state; accessible label is `Save failed`. Use backend/API mocking or a component harness. |
 | Document | Disk changed | Open local file, modify file externally while browser content is clean | `file-conflict-notice`, `file-conflict-action-reload`, `file-conflict-action-overwrite` | Banner title: `File changed on disk`. |
 | Document | Save conflict | Edit in browser, then modify file externally before autosave resolves | `file-conflict-notice`, `file-conflict-action-keep-editing` | Banner title: `Save conflict`; autosave pauses. |
 | Document | Autosave paused | Keep editing after conflict | `file-conflict-notice`, `file-conflict-action-overwrite` | Banner title: `Autosave paused`; no keep-editing action. |
 | Document | Review handoff idle | Open a local file while a watcher is connected | `review-handoff-button` | Header text: `Agent watching`. |
-| Document | Review handoff comment popover | Open a local file while a watcher is connected, then click the handoff dropdown trigger | `review-handoff-comment-trigger`, `review-handoff-comment-popover`, `review-handoff-overall-comment` | Capture the split handoff control and textarea before submission. |
+| Document | Review handoff comment popover | Open a local file while a watcher is connected, then click the handoff dropdown trigger | `review-handoff-comment-trigger`, `review-handoff-comment-popover`, `review-handoff-overall-comment` | Capture the split handoff control and textarea with `Overall comment` placeholder before submission. |
 | Document | Review handoff sending | Click handoff button while watcher is connected | `review-handoff-button` | Button label: `Sending`. |
 | Document | Review handoff sent | Successful handoff | `review-handoff-status` | Popover title: `Your agent is now working`. |
 | Document | Review handoff undelivered | Watcher disconnects before handoff | `review-handoff-status` | Popover title: `No agent is watching now`. |

--- a/packages/app/e2e/criticmarkup-review.spec.ts
+++ b/packages/app/e2e/criticmarkup-review.spec.ts
@@ -96,6 +96,44 @@ test.describe("CriticMarkup review flows", () => {
     });
   });
 
+  test("shows tooltips for selection menu formatting actions", async ({
+    page,
+  }) => {
+    const filePath = writeProjectFile(
+      projectDir,
+      "selection-tooltips.md",
+      [
+        "# Selection Tooltips",
+        "",
+        "This paragraph has target text to review.",
+        "",
+      ].join("\n"),
+    );
+
+    await openMarkdownFile(page, filePath);
+    await selectRichText(page, "target text");
+
+    await page.getByTestId("selection-menu-action-bold").hover();
+    await expect(
+      page.locator('[data-slot="tooltip-content"][data-open]'),
+    ).toHaveText("Bold");
+
+    await expect(
+      page.getByTestId("selection-menu-action-suggest-insertion"),
+    ).toHaveCount(0);
+    await expect(
+      page.getByTestId("selection-menu-action-suggest-deletion"),
+    ).toHaveCount(0);
+    await expect(
+      page.getByTestId("selection-menu-action-suggest-replacement"),
+    ).toHaveCount(0);
+
+    await page.getByTestId("selection-menu-action-comment").hover();
+    await expect(
+      page.locator('[data-slot="tooltip-content"][data-open]'),
+    ).toHaveCount(0);
+  });
+
   test("accepts and rejects suggested changes on disk @smoke", async ({
     page,
   }) => {

--- a/packages/app/e2e/criticmarkup-review.spec.ts
+++ b/packages/app/e2e/criticmarkup-review.spec.ts
@@ -114,9 +114,9 @@ test.describe("CriticMarkup review flows", () => {
     await selectRichText(page, "target text");
 
     await page.getByTestId("selection-menu-action-bold").hover();
-    await expect(
-      page.locator('[data-slot="tooltip-content"][data-open]'),
-    ).toHaveText("Bold");
+    await expect(page.getByTestId("selection-menu-action-tooltip")).toHaveText(
+      "Bold",
+    );
 
     await expect(
       page.getByTestId("selection-menu-action-suggest-insertion"),
@@ -129,9 +129,9 @@ test.describe("CriticMarkup review flows", () => {
     ).toHaveCount(0);
 
     await page.getByTestId("selection-menu-action-comment").hover();
-    await expect(
-      page.locator('[data-slot="tooltip-content"][data-open]'),
-    ).toHaveCount(0);
+    await expect(page.getByTestId("selection-menu-action-tooltip")).toHaveCount(
+      0,
+    );
   });
 
   test("accepts and rejects suggested changes on disk @smoke", async ({

--- a/packages/app/e2e/markdown-roundtrip.spec.ts
+++ b/packages/app/e2e/markdown-roundtrip.spec.ts
@@ -100,7 +100,10 @@ test.describe("markdown round-trips", () => {
 
     await openMarkdownFile(page, filePath);
 
-    await expect(documentSaveStatus(page)).toContainText("Saved");
+    await expect(documentSaveStatus(page)).toHaveAttribute(
+      "aria-label",
+      "Saved",
+    );
 
     logE2eEvent("markdown-roundtrip.initial-saved", {
       file: "initial-saved.md",
@@ -123,7 +126,10 @@ test.describe("markdown round-trips", () => {
     await expect
       .poll(() => readProjectFile(projectDir, "manual-save.md"))
       .toContain("Saved by shortcut.");
-    await expect(documentSaveStatus(page)).toContainText("Saved");
+    await expect(documentSaveStatus(page)).toHaveAttribute(
+      "aria-label",
+      "Saved",
+    );
 
     logE2eEvent("markdown-roundtrip.manual-save-shortcut", {
       file: "manual-save.md",
@@ -152,7 +158,10 @@ test.describe("markdown round-trips", () => {
     await expect
       .poll(() => readProjectFile(projectDir, "rich-save.md"))
       .toContain("Saved by shortcut.");
-    await expect(documentSaveStatus(page)).toContainText("Saved");
+    await expect(documentSaveStatus(page)).toHaveAttribute(
+      "aria-label",
+      "Saved",
+    );
 
     logE2eEvent("markdown-roundtrip.rich-manual-save", {
       file: "rich-save.md",
@@ -202,7 +211,10 @@ test.describe("markdown round-trips", () => {
         { defaultPrevented: true, metaKey: true, ctrlKey: false },
         { defaultPrevented: true, metaKey: false, ctrlKey: true },
       ]);
-      await expect(documentSaveStatus(page)).toContainText("Saved");
+      await expect(documentSaveStatus(page)).toHaveAttribute(
+        "aria-label",
+        "Saved",
+      );
     }
 
     logE2eEvent("markdown-roundtrip.save-default-prevented", {

--- a/packages/app/e2e/preview.spec.ts
+++ b/packages/app/e2e/preview.spec.ts
@@ -34,7 +34,8 @@ test.describe("in-memory preview", () => {
     await page.goto("/preview");
 
     await expect(page.getByTestId("review-handoff-button")).toHaveCount(0);
-    await expect(page.getByTestId("document-save-status")).toContainText(
+    await expect(page.getByTestId("document-save-status")).toHaveAttribute(
+      "aria-label",
       "Saved",
     );
 

--- a/packages/app/e2e/stale-write.spec.ts
+++ b/packages/app/e2e/stale-write.spec.ts
@@ -41,7 +41,10 @@ test.describe("stale writes", () => {
     fs.writeFileSync(filePath, "# Conflict\n\nExternal body.\n");
     await appendInCodeEditor(page, "\nLocal body.\n");
 
-    await expect(documentSaveStatus(page)).toContainText("Save conflict");
+    await expect(documentSaveStatus(page)).toHaveAttribute(
+      "aria-label",
+      "Save conflict",
+    );
     await expect(page.getByTestId("file-conflict-action-reload")).toBeVisible();
     await expect(
       page.getByTestId("file-conflict-action-keep-editing"),
@@ -51,7 +54,10 @@ test.describe("stale writes", () => {
     );
 
     await page.getByTestId("file-conflict-action-keep-editing").click();
-    await expect(documentSaveStatus(page)).toContainText("Autosave paused");
+    await expect(documentSaveStatus(page)).toHaveAttribute(
+      "aria-label",
+      "Autosave paused",
+    );
     await appendInCodeEditor(page, "\nStill local.\n");
     await expect(codeEditor(page)).toContainText("Local body.");
     await expect(codeEditor(page)).toContainText("Still local.");
@@ -81,15 +87,27 @@ test.describe("stale writes", () => {
     fs.writeFileSync(filePath, "# Conflict\n\nExternal body.\n");
     await appendInCodeEditor(page, "\nLocal overwrite body.\n");
 
-    await expect(documentSaveStatus(page)).toContainText("Save conflict");
+    await expect(documentSaveStatus(page)).toHaveAttribute(
+      "aria-label",
+      "Save conflict",
+    );
     await page.getByTestId("file-conflict-action-overwrite").click();
 
     await expect
       .poll(() => readProjectFile(projectDir, "overwrite-conflict.md"))
       .toContain("Local overwrite body.");
-    await expect(documentSaveStatus(page)).toContainText("Saved");
-    await expect(documentSaveStatus(page)).not.toContainText("Save failed");
-    await expect(documentSaveStatus(page)).not.toContainText("Unsaved changes");
+    await expect(documentSaveStatus(page)).toHaveAttribute(
+      "aria-label",
+      "Saved",
+    );
+    await expect(documentSaveStatus(page)).not.toHaveAttribute(
+      "aria-label",
+      "Save failed",
+    );
+    await expect(documentSaveStatus(page)).not.toHaveAttribute(
+      "aria-label",
+      "Unsaved changes",
+    );
 
     logE2eEvent("stale-write.overwrite-saved", {
       file: "overwrite-conflict.md",
@@ -117,7 +135,10 @@ test.describe("stale writes", () => {
       process.platform === "darwin" ? "Meta+S" : "Control+S",
     );
 
-    await expect(documentSaveStatus(page)).toContainText("Save conflict");
+    await expect(documentSaveStatus(page)).toHaveAttribute(
+      "aria-label",
+      "Save conflict",
+    );
     await expect(fileConflictNotice(page)).toContainText(
       "This file changed on disk while you have unsaved edits.",
     );
@@ -148,7 +169,10 @@ test.describe("stale writes", () => {
     fs.utimesSync(filePath, fixedTimestamp, fixedTimestamp);
     await appendInCodeEditor(page, "\nLocal body.\n");
 
-    await expect(documentSaveStatus(page)).toContainText("Save conflict");
+    await expect(documentSaveStatus(page)).toHaveAttribute(
+      "aria-label",
+      "Save conflict",
+    );
     expect(readProjectFile(projectDir, "metadata-conflict.md")).toBe(
       "# External\n",
     );

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -26,7 +26,6 @@ import {
   SelectItem,
   SelectItemText,
   SelectTrigger,
-  SelectValue,
 } from "./components/ui/select";
 import { Textarea } from "./components/ui/textarea";
 import {
@@ -36,6 +35,7 @@ import {
 } from "./components/ui/tooltip";
 import { criticMarkdownHasReviewRail } from "./critic-markup";
 import { cn } from "./lib/utils";
+import { toHtml } from "./markdown";
 import {
   type DocumentInteractionMode,
   type DocumentSaveController,
@@ -51,11 +51,12 @@ type ReviewHandoffState =
   | "notified"
   | "undelivered"
   | "error";
+type FileCopyAction = "path" | "filename" | "markdown" | "rich-text";
 
 const documentInteractionModeOptions = [
-  { value: "editing", label: "editing", Icon: PencilLine },
-  { value: "suggesting", label: "suggesting", Icon: MessageSquarePlus },
-  { value: "viewing", label: "viewing", Icon: Eye },
+  { value: "editing", label: "Editing", Icon: PencilLine },
+  { value: "suggesting", label: "Suggesting", Icon: MessageSquarePlus },
+  { value: "viewing", label: "Viewing", Icon: Eye },
 ] satisfies {
   value: DocumentInteractionMode;
   label: string;
@@ -82,6 +83,38 @@ const conflictNoticeCopy: Record<
     body: "Keep editing locally, then reload from disk to discard your draft or overwrite the disk file when you are ready.",
   },
 };
+
+const fileCopyMenuOptions = [
+  { action: "path", label: "Copy path" },
+  { action: "filename", label: "Copy filename" },
+  { action: "markdown", label: "Copy markdown" },
+  { action: "rich-text", label: "Copy rich text" },
+] satisfies {
+  action: FileCopyAction;
+  label: string;
+}[];
+
+async function writePlainTextToClipboard(text: string) {
+  await navigator.clipboard.writeText(text);
+}
+
+async function writeRichTextToClipboard(markdown: string) {
+  const clipboardWithRichText = navigator.clipboard as Clipboard & {
+    write?: Clipboard["write"];
+  };
+
+  if (clipboardWithRichText.write && typeof ClipboardItem !== "undefined") {
+    await clipboardWithRichText.write([
+      new ClipboardItem({
+        "text/html": new Blob([toHtml(markdown)], { type: "text/html" }),
+        "text/plain": new Blob([markdown], { type: "text/plain" }),
+      }),
+    ]);
+    return;
+  }
+
+  await writePlainTextToClipboard(markdown);
+}
 
 function getSaveStatusViewModel(
   saveState: DocumentSaveState,
@@ -136,8 +169,8 @@ function getSaveStatusViewModel(
     return {
       label: "Unsaved changes",
       ariaLabel: "Unsaved changes",
-      tone: "warning" as const,
-      Icon: AlertTriangle,
+      tone: "neutral" as const,
+      Icon: Loader2,
     };
   }
 
@@ -165,17 +198,22 @@ export function DocumentSaveStatusIndicator({
       role="status"
       aria-label={saveStatus.ariaLabel}
       className={cn(
-        "inline-flex h-7 max-w-full shrink-0 items-center gap-1.5 px-1 font-mono text-[0.68rem] leading-none text-stone-400 dark:text-stone-500",
+        "inline-flex size-7 shrink-0 items-center justify-center text-stone-400 dark:text-stone-500",
+        saveStatus.tone === "warning" && "text-amber-600 dark:text-amber-400",
+        saveStatus.tone === "danger" && "text-red-600 dark:text-red-400",
       )}
     >
       <SaveStatusIcon
+        data-testid="document-save-status-icon"
         className={cn(
           "size-3.5 shrink-0",
-          saveStatus.label === "Saving" && "animate-spin",
+          (saveStatus.label === "Saving" ||
+            saveStatus.label === "Unsaved changes") &&
+            "animate-spin",
+          saveStatus.label === "Saved" && "document-save-status-saved",
         )}
         aria-hidden="true"
       />
-      <span className="min-w-0 truncate">{saveStatus.label}</span>
     </span>
   );
 }
@@ -245,6 +283,9 @@ export function DocumentWorkspace({
   const [reviewWatcherCount, setReviewWatcherCount] = useState(0);
   const [reviewHandoffPopoverOpen, setReviewHandoffPopoverOpen] =
     useState(false);
+  const [fileCopyMenuOpen, setFileCopyMenuOpen] = useState(false);
+  const [copiedFileAction, setCopiedFileAction] =
+    useState<FileCopyAction | null>(null);
   const [overallComment, setOverallComment] = useState("");
   const sawNoWatcherAfterNotifiedRef = useRef(false);
   const saveControllerRef = useRef<DocumentSaveController | null>(null);
@@ -375,6 +416,36 @@ export function DocumentWorkspace({
       }
     },
     [activeDocumentPath, onCompleteReview, reviewHandoffState],
+  );
+
+  const handleCopyFileMenuAction = useCallback(
+    async (action: FileCopyAction) => {
+      if (!documentPage) return;
+
+      const copyTextByAction: Record<
+        Exclude<FileCopyAction, "rich-text">,
+        string
+      > = {
+        path: activeDocumentPath ?? documentFilenameLabel,
+        filename: documentFilenameLabel,
+        markdown: documentPage.content,
+      };
+
+      try {
+        if (action === "rich-text") {
+          await writeRichTextToClipboard(documentPage.content);
+        } else {
+          await writePlainTextToClipboard(copyTextByAction[action]);
+        }
+
+        setCopiedFileAction(action);
+        window.setTimeout(() => setCopiedFileAction(null), 1400);
+        setFileCopyMenuOpen(false);
+      } catch (error) {
+        console.error("Failed to copy document data:", error);
+      }
+    },
+    [activeDocumentPath, documentFilenameLabel, documentPage],
   );
 
   const editorViewModeToggleLabel =
@@ -511,22 +582,18 @@ export function DocumentWorkspace({
                     }}
                   >
                     <div>
-                      <label
-                        htmlFor="review-handoff-overall-comment"
-                        className="text-sm font-semibold text-stone-950 dark:text-slate-50"
-                      >
-                        Overall comment
-                      </label>
                       <Textarea
                         id="review-handoff-overall-comment"
                         data-testid="review-handoff-overall-comment"
+                        aria-label="Overall comment"
+                        placeholder="Overall comment"
                         value={overallComment}
                         onChange={(event) =>
                           setOverallComment(event.currentTarget.value)
                         }
                         maxLength={4000}
                         rows={4}
-                        className="mt-2 min-h-24 resize-y"
+                        className="min-h-24 resize-y"
                       />
                     </div>
                     <Button
@@ -566,12 +633,6 @@ export function DocumentWorkspace({
             </Popover>
           ) : null}
         </div>
-        {documentPage ? (
-          <DocumentSaveStatusIndicator
-            saveState={saveState}
-            diskChangeState={documentDiskChangeState}
-          />
-        ) : null}
       </div>
       {conflictNotice ? (
         <div
@@ -651,7 +712,7 @@ export function DocumentWorkspace({
                       <button
                         type="button"
                         data-testid="document-editor-view-toggle"
-                        className="grid h-[1.25rem] shrink-0 grid-cols-2 rounded-[999px] bg-[#DED8CE] dark:bg-slate-700 px-[2px] py-[2px] shadow-[inset_0_1px_0_rgba(255,251,245,0.72)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+                        className="grid h-[1.25rem] shrink-0 grid-cols-2 rounded-[999px] bg-[#E8E3DB] dark:bg-slate-700 px-[2px] pt-[3px] pb-[3px] shadow-[inset_0_1px_0_rgba(255,251,245,0.72)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
                       >
                         <span
                           className={`flex h-[1rem] w-[1.375rem] items-center justify-center rounded-full transition ${
@@ -684,12 +745,57 @@ export function DocumentWorkspace({
                   />
                   <TooltipContent>{editorViewModeToggleLabel}</TooltipContent>
                 </Tooltip>
-                <div
-                  className="min-w-0 truncate font-mono text-[0.7rem] tracking-[0.01em] text-stone-400 dark:text-stone-500"
-                  title={documentFilenameLabel}
+                <Popover
+                  open={fileCopyMenuOpen}
+                  onOpenChange={setFileCopyMenuOpen}
                 >
-                  {documentFilenameLabel}
-                </div>
+                  <PopoverTrigger
+                    render={
+                      <button
+                        type="button"
+                        data-testid="document-file-menu-trigger"
+                        className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-full px-1 py-0.5 font-mono text-[0.7rem] tracking-[0.01em] text-stone-400 outline-none transition hover:bg-[#EEE9E1] hover:text-stone-600 focus-visible:ring-2 focus-visible:ring-stone-300/70 dark:text-stone-500 dark:hover:bg-slate-800 dark:hover:text-stone-300 dark:focus-visible:ring-slate-600/70"
+                        title={documentFilenameLabel}
+                        aria-label="Document file actions"
+                      >
+                        <span className="min-w-0 truncate">
+                          {documentFilenameLabel}
+                        </span>
+                        <ChevronDown
+                          className="size-[0.62rem] shrink-0"
+                          aria-hidden="true"
+                        />
+                      </button>
+                    }
+                  />
+                  <PopoverContent
+                    aria-label="Document file actions"
+                    data-testid="document-file-menu"
+                    className="w-44 p-1"
+                    align="start"
+                  >
+                    <div className="flex flex-col">
+                      {fileCopyMenuOptions.map(({ action, label }) => (
+                        <button
+                          key={action}
+                          type="button"
+                          data-testid={`document-file-menu-${action}`}
+                          className="flex h-8 items-center justify-between rounded-md px-2 text-left text-[0.72rem] leading-none text-stone-700 outline-none transition hover:bg-[#EEE9E1] focus-visible:bg-[#EEE9E1] dark:text-stone-300 dark:hover:bg-slate-700 dark:focus-visible:bg-slate-700"
+                          onClick={() => void handleCopyFileMenuAction(action)}
+                        >
+                          <span>{label}</span>
+                          {copiedFileAction === action ? (
+                            <Check className="size-3 text-stone-500 dark:text-stone-400" />
+                          ) : null}
+                        </button>
+                      ))}
+                    </div>
+                  </PopoverContent>
+                </Popover>
+                <DocumentSaveStatusIndicator
+                  saveState={saveState}
+                  diskChangeState={documentDiskChangeState}
+                />
                 <div className="ml-auto inline-flex h-[1.25rem] shrink-0 items-center">
                   <Select<DocumentInteractionMode>
                     value={documentInteractionMode}
@@ -703,7 +809,9 @@ export function DocumentWorkspace({
                       className="h-[1.5rem] px-1 font-mono text-[0.7rem] leading-[1.25rem] font-normal tracking-[0.01em] text-stone-400 dark:text-stone-500 hover:text-stone-500 dark:hover:text-stone-400"
                     >
                       <ActiveDocumentInteractionModeIcon className="size-[0.68rem]" />
-                      <SelectValue />
+                      <span className="truncate">
+                        {activeDocumentInteractionMode?.label}
+                      </span>
                     </SelectTrigger>
                     <SelectContent>
                       {documentInteractionModeOptions.map(

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -227,9 +227,11 @@ export function isReviewHandoffDisabled({
   documentDiskChangeState: DiskChangeState;
   reviewHandoffState: ReviewHandoffState;
 }) {
+  // Transient save states ("saving"/"unsaved") intentionally do NOT disable the
+  // button. Disabling on them dims the whole control on every keystroke while
+  // autosave debounces. Instead the button stays enabled and flushes the
+  // pending save on click, so the agent still receives the latest content.
   return (
-    saveState === "saving" ||
-    saveState === "unsaved" ||
     saveState === "error" ||
     reviewHandoffState !== "idle" ||
     documentDiskChangeState !== "clean"
@@ -398,6 +400,13 @@ export function DocumentWorkspace({
 
       setReviewHandoffState("notifying");
       try {
+        // The button stays enabled while autosave is still pending, so make
+        // sure any debounced edits are persisted before handing off.
+        const flushResult = await saveControllerRef.current?.flushSave();
+        if (flushResult && flushResult.status === "error") {
+          throw flushResult.error;
+        }
+
         const result = await onCompleteReview(options);
         if (result.delivered) {
           setReviewWatcherCount(0);
@@ -519,7 +528,7 @@ export function DocumentWorkspace({
               open={reviewHandoffPopoverOpen}
               onOpenChange={setReviewHandoffPopoverOpen}
             >
-              <div className="relative flex items-center overflow-hidden rounded-[7px] shadow-[0_10px_28px_rgba(0,0,0,0.18)] after:pointer-events-none after:absolute after:top-px after:right-8 after:bottom-px after:z-10 after:w-px after:bg-slate-700 after:content-[''] dark:after:bg-slate-700">
+              <div className="relative flex items-center overflow-hidden rounded-[7px] shadow-[0_10px_28px_rgba(0,0,0,0.18)] after:pointer-events-none after:absolute after:top-px after:right-8 after:bottom-px after:z-10 after:w-px after:bg-[#444] after:content-[''] dark:after:bg-[#444]">
                 <Button
                   type="button"
                   data-testid="review-handoff-button"
@@ -712,10 +721,10 @@ export function DocumentWorkspace({
                       <button
                         type="button"
                         data-testid="document-editor-view-toggle"
-                        className="grid h-[1.25rem] shrink-0 grid-cols-2 rounded-[999px] bg-[#E8E3DB] dark:bg-slate-700 px-[2px] pt-[3px] pb-[3px] shadow-[inset_0_1px_0_rgba(255,251,245,0.72)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+                        className="grid shrink-0 grid-cols-2 rounded-[999px] bg-[#E8E3DB] dark:bg-slate-700 px-[2px] pt-[3px] pb-[2px] shadow-[inset_0_1px_0_rgba(255,251,245,0.72)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
                       >
                         <span
-                          className={`flex h-[1rem] w-[1.375rem] items-center justify-center rounded-full transition ${
+                          className={`flex w-[1.375rem] items-center justify-center rounded-full py-[2px] transition ${
                             documentEditorViewMode === "rich-text"
                               ? "bg-[#FFFDFC] dark:bg-slate-500 text-stone-700 dark:text-white shadow-[0_1px_2px_rgba(41,37,36,0.12)]"
                               : "text-stone-500 dark:text-slate-400"
@@ -724,7 +733,7 @@ export function DocumentWorkspace({
                           <Eye className="size-[0.75rem]" />
                         </span>
                         <span
-                          className={`flex h-[1rem] w-[1.375rem] items-center justify-center rounded-full transition ${
+                          className={`flex w-[1.375rem] items-center justify-center rounded-full py-[2px] transition ${
                             documentEditorViewMode === "code"
                               ? "bg-[#FFFDFC] dark:bg-slate-500 text-stone-700 dark:text-white shadow-[0_1px_2px_rgba(41,37,36,0.12)]"
                               : "text-stone-500 dark:text-slate-400"

--- a/packages/app/src/EditorContextMenu.tsx
+++ b/packages/app/src/EditorContextMenu.tsx
@@ -12,10 +12,7 @@ import {
   List,
   ListOrdered,
   MessageSquarePlus,
-  Minus,
-  Plus,
   Quote,
-  Replace,
   Trash2,
   X,
 } from "lucide-react";
@@ -23,6 +20,11 @@ import {
   getAddCommentShortcutLabel,
   matchesAddCommentShortcut,
 } from "./comment-shortcuts";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "./components/ui/tooltip";
 import { toHtml } from "./markdown";
 import type { StorageBackend } from "./storage";
 
@@ -169,13 +171,13 @@ function SelectionMenuButton({
   disabled?: boolean;
   onClick: () => void;
 }) {
-  return (
+  const button = (
     <button
       type="button"
       data-testid={`selection-menu-action-${toTestIdSegment(label)}`}
       className={`inline-flex size-9 items-center justify-center rounded-xl border text-slate-600 dark:text-slate-400 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300 dark:focus-visible:ring-slate-600 ${
         active
-          ? "border-slate-900 bg-slate-900 dark:border-slate-100 dark:bg-slate-100 text-white dark:text-slate-900 shadow-[0_8px_18px_rgba(15,23,42,0.18)]"
+          ? "border-sky-200 bg-sky-100 text-sky-950 shadow-[0_8px_18px_rgba(14,116,144,0.14)] dark:border-sky-500/30 dark:bg-sky-400/20 dark:text-sky-100"
           : "border-transparent hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-900 dark:hover:text-slate-100"
       } disabled:cursor-not-allowed disabled:opacity-40`}
       onMouseDown={(event) => {
@@ -186,10 +188,16 @@ function SelectionMenuButton({
       disabled={disabled}
       aria-label={label}
       aria-pressed={active}
-      title={label}
     >
       {icon}
     </button>
+  );
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={button} />
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -642,7 +650,7 @@ export function EditorContextMenu({
       {selectionActionPosition && !linkPopoverState ? (
         <div
           data-testid="selection-menu"
-          className="absolute z-30 w-max max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-full rounded-[22px] border border-slate-200/90 dark:border-slate-700/90 bg-white/95 dark:bg-slate-800/95 p-2 shadow-[0_18px_48px_rgba(15,23,42,0.16)] dark:shadow-[0_18px_48px_rgba(0,0,0,0.4)] backdrop-blur-xl"
+          className="absolute z-30 w-max max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-full rounded-2xl border border-slate-200/90 dark:border-slate-700/90 bg-white/95 dark:bg-slate-800/95 p-2 shadow-[0_18px_48px_rgba(15,23,42,0.16)] dark:shadow-[0_18px_48px_rgba(0,0,0,0.4)] backdrop-blur-xl"
           style={{
             left: selectionActionPosition.left,
             top: selectionActionPosition.top,
@@ -701,100 +709,63 @@ export function EditorContextMenu({
               active={selectionMenuState.isLinkActive}
               onClick={openLinkPopover}
             />
-            <SelectionMenuButton
-              label="Suggest insertion"
-              icon={<Plus className="size-4" />}
-              disabled={!onSuggestInsertion}
-              onClick={() => {
-                onSuggestInsertion?.();
-                setSelectionActionPosition(null);
-              }}
-            />
-            <SelectionMenuButton
-              label="Suggest deletion"
-              icon={<Minus className="size-4" />}
-              disabled={!onSuggestDeletion || editor?.state.selection.empty}
-              onClick={() => {
-                onSuggestDeletion?.();
-                setSelectionActionPosition(null);
-              }}
-            />
-            <SelectionMenuButton
-              label="Suggest replacement"
-              icon={<Replace className="size-4" />}
-              disabled={!onSuggestReplacement || editor?.state.selection.empty}
-              onClick={() => {
-                onSuggestReplacement?.();
-                setSelectionActionPosition(null);
-              }}
-            />
           </div>
-          <div
-            className="my-2 h-px bg-slate-200/80 dark:bg-slate-700/80"
-            aria-hidden="true"
-          />
           {selectionMenuState.activeCriticChangeId ? (
-            <>
-              <div className="grid grid-cols-2 gap-1">
-                <button
-                  type="button"
-                  data-testid="selection-menu-action-accept-suggestion"
-                  className="inline-flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-emerald-700 transition hover:bg-emerald-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
-                  onMouseDown={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                  }}
-                  onClick={() => {
-                    if (selectionMenuState.activeCriticChangeId) {
-                      editor
-                        ?.chain()
-                        .focus()
-                        .acceptCriticChange(
-                          selectionMenuState.activeCriticChangeId,
-                        )
-                        .run();
-                    }
-                    setSelectionActionPosition(null);
-                  }}
-                >
-                  <Check className="size-4" />
-                  <span>Accept</span>
-                </button>
-                <button
-                  type="button"
-                  data-testid="selection-menu-action-reject-suggestion"
-                  className="inline-flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-rose-700 transition hover:bg-rose-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-300"
-                  onMouseDown={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                  }}
-                  onClick={() => {
-                    if (selectionMenuState.activeCriticChangeId) {
-                      editor
-                        ?.chain()
-                        .focus()
-                        .rejectCriticChange(
-                          selectionMenuState.activeCriticChangeId,
-                        )
-                        .run();
-                    }
-                    setSelectionActionPosition(null);
-                  }}
-                >
-                  <X className="size-4" />
-                  <span>Reject</span>
-                </button>
-              </div>
-              <div
-                className="my-2 h-px bg-slate-200/80 dark:bg-slate-700/80"
-                aria-hidden="true"
-              />
-            </>
+            <div className="grid grid-cols-2 gap-1">
+              <button
+                type="button"
+                data-testid="selection-menu-action-accept-suggestion"
+                className="inline-flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-emerald-700 transition hover:bg-emerald-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                }}
+                onClick={() => {
+                  if (selectionMenuState.activeCriticChangeId) {
+                    editor
+                      ?.chain()
+                      .focus()
+                      .acceptCriticChange(
+                        selectionMenuState.activeCriticChangeId,
+                      )
+                      .run();
+                  }
+                  setSelectionActionPosition(null);
+                }}
+              >
+                <Check className="size-4" />
+                <span>Accept</span>
+              </button>
+              <button
+                type="button"
+                data-testid="selection-menu-action-reject-suggestion"
+                className="inline-flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-rose-700 transition hover:bg-rose-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-300"
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                }}
+                onClick={() => {
+                  if (selectionMenuState.activeCriticChangeId) {
+                    editor
+                      ?.chain()
+                      .focus()
+                      .rejectCriticChange(
+                        selectionMenuState.activeCriticChangeId,
+                      )
+                      .run();
+                  }
+                  setSelectionActionPosition(null);
+                }}
+              >
+                <X className="size-4" />
+                <span>Reject</span>
+              </button>
+            </div>
           ) : null}
           <button
             type="button"
             data-testid="selection-menu-action-comment"
-            className="flex w-full items-center justify-between gap-3 rounded-xl px-3 py-2 text-left text-sm font-medium text-slate-700 dark:text-slate-300 transition hover:bg-slate-100 dark:hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300 dark:focus-visible:ring-slate-600"
+            className="mt-2 flex w-full items-center justify-center gap-2 rounded-xl bg-[#E8E3DB] px-3 py-2 text-left text-sm font-bold text-black shadow-[inset_0_1px_0_rgba(255,251,245,0.72)] transition hover:bg-[#ded8ce] focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300 dark:bg-slate-700 dark:text-slate-100 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] dark:hover:bg-slate-600 dark:focus-visible:ring-slate-600 disabled:cursor-not-allowed disabled:opacity-40"
             disabled={!onAddComment || editor?.state.selection.empty}
             onMouseDown={(event) => {
               event.preventDefault();
@@ -808,9 +779,6 @@ export function EditorContextMenu({
             <span className="inline-flex items-center gap-2">
               <MessageSquarePlus className="size-4.5" />
               <span>Comment</span>
-            </span>
-            <span className="rounded-full border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 px-2.5 py-1 text-[11px] font-semibold tracking-[0.01em] text-slate-500 dark:text-slate-400">
-              {shortcutLabel}
             </span>
           </button>
         </div>

--- a/packages/app/src/EditorContextMenu.tsx
+++ b/packages/app/src/EditorContextMenu.tsx
@@ -196,7 +196,9 @@ function SelectionMenuButton({
   return (
     <Tooltip>
       <TooltipTrigger render={button} />
-      <TooltipContent>{label}</TooltipContent>
+      <TooltipContent data-testid="selection-menu-action-tooltip">
+        {label}
+      </TooltipContent>
     </Tooltip>
   );
 }

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -718,3 +718,18 @@
   --code-block-border: oklch(1 0 0 / 10%);
   --code-block-foreground: oklch(0.985 0 0);
 }
+
+@keyframes document-save-status-saved-fade {
+  0%,
+  20% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+  }
+}
+
+.document-save-status-saved {
+  animation: document-save-status-saved-fade 2s ease-out forwards;
+}

--- a/packages/app/test/view-toggle-bugs.test.tsx
+++ b/packages/app/test/view-toggle-bugs.test.tsx
@@ -262,6 +262,7 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
       root.unmount();
     });
     container.remove();
+    Reflect.deleteProperty(globalThis, "ClipboardItem");
     vi.restoreAllMocks();
   });
 
@@ -285,10 +286,12 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
 
   async function renderWorkspace({
     documentDiskChangeState = "clean",
+    documentContent = "Hello world",
     watcherCount = 0,
     onSaveDocument = async () => {},
   }: {
     documentDiskChangeState?: "clean" | "changed" | "conflict" | "paused";
+    documentContent?: string;
     watcherCount?: number;
     onSaveDocument?: (id: string, content: string) => Promise<void>;
   } = {}) {
@@ -299,7 +302,7 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     await act(async () => {
       root.render(
         <DocumentWorkspace
-          documentPage={createPage()}
+          documentPage={createPage(documentContent)}
           activeDocumentPath="test.md"
           documentFilenameLabel="test.md"
           documentEditorViewMode="rich-text"
@@ -321,20 +324,28 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     });
   }
 
+  async function openFileMenu() {
+    await click(getByTestId(container, "document-file-menu-trigger"));
+    return getByTestId(document.body, "document-file-menu");
+  }
+
   it.each([
-    ["saved", "Saved"],
-    ["saving", "Saving"],
-    ["unsaved", "Unsaved changes"],
-    ["error", "Save failed"],
+    ["saved", "Saved", "document-save-status-saved"],
+    ["saving", "Saving", "animate-spin"],
+    ["unsaved", "Unsaved changes", "animate-spin"],
+    ["error", "Save failed", ""],
   ] satisfies Array<
-    [DocumentSaveState, string]
-  >)("shows persistent %s save status", async (saveState, label) => {
+    [DocumentSaveState, string, string]
+  >)("shows icon-only %s save status", async (saveState, label, iconClass) => {
     await renderSaveStatus({ saveState });
 
-    expect(
-      getByTestId(container, "document-save-status").textContent,
-    ).toContain(label);
-    expect(container.textContent).toContain(label);
+    const status = getByTestId(container, "document-save-status");
+    expect(status.getAttribute("aria-label")).toBe(label);
+    expect(status.textContent).toBe("");
+    const icon = getByTestId(status, "document-save-status-icon");
+    if (iconClass) {
+      expect(icon.classList.contains(iconClass)).toBe(true);
+    }
   });
 
   it.each([
@@ -344,16 +355,17 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
   ] as const)("shows disk-blocked %s save status", async (state, label) => {
     await renderSaveStatus({ documentDiskChangeState: state });
 
-    expect(
-      getByTestId(container, "document-save-status").textContent,
-    ).toContain(label);
-    expect(container.textContent).toContain(label);
+    const status = getByTestId(container, "document-save-status");
+    expect(status.getAttribute("aria-label")).toBe(label);
+    expect(status.textContent).toBe("");
+    expect(getByTestId(status, "document-save-status-icon")).not.toBeNull();
   });
 
-  it("renders save status below the handoff button when handoff exists", async () => {
+  it("renders save status next to the filename when handoff exists", async () => {
     await renderWorkspace({ watcherCount: 1 });
 
     const stack = queryByTestId(container, "document-status-stack");
+    const header = getByTestId(container, "document-page-header");
     const doneReviewingButton = queryByTestId(
       container,
       "review-handoff-button",
@@ -362,16 +374,79 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     expect(doneReviewingButton).toBeDefined();
     expect(doneReviewingButton?.textContent).toContain("I'm done");
     expect(doneReviewingButton?.textContent).not.toContain("Saved");
-    expect(stack?.textContent).toContain("Saved");
+    expect(stack?.textContent).not.toContain("Saved");
+    expect(header.textContent).toContain("test.md");
+    expect(header.textContent).not.toContain("Saved");
+    expect(
+      getByTestId(header, "document-save-status").getAttribute("aria-label"),
+    ).toBe("Saved");
   });
 
-  it("renders standalone save status in the top-right stack without handoff", async () => {
+  it("renders save status next to the filename without handoff", async () => {
     await renderWorkspace();
 
     const stack = queryByTestId(container, "document-status-stack");
+    const header = getByTestId(container, "document-page-header");
     expect(stack).not.toBeNull();
     expect(stack?.textContent).not.toContain("I'm done");
-    expect(stack?.textContent).toContain("Saved");
+    expect(stack?.textContent).not.toContain("Saved");
+    expect(header.textContent).toContain("test.md");
+    expect(header.textContent).not.toContain("Saved");
+    expect(
+      getByTestId(header, "document-save-status").getAttribute("aria-label"),
+    ).toBe("Saved");
+  });
+
+  it.each([
+    ["path", "test.md"],
+    ["filename", "test.md"],
+    ["markdown", "# Heading\n\nBody"],
+  ] as const)("copies document %s from the file menu", async (action, text) => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    await renderWorkspace({ documentContent: "# Heading\n\nBody" });
+    await openFileMenu();
+    await click(getByTestId(document.body, `document-file-menu-${action}`));
+
+    expect(writeText).toHaveBeenCalledWith(text);
+  });
+
+  it("copies document rich text with html and plain markdown flavors", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const clipboardItems: Array<Record<string, Blob>> = [];
+    class ClipboardItemMock {
+      items: Record<string, Blob>;
+
+      constructor(items: Record<string, Blob>) {
+        this.items = items;
+        clipboardItems.push(items);
+      }
+    }
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { write },
+    });
+    Object.defineProperty(globalThis, "ClipboardItem", {
+      configurable: true,
+      value: ClipboardItemMock,
+    });
+
+    await renderWorkspace({ documentContent: "# Heading\n\nBody" });
+    await openFileMenu();
+    await click(getByTestId(document.body, "document-file-menu-rich-text"));
+
+    expect(clipboardItems).toHaveLength(1);
+    expect(clipboardItems[0]).toEqual({
+      "text/html": expect.any(Blob),
+      "text/plain": expect.any(Blob),
+    });
+    expect(write).toHaveBeenCalledWith([
+      expect.objectContaining({ items: expect.any(Object) }),
+    ]);
   });
 
   it.each([
@@ -427,8 +502,8 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     expect(container.textContent).toContain("Save conflict");
     expect(container.textContent).toContain("This file changed on disk");
     expect(
-      getByTestId(container, "document-save-status").textContent,
-    ).toContain("Save conflict");
+      getByTestId(container, "document-save-status").getAttribute("aria-label"),
+    ).toBe("Save conflict");
   });
 
   it.each([
@@ -512,18 +587,18 @@ describe("interaction mode preserved across view toggle (issue 3 fix)", () => {
       });
     };
 
-    // Mount with rich-text → mode is "editing" by default
+    // Mount with rich-text -> mode is "Editing" by default
     await renderWorkspace("rich-text");
     expect(
       getByTestId(container, "document-mode-trigger").textContent,
-    ).toContain("editing");
+    ).toContain("Editing");
 
-    // Rerender with code view (same component instance, no remount) →
-    // mode stays "editing" because the component is not destroyed.
+    // Rerender with code view (same component instance, no remount) ->
+    // mode stays "Editing" because the component is not destroyed.
     await renderWorkspace("code");
     expect(
       getByTestId(container, "document-mode-trigger").textContent,
-    ).toContain("editing");
+    ).toContain("Editing");
   });
 });
 
@@ -670,6 +745,8 @@ describe("review handoff watcher affordance", () => {
     if (!textarea) {
       throw new Error("Overall comment textarea not found");
     }
+    expect(textarea.getAttribute("placeholder")).toBe("Overall comment");
+    expect(document.body.textContent).not.toContain("Overall comment");
 
     await change(textarea, "  Please prioritize the CLI contract.  ");
 

--- a/packages/app/test/view-toggle-bugs.test.tsx
+++ b/packages/app/test/view-toggle-bugs.test.tsx
@@ -507,8 +507,6 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
   });
 
   it.each([
-    ["saving", "clean"],
-    ["unsaved", "clean"],
     ["error", "clean"],
     ["saved", "conflict"],
   ] satisfies Array<
@@ -523,7 +521,22 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     ).toBe(true);
   });
 
-  it("allows handoff only when saved, conflict-free, and idle", () => {
+  it.each(["saving", "unsaved"] satisfies DocumentSaveState[])(
+    "keeps handoff enabled while a debounced save is pending (save state %s)",
+    (saveState) => {
+      // The button must not dim on every keystroke while autosave debounces; it
+      // stays enabled and flushes the pending save on click instead.
+      expect(
+        isReviewHandoffDisabled({
+          saveState,
+          documentDiskChangeState: "clean",
+          reviewHandoffState: "idle",
+        }),
+      ).toBe(false);
+    },
+  );
+
+  it("allows handoff when saved, conflict-free, and idle", () => {
     expect(
       isReviewHandoffDisabled({
         saveState: "saved",

--- a/packages/app/test/view-toggle-bugs.test.tsx
+++ b/packages/app/test/view-toggle-bugs.test.tsx
@@ -521,20 +521,20 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     ).toBe(true);
   });
 
-  it.each(["saving", "unsaved"] satisfies DocumentSaveState[])(
-    "keeps handoff enabled while a debounced save is pending (save state %s)",
-    (saveState) => {
-      // The button must not dim on every keystroke while autosave debounces; it
-      // stays enabled and flushes the pending save on click instead.
-      expect(
-        isReviewHandoffDisabled({
-          saveState,
-          documentDiskChangeState: "clean",
-          reviewHandoffState: "idle",
-        }),
-      ).toBe(false);
-    },
-  );
+  it.each([
+    "saving",
+    "unsaved",
+  ] satisfies DocumentSaveState[])("keeps handoff enabled while a debounced save is pending (save state %s)", (saveState) => {
+    // The button must not dim on every keystroke while autosave debounces; it
+    // stays enabled and flushes the pending save on click instead.
+    expect(
+      isReviewHandoffDisabled({
+        saveState,
+        documentDiskChangeState: "clean",
+        reviewHandoffState: "idle",
+      }),
+    ).toBe(false);
+  });
 
   it("allows handoff when saved, conflict-free, and idle", () => {
     expect(


### PR DESCRIPTION
## Summary

This polishes document editing controls so file actions, save state, review handoff, and selection formatting take less space while staying accessible. The filename menu now copies path, filename, markdown, or rich text; save state is icon-only next to the filename; review handoff stays enabled through pending autosaves and flushes before notifying. The selection toolbar now focuses on direct formatting and link actions with tooltips and a stronger comment action, while suggestion accept and reject remain contextual. Updated unit, selector, e2e, smoke coverage, and the screenshot guide for these states.

## Test Plan

- `pnpm check`
- `pnpm test:smoke`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
