### PR TITLE
Fix Nathan Baschez profile link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,4 +349,4 @@ MIT
 
 * * *
 
-Built by [Nathan Baschez](https://twitter.com/nbashaw)
+Built by [Nathan Baschez](https://x.com/nbaschez)


### PR DESCRIPTION
The "Built by Nathan Baschez" credit at the bottom of the README links to an incorrect URL.

This updates it to the correct profile URL: https://x.com/nbaschez

🤖 Generated with [Claude Code](https://claude.com/claude-code)