### PR TITLE
chore: bump roughdraft to 0.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roughdraft",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "A local markdown review app",
   "license": "MIT",
   "author": "Nathan Baschez",


### PR DESCRIPTION
Bumps the published `roughdraft` package from 0.1.8 to 0.1.9 in the root `package.json`. This is the only file the publish pipeline reads, so merging to `main` triggers the npm publish workflow (which runs `pnpm check`, `npm publish`, and tags `v0.1.9`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)