### PR TITLE
fix(cli): bound watch long-polls so reviews over 5 minutes don't crash (UND_ERR_HEADERS_TIMEOUT)

### DIFF
--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -11,6 +11,7 @@ import {
   ensureServerRunning,
   getServerStateFilePath,
   runCli,
+  WATCH_POLL_SECONDS,
 } from "./cli";
 import { createApp } from "./index";
 import { ROUGHDRAFT_DEFAULT_PORT } from "./network";
@@ -1021,6 +1022,73 @@ describe("cli", () => {
     });
   });
 
+  it("re-polls with bounded timeouts and afterSequence threading until an event arrives", async () => {
+    const test = createTestDependencies();
+    const documentPath = path.join(projectDir, "draft.md");
+    fs.writeFileSync(documentPath, "# Draft\n");
+
+    const watchBodies: Array<Record<string, unknown>> = [];
+    const watchResponses = [
+      { events: [], timedOut: true, nextSequence: 5 },
+      {
+        events: [{ documentPath, type: "review.completed", sequence: 5 }],
+        timedOut: false,
+        nextSequence: 6,
+      },
+    ];
+    const deps = {
+      ...test.deps,
+      fetchImpl: (async (
+        input: Parameters<typeof fetch>[0],
+        init?: Parameters<typeof fetch>[1],
+      ) => {
+        const url =
+          input instanceof URL
+            ? input
+            : new URL(
+                typeof input === "string" ? input : input.url,
+                "http://localhost",
+              );
+        if (url.pathname === "/api/review-events/watch") {
+          watchBodies.push(
+            JSON.parse(String(init?.body)) as Record<string, unknown>,
+          );
+          const payload =
+            watchResponses[
+              Math.min(watchBodies.length, watchResponses.length) - 1
+            ];
+          return new Response(JSON.stringify(payload), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return test.deps.fetchImpl(input, init);
+      }) as typeof fetch,
+    };
+
+    const exitCode = await runCli(["watch", documentPath, "--json"], deps);
+
+    expect(exitCode).toBe(0);
+    expect(watchBodies).toHaveLength(2);
+    expect(watchBodies[0]).toMatchObject({
+      fromNow: true,
+      timeoutSeconds: WATCH_POLL_SECONDS,
+    });
+    expect(watchBodies[0]).not.toHaveProperty("afterSequence");
+    expect(watchBodies[1]).toMatchObject({
+      fromNow: false,
+      afterSequence: 4,
+      timeoutSeconds: WATCH_POLL_SECONDS,
+    });
+
+    const payload = parseOnlyJsonLog<{
+      timedOut: boolean;
+      events: Array<{ documentPath: string; type: string }>;
+    }>(test.logs);
+    expect(payload.timedOut).toBe(false);
+    expect(payload.events).toHaveLength(1);
+  });
+
   it("opens a document and waits for the next review event by default from open --json", async () => {
     const test = createTestDependencies();
     const documentPath = path.join(projectDir, "draft.md");
@@ -1076,8 +1144,8 @@ describe("cli", () => {
     }
     expect(watchRequestBody).toMatchObject({
       batchWindowSeconds: 0,
+      timeoutSeconds: WATCH_POLL_SECONDS,
     });
-    expect(watchRequestBody).not.toHaveProperty("timeoutSeconds");
     await fetch(`http://localhost:${persisted?.port}/api/review-events`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -28,6 +28,11 @@ const SERVER_WAIT_ATTEMPTS = 40;
 const SERVER_WAIT_DELAY_MS = 150;
 const PROCESS_WAIT_ATTEMPTS = 20;
 const PROCESS_WAIT_DELAY_MS = 150;
+// Upper bound for a single watch long-poll. Node's fetch (undici) aborts any
+// request whose response headers have not arrived within 300 seconds, and the
+// watch endpoint sends no headers until an event fires, so each poll must stay
+// safely under that limit. The server clamps waits to 300 seconds as well.
+export const WATCH_POLL_SECONDS = 240;
 const USAGE_ERROR = 2;
 const KNOWN_COMMANDS = [
   "open",
@@ -2117,57 +2122,92 @@ async function runWatch(
     serverUrl = result.server.url;
   }
   const relativePath = path.relative(target.projectDir, target.openPath);
-  const body: {
-    projectPath: string;
-    path: string;
-    timeoutSeconds?: number;
-    batchWindowSeconds: number;
-    fromNow: boolean;
-  } = {
-    projectPath: target.projectDir,
-    path: relativePath,
-    batchWindowSeconds: options.batchWindowSeconds,
-    fromNow: !options.replay,
-  };
-  if (options.timeoutSeconds !== undefined) {
-    body.timeoutSeconds = options.timeoutSeconds;
+  const deadline =
+    options.timeoutSeconds !== undefined
+      ? Date.now() + options.timeoutSeconds * 1000
+      : undefined;
+
+  // The watch endpoint holds the request open without sending response headers
+  // until an event fires, and undici aborts any request whose headers have not
+  // arrived within 300 seconds (UND_ERR_HEADERS_TIMEOUT). Issue a series of
+  // bounded polls instead of one unbounded request, threading afterSequence
+  // between polls so an event emitted in the gap between two polls is still
+  // delivered from the server's retained event queue.
+  let fromNow = !options.replay;
+  let afterSequence: number | undefined;
+
+  while (true) {
+    const remainingSeconds =
+      deadline !== undefined
+        ? Math.max(0, Math.ceil((deadline - Date.now()) / 1000))
+        : undefined;
+    const pollSeconds =
+      remainingSeconds !== undefined
+        ? Math.min(WATCH_POLL_SECONDS, remainingSeconds)
+        : WATCH_POLL_SECONDS;
+    const body: {
+      projectPath: string;
+      path: string;
+      timeoutSeconds: number;
+      batchWindowSeconds: number;
+      fromNow: boolean;
+      afterSequence?: number;
+    } = {
+      projectPath: target.projectDir,
+      path: relativePath,
+      timeoutSeconds: pollSeconds,
+      batchWindowSeconds: options.batchWindowSeconds,
+      fromNow,
+    };
+    if (!fromNow && afterSequence !== undefined) {
+      body.afterSequence = afterSequence;
+    }
+
+    const response = await deps.fetchImpl(
+      new URL("/api/review-events/watch", serverUrl),
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout((pollSeconds + 5) * 1000),
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to watch review events: ${response.status}`);
+    }
+
+    const payload = (await response.json()) as {
+      events?: unknown[];
+      timedOut?: boolean;
+      nextSequence?: number;
+    };
+
+    if (typeof payload.nextSequence === "number") {
+      fromNow = false;
+      afterSequence = Math.max(0, payload.nextSequence - 1);
+    }
+
+    const reachedDeadline =
+      remainingSeconds !== undefined && remainingSeconds <= pollSeconds;
+    if (payload.timedOut && !reachedDeadline) {
+      continue;
+    }
+
+    if (json) {
+      emitJson(deps.log, payload);
+      return payload.timedOut ? 1 : 0;
+    }
+
+    if (payload.timedOut) {
+      deps.log(`No review completed event received for ${target.openPath}.`);
+      return 1;
+    }
+
+    deps.log(`Review completed for ${target.openPath}.`);
+    deps.log(`Received ${(payload.events ?? []).length} event(s).`);
+    return 0;
   }
-
-  const response = await deps.fetchImpl(
-    new URL("/api/review-events/watch", serverUrl),
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-      ...(options.timeoutSeconds !== undefined
-        ? { signal: AbortSignal.timeout((options.timeoutSeconds + 5) * 1000) }
-        : {}),
-    },
-  );
-
-  if (!response.ok) {
-    throw new Error(`Failed to watch review events: ${response.status}`);
-  }
-
-  const payload = (await response.json()) as {
-    events?: unknown[];
-    timedOut?: boolean;
-    nextSequence?: number;
-  };
-
-  if (json) {
-    emitJson(deps.log, payload);
-    return payload.timedOut ? 1 : 0;
-  }
-
-  if (payload.timedOut) {
-    deps.log(`No review completed event received for ${target.openPath}.`);
-    return 1;
-  }
-
-  deps.log(`Review completed for ${target.openPath}.`);
-  deps.log(`Received ${(payload.events ?? []).length} event(s).`);
-  return 0;
 }
 
 function isMarkdownPath(targetPath: string): boolean {


### PR DESCRIPTION
## Problem

`roughdraft open` waits for Done Reviewing via a single long-poll to `/api/review-events/watch`. The server sends no response headers until the event fires, and Node's built-in `fetch` (undici) aborts any request whose response headers haven't arrived within 300 seconds. The result: every review session longer than 5 minutes crashes the CLI with `UND_ERR_HEADERS_TIMEOUT`, deterministically at the 5:00 mark.

Reproduction (no interaction needed): `roughdraft watch some.md` against a running server with no review activity crashes at exactly 300s with the stack trace reported in #93 and #108.

Fixes #93
Fixes #108
(#113 is the same class of bug on the remote SSE path; not addressed here.)

## Fix

`runWatch` now issues a series of bounded polls (240s each, safely under both undici's 300s headers timeout and the server's existing 300s wait clamp in `normalizeWaitOptions`) instead of one unbounded request.

To keep this race-free, each poll response's `nextSequence` is threaded into the next poll as `afterSequence` (with `fromNow: false`), so a Done Reviewing click that lands in the gap between two polls is still delivered from the server's retained event queue (`MAX_RETAINED_EVENTS`). No new dependencies and no server changes — the watch API already supports `timeoutSeconds` and `afterSequence`.

Notes on behavior:
- `--timeout` values above 300s are now actually honored. Previously the server clamped the wait to 300s and the CLI reported a timeout early.
- Watch requests now always carry an explicit `timeoutSeconds` (the per-poll bound); the overall no-timeout semantics of `open`/`watch` are unchanged.
- If a poll response carries no `nextSequence` (e.g. an older server), the CLI falls back to the previous `fromNow` re-anchoring behavior.

## Testing

- New test covering the re-poll loop: first poll times out, second poll must send `fromNow: false` + `afterSequence`, event delivered, exit 0.
- Updated the existing default-open test for the now-explicit per-poll `timeoutSeconds`.
- `pnpm --filter @roughdraft/server test` — 121 passed; `pnpm lint` and `tsc --noEmit` clean.
- Manually verified against a live server: stock CLI crashes at exactly 300s; patched CLI survived past 6 minutes and exited 0 when the review-completed event fired.