### PR TITLE
fix: declare `yaml` as a root dependency so global installs work (#109)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   ],
   "dependencies": {
     "@roughdraft/rfm": "file:packages/rfm",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",

--- a/packages/server/src/packaging.test.ts
+++ b/packages/server/src/packaging.test.ts
@@ -9,9 +9,7 @@ const repoRoot = path.resolve(dirname, "../../..");
 function readPackageJson(relativePath: string): {
   dependencies?: Record<string, string>;
 } {
-  return JSON.parse(
-    fs.readFileSync(path.join(repoRoot, relativePath), "utf8"),
-  );
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, relativePath), "utf8"));
 }
 
 describe("published package dependencies", () => {
@@ -24,7 +22,8 @@ describe("published package dependencies", () => {
   // ERR_MODULE_NOT_FOUND.
   it("declares every @roughdraft/rfm runtime dependency in the root package", () => {
     const rootDeps = readPackageJson("package.json").dependencies ?? {};
-    const rfmDeps = readPackageJson("packages/rfm/package.json").dependencies ?? {};
+    const rfmDeps =
+      readPackageJson("packages/rfm/package.json").dependencies ?? {};
 
     const missing = Object.keys(rfmDeps).filter((dep) => !(dep in rootDeps));
 

--- a/packages/server/src/packaging.test.ts
+++ b/packages/server/src/packaging.test.ts
@@ -1,0 +1,37 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(dirname, "../../..");
+
+function readPackageJson(relativePath: string): {
+  dependencies?: Record<string, string>;
+} {
+  return JSON.parse(
+    fs.readFileSync(path.join(repoRoot, relativePath), "utf8"),
+  );
+}
+
+describe("published package dependencies", () => {
+  // Regression test for #109. The root `roughdraft` package ships
+  // `@roughdraft/rfm` as raw `dist` (see the `files` whitelist), so rfm's
+  // runtime `import`s are resolved from the installed package's node_modules
+  // at runtime — nothing bundles them. Any runtime dependency rfm declares
+  // must therefore also be declared in the root manifest, otherwise
+  // `npm i -g roughdraft` never installs it and the CLI crashes with
+  // ERR_MODULE_NOT_FOUND.
+  it("declares every @roughdraft/rfm runtime dependency in the root package", () => {
+    const rootDeps = readPackageJson("package.json").dependencies ?? {};
+    const rfmDeps = readPackageJson("packages/rfm/package.json").dependencies ?? {};
+
+    const missing = Object.keys(rfmDeps).filter((dep) => !(dep in rootDeps));
+
+    expect(
+      missing,
+      `rfm runtime deps missing from root package.json dependencies: ${missing.join(", ")}. ` +
+        "Promote them so a global install resolves them (see #109).",
+    ).toEqual([]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.12


### PR DESCRIPTION
## Summary

Fixes #109 — after a fresh `npm i -g roughdraft`, every command crashes with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'yaml' imported from
.../roughdraft/packages/rfm/dist/index.js
```

## Root cause

`@roughdraft/rfm`'s published `dist/index.js` does a **runtime** `import 'yaml'` in Node. `yaml` is declared as a dependency of the *private* `@roughdraft/rfm` workspace package, but the root `package.json` (what users install) only lists `@roughdraft/rfm` (via `file:packages/rfm`) and `express`. The root `files` whitelist ships `packages/rfm/dist` as raw, unbundled code, so its runtime imports are resolved from the installed package's `node_modules` — but `yaml` is never there, because it isn't declared in the manifest npm installs. The CLI is unusable.

(`packages/app` also imports `yaml`, but that's bundled into its browser build, so it's unaffected — this only bites the Node-resolved `rfm` runtime import.)

## Fix

Promote `yaml` to the root `dependencies` (matching `rfm`'s `^2.9.0` range). npm then installs `yaml` into the package's `node_modules`, where Node resolves it by walking up from `packages/rfm/dist`. This makes the documented #109 workaround permanent. Lockfile updated to add `yaml` to the root importer (the `yaml@2.9.0` snapshot was already present transitively).

## Following the repo Bug Fix Workflow ("Prove It")

1. **Reproduce first:** `packages/server/src/packaging.test.ts` asserts every runtime dependency of `@roughdraft/rfm` is declared in the root `package.json`. It **fails** on the missing `yaml` before the promotion and **passes** after — a behavioral guard for the whole class of "transitive workspace runtime dep not promoted to the published manifest", not just `yaml`.
2. **Fix:** promote `yaml` to the root manifest.
3. **Verify:** test passes; full gate green (below).

## Verification

Ran the full CI gate locally with **pnpm 10** (matching `ci.yml`'s `pnpm/action-setup@v4 version: 10`):

- ✅ `pnpm install --frozen-lockfile` — accepts the lockfile edit; installs `yaml 2.9.0` at the root.
- ✅ `pnpm check` — **exit 0** (biome lint + `test:selectors` + vitest across all 5 workspace projects + build).
- ✅ New `packaging.test.ts` passes; confirmed it fails without the dependency promotion.
- ✅ Reproduced the original crash on a real global install and confirmed the fix resolves it.