### PR TITLE
fix: long-poll review watch over node:http to avoid undici timeout

### DIFF
--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -11,6 +11,7 @@ import {
   ensureServerRunning,
   getServerStateFilePath,
   runCli,
+  WATCH_POLL_REISSUE_SECONDS,
 } from "./cli";
 import { createApp } from "./index";
 import { ROUGHDRAFT_DEFAULT_PORT } from "./network";
@@ -730,22 +731,19 @@ describe("cli", () => {
           );
         }
 
-        if (url.pathname === "/api/review-events/watch") {
-          watchUrl = url.toString();
-          return new Response(
-            JSON.stringify({
-              events: [{ documentPath, type: "review.completed" }],
-              timedOut: false,
-              nextSequence: 2,
-            }),
-            {
-              status: 200,
-              headers: { "Content-Type": "application/json" },
-            },
-          );
-        }
-
         throw new Error(`Unexpected request: ${url.toString()}`);
+      },
+      pollReviewEvents: async (url) => {
+        watchUrl = url.toString();
+        return {
+          ok: true,
+          status: 200,
+          payload: {
+            events: [{ documentPath, type: "review.completed" }],
+            timedOut: false,
+            nextSequence: 2,
+          },
+        };
       },
       spawnServerProcess: async () => {
         spawnCount += 1;
@@ -1029,27 +1027,14 @@ describe("cli", () => {
       timeoutSeconds?: number;
       batchWindowSeconds?: number;
     } | null = null;
+    const realPoll = test.deps.pollReviewEvents;
+    const captureWatchBody: typeof realPoll = (url, body, options) => {
+      watchRequestBody = body;
+      return realPoll(url, body, options);
+    };
     const deps = {
       ...test.deps,
-      fetchImpl: async (input: Parameters<typeof fetch>[0], init) => {
-        const url =
-          input instanceof URL
-            ? input
-            : new URL(
-                typeof input === "string" ? input : input.url,
-                "http://localhost",
-              );
-        if (
-          url.pathname === "/api/review-events/watch" &&
-          typeof init?.body === "string"
-        ) {
-          watchRequestBody = JSON.parse(init.body) as {
-            timeoutSeconds?: number;
-            batchWindowSeconds?: number;
-          };
-        }
-        return test.deps.fetchImpl(input, init);
-      },
+      pollReviewEvents: captureWatchBody,
     };
 
     const watchPromise = runCli(
@@ -1076,8 +1061,8 @@ describe("cli", () => {
     }
     expect(watchRequestBody).toMatchObject({
       batchWindowSeconds: 0,
+      timeoutSeconds: WATCH_POLL_REISSUE_SECONDS,
     });
-    expect(watchRequestBody).not.toHaveProperty("timeoutSeconds");
     await fetch(`http://localhost:${persisted?.port}/api/review-events`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -1101,6 +1086,52 @@ describe("cli", () => {
         },
       ],
     });
+  });
+
+  it("re-issues the watch poll when a bounded poll returns before a review event", async () => {
+    const test = createTestDependencies();
+    const documentPath = path.join(projectDir, "draft.md");
+    fs.writeFileSync(documentPath, "# Draft\n");
+
+    let pollCount = 0;
+    const deps = {
+      ...test.deps,
+      pollReviewEvents: async () => {
+        pollCount += 1;
+        // The server bounds each poll and returns before the user clicks "Done
+        // Reviewing"; the CLI must re-issue rather than treat it as a timeout.
+        if (pollCount === 1) {
+          return {
+            ok: true,
+            status: 200,
+            payload: { timedOut: true, nextSequence: 1 },
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          payload: {
+            events: [{ documentPath, type: "review.completed" }],
+            timedOut: false,
+            nextSequence: 2,
+          },
+        };
+      },
+    };
+
+    const exitCode = await runCli(
+      ["watch", documentPath, "--json", "--batch-window", "0"],
+      deps,
+    );
+    const payload = parseOnlyJsonLog<{
+      timedOut: boolean;
+      events: Array<{ documentPath: string; type: string }>;
+    }>(test.logs);
+
+    expect(exitCode).toBe(0);
+    expect(pollCount).toBe(2);
+    expect(payload.timedOut).toBe(false);
+    expect(payload.events).toHaveLength(1);
   });
 
   it("cleans stale state during status checks", async () => {

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
@@ -28,6 +29,14 @@ const SERVER_WAIT_ATTEMPTS = 40;
 const SERVER_WAIT_DELAY_MS = 150;
 const PROCESS_WAIT_ATTEMPTS = 20;
 const PROCESS_WAIT_DELAY_MS = 150;
+// Per-poll bound the CLI requests when waiting indefinitely for "Done
+// Reviewing". The server clamps each watch to its own maximum, so this is large
+// enough that re-issues are rare; node:http imposes no client-side headers
+// timeout, so the loop re-polls cleanly until a real event arrives.
+export const WATCH_POLL_REISSUE_SECONDS = 1800;
+// Client-side safety bound added on top of an explicit --timeout so the command
+// cannot hang if the server never responds.
+const WATCH_EXPLICIT_TIMEOUT_GRACE_SECONDS = 5;
 const USAGE_ERROR = 2;
 const KNOWN_COMMANDS = [
   "open",
@@ -75,10 +84,35 @@ export interface SpawnedServer {
   pid: number;
 }
 
+interface ReviewWatchRequestBody {
+  projectPath: string;
+  path: string;
+  batchWindowSeconds: number;
+  fromNow: boolean;
+  timeoutSeconds?: number;
+}
+
+interface ReviewWatchPayload {
+  events?: unknown[];
+  timedOut?: boolean;
+  nextSequence?: number;
+}
+
+interface ReviewWatchResult {
+  ok: boolean;
+  status: number;
+  payload: ReviewWatchPayload;
+}
+
 export interface CliDependencies {
   env: NodeJS.ProcessEnv;
   cwd: string;
   fetchImpl: typeof fetch;
+  pollReviewEvents: (
+    url: URL,
+    body: ReviewWatchRequestBody,
+    options?: { timeoutMs?: number },
+  ) => Promise<ReviewWatchResult>;
   findAvailablePortImpl: typeof findAvailablePort;
   sleepImpl: (ms: number) => Promise<void>;
   spawnServerProcess: (options: {
@@ -803,6 +837,60 @@ function defaultSpawnServerProcess(options: {
   return { pid: child.pid };
 }
 
+// Long-poll the review-events watch endpoint over node:http instead of undici's
+// global fetch. The server holds the request open until a review.completed event
+// arrives or its own bound elapses; undici enforces a ~300s headers timeout that
+// fires mid-poll (UND_ERR_HEADERS_TIMEOUT) before the user clicks "Done
+// Reviewing", whereas node:http imposes no client-side headers timeout.
+function defaultPollReviewEvents(
+  url: URL,
+  body: ReviewWatchRequestBody,
+  options: { timeoutMs?: number } = {},
+): Promise<ReviewWatchResult> {
+  return new Promise((resolve, reject) => {
+    const data = Buffer.from(JSON.stringify(body), "utf8");
+    const request = http.request(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname + url.search,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": data.length,
+        },
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk: Buffer) => chunks.push(chunk));
+        response.on("end", () => {
+          const status = response.statusCode ?? 0;
+          const text = Buffer.concat(chunks).toString("utf8");
+          let payload: ReviewWatchPayload;
+          try {
+            payload = text ? (JSON.parse(text) as ReviewWatchPayload) : {};
+          } catch {
+            reject(
+              new Error(`Unexpected watch response: ${text.slice(0, 200)}`),
+            );
+            return;
+          }
+          resolve({ ok: status >= 200 && status < 300, status, payload });
+        });
+      },
+    );
+    request.on("error", reject);
+    // Only the explicit --timeout path arms a client-side bound; the indefinite
+    // poll relies on the server's own bound and re-issues.
+    if (options.timeoutMs !== undefined) {
+      request.setTimeout(options.timeoutMs, () => {
+        request.destroy(new Error("Watch request timed out"));
+      });
+    }
+    request.end(data);
+  });
+}
+
 export function createCliDependencies(
   overrides: Partial<CliDependencies> = {},
 ): CliDependencies {
@@ -812,6 +900,7 @@ export function createCliDependencies(
     env: overrides.env ?? process.env,
     cwd: overrides.cwd ?? process.cwd(),
     fetchImpl,
+    pollReviewEvents: overrides.pollReviewEvents ?? defaultPollReviewEvents,
     findAvailablePortImpl: overrides.findAvailablePortImpl ?? findAvailablePort,
     sleepImpl: overrides.sleepImpl ?? ((ms) => sleep(ms)),
     spawnServerProcess:
@@ -2117,55 +2206,66 @@ async function runWatch(
     serverUrl = result.server.url;
   }
   const relativePath = path.relative(target.projectDir, target.openPath);
-  const body: {
-    projectPath: string;
-    path: string;
-    timeoutSeconds?: number;
-    batchWindowSeconds: number;
-    fromNow: boolean;
-  } = {
+  const watchUrl = new URL("/api/review-events/watch", serverUrl);
+  const baseBody: ReviewWatchRequestBody = {
     projectPath: target.projectDir,
     path: relativePath,
     batchWindowSeconds: options.batchWindowSeconds,
     fromNow: !options.replay,
   };
+
+  // Explicit --timeout: a single bounded poll, surfacing a timeout as a
+  // non-zero exit. The client-side bound is a safety net on top of the server's.
   if (options.timeoutSeconds !== undefined) {
-    body.timeoutSeconds = options.timeoutSeconds;
+    const { ok, status, payload } = await deps.pollReviewEvents(
+      watchUrl,
+      { ...baseBody, timeoutSeconds: options.timeoutSeconds },
+      {
+        timeoutMs:
+          (options.timeoutSeconds + WATCH_EXPLICIT_TIMEOUT_GRACE_SECONDS) *
+          1000,
+      },
+    );
+    if (!ok) {
+      throw new Error(`Failed to watch review events: ${status}`);
+    }
+    return reportWatchPayload(deps, target.openPath, payload, json);
   }
 
-  const response = await deps.fetchImpl(
-    new URL("/api/review-events/watch", serverUrl),
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-      ...(options.timeoutSeconds !== undefined
-        ? { signal: AbortSignal.timeout((options.timeoutSeconds + 5) * 1000) }
-        : {}),
-    },
-  );
-
-  if (!response.ok) {
-    throw new Error(`Failed to watch review events: ${response.status}`);
+  // No --timeout: wait until "Done Reviewing". Each poll is bounded server-side,
+  // so re-issue cleanly whenever the server returns before a real event.
+  for (;;) {
+    const { ok, status, payload } = await deps.pollReviewEvents(watchUrl, {
+      ...baseBody,
+      timeoutSeconds: WATCH_POLL_REISSUE_SECONDS,
+    });
+    if (!ok) {
+      throw new Error(`Failed to watch review events: ${status}`);
+    }
+    if (payload.timedOut) {
+      continue;
+    }
+    return reportWatchPayload(deps, target.openPath, payload, json);
   }
+}
 
-  const payload = (await response.json()) as {
-    events?: unknown[];
-    timedOut?: boolean;
-    nextSequence?: number;
-  };
-
+function reportWatchPayload(
+  deps: CliDependencies,
+  openPath: string,
+  payload: ReviewWatchPayload,
+  json: boolean,
+): number {
   if (json) {
     emitJson(deps.log, payload);
     return payload.timedOut ? 1 : 0;
   }
 
   if (payload.timedOut) {
-    deps.log(`No review completed event received for ${target.openPath}.`);
+    deps.log(`No review completed event received for ${openPath}.`);
     return 1;
   }
 
-  deps.log(`Review completed for ${target.openPath}.`);
+  deps.log(`Review completed for ${openPath}.`);
   deps.log(`Received ${(payload.events ?? []).length} event(s).`);
   return 0;
 }


### PR DESCRIPTION
## Problem

`roughdraft open` and `roughdraft watch` time out after ~5 minutes while waiting for "Done Reviewing". `runWatch` used undici's global `fetch`, whose ~300s `headersTimeout` fires mid-poll before the user finishes reviewing:

```
TypeError: fetch failed
  at async runWatch (.../dist/cli.js)
  [cause]: HeadersTimeoutError: Headers Timeout Error
    code: 'UND_ERR_HEADERS_TIMEOUT'
```

The review-events watch is a long poll: the server holds the request open until a `review.completed` event arrives. undici imposes a client-side headers timeout that can't be disabled per request, so the poll dies at ~300s.

## Fix

- Replace undici `fetch` in the watch path with a `node:http` poll, which imposes no client-side headers timeout. Added as an injectable `pollReviewEvents` dependency (mirroring the existing `fetchImpl` pattern) so it stays testable.
- Add a re-issue loop: the default (no `--timeout`) watch requests a server-bounded poll and re-issues whenever the server returns before a real event, so it waits indefinitely for "Done Reviewing" without holding one connection past the server's bound.
- Preserve explicit `--timeout N` semantics (single bounded poll, exit 1 on no event) with a client-side safety net.

## Verification

- `tsc --noEmit` clean; biome lint clean.
- Full server suite: 121/121 pass, including a new test asserting the re-issue loop (a bounded poll returning `timedOut` re-polls instead of exiting 1).
- Real CLI against a real server: default `watch` receives a real event → exit 0; `watch --timeout 1` with no event → exit 1.
- Real 5+ minute review via the CLI completed cleanly with no `UND_ERR_HEADERS_TIMEOUT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
