### PR TITLE
fix: add yaml to root runtime dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   ],
   "dependencies": {
     "@roughdraft/rfm": "file:packages/rfm",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.12


### PR DESCRIPTION
Fixes #116 by declaring `yaml` as a root runtime dependency of the published `roughdraft` package.

The root package publishes `packages/rfm/dist` as vendored files and has a `file:packages/rfm` dependency. Since `@roughdraft/rfm` is bundled as files inside the root package, npm does not install `packages/rfm/package.json` dependencies for global consumers. `packages/rfm/dist/index.js` imports `yaml`, so clean global installs can fail with `ERR_MODULE_NOT_FOUND`.

This hoists `yaml` to the root package dependencies and updates the lockfile so the packed root package installs it directly.

Verification:
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @roughdraft/rfm build`
- `corepack pnpm --filter @roughdraft/server exec tsc`
- `npm pack`, install the tarball into a fresh project, then import `./node_modules/roughdraft/packages/rfm/dist/index.js` successfully
- Fresh tarball consumer confirms `import("yaml")` succeeds and root `package.json` contains `yaml: ^2.9.0`