### PR TITLE
Polish dark mode review interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,13 +263,7 @@ This is {==highlighted==} text.
 Roughdraft extends those markers with compact id references so review state can round-trip through the file. Root comments and suggestions keep an inline anchor such as `{#c1}` or `{#s1}`, while metadata lives in final YAML endmatter:
 
 ```markdown
-Please revisit {==this sentence==}{>>Needs a source<<}{#c1}.
-
----
-comments:
-  c1:
-    by: user
-    at: "2026-04-28T12:00:00.000Z"
+Please revisit {==this sentence==}{>>Needs a source<<}{id="c1" by="user" at="2026-06-14T06:38:34.897Z"}{>><<}{id="c6" by="user" at="2026-06-14T06:48:16.819Z" re="c1"}. --- comments: c1: by: user at: "2026-04-28T12:00:00.000Z"
 ```
 
 Supported attributes:
@@ -286,18 +280,7 @@ Supported attributes:
 Replies are stored in endmatter with a `body` and `re` pointer:
 
 ```markdown
-Please revisit {==this sentence==}{>>Needs a source<<}{#c1}.
-
----
-comments:
-  c1:
-    by: user
-    at: "2026-04-28T12:00:00.000Z"
-  c2:
-    body: I can add one from the intro.
-    by: AI
-    at: "2026-04-28T12:05:00.000Z"
-    re: c1
+Please revisit {==this sentence==}{>>Needs a source<<}{id="c1" by="user" at="2026-06-14T06:38:34.897Z"}{>><<}{id="c6" by="user" at="2026-06-14T06:48:16.819Z" re="c1"}. --- comments: c1: by: user at: "2026-04-28T12:00:00.000Z" c2: body: I can add one from the intro. by: AI at: "2026-04-28T12:05:00.000Z" re: c1
 ```
 
 Suggested changes can also carry ids and discussion:

--- a/docs/spec/ui-state-screenshot-guide.md
+++ b/docs/spec/ui-state-screenshot-guide.md
@@ -138,6 +138,7 @@ suggestions:
 | Review rail | Comments | Open review fixture in rich mode | `document-review-rail`, `comment-thread-root` | Thread containers use `data-comment-thread-container="true"`. |
 | Review rail | Suggestions | Open review fixture in rich mode | `suggestion-thread-s1`, `suggestion-thread-s2`, `suggestion-thread-s3` | Thread containers use `data-suggestion-thread-container="true"`. |
 | Review rail | Draft suggestion | Select text and choose a suggestion action | `draft-suggestion-thread`, `draft-suggestion-editor` | Capture dismiss/cancel/apply actions. |
+| Comment editor | New root comment draft | Select text and choose Add comment | `comment-rail-c1-editor`, `comment-rail-c1-action-save` | Save uses the popover-style button; footer Cancel is absent because the thread trash action dismisses the draft. |
 | Comment editor | Root comment editing | Use a comment card edit action | `comment-rail-root-editor` | Comment test IDs follow `comment-${variant}-${id}-...`. |
 | Comment editor | Reply editing | Use a reply action | `comment-rail-child-editor` | Useful for nested thread spacing. |
 | Code mode | Review rail present | Open review fixture with `?editor=code` | `page-card-code`, `markdown-code-editor` | Confirms code editor and rail can coexist. |

--- a/packages/app/e2e/criticmarkup-review.spec.ts
+++ b/packages/app/e2e/criticmarkup-review.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import {
   createMarkdownProject,
   logE2eEvent,
@@ -96,6 +96,46 @@ test.describe("CriticMarkup review flows", () => {
     });
   });
 
+  test("animates the document layout when the review rail appears and disappears @smoke", async ({
+    page,
+  }) => {
+    const filePath = writeProjectFile(
+      projectDir,
+      "layout-animation.md",
+      [
+        "# Layout Animation",
+        "",
+        "This paragraph has target text to review.",
+        "",
+      ].join("\n"),
+    );
+
+    await openMarkdownFile(page, filePath);
+    await selectRichText(page, "target text");
+    await page.getByTestId("selection-menu-action-comment").waitFor();
+
+    const addSamplesPromise = sampleReviewLayoutAnimation(page);
+    await page.getByTestId("selection-menu-action-comment").click();
+    const addSamples = await addSamplesPromise;
+
+    expect(hasAnimatedReviewLayout(addSamples)).toBe(true);
+    await page
+      .getByTestId("comment-rail-c1-editor")
+      .fill("Clarify this phrase.");
+    await page.getByTestId("comment-rail-c1-action-save").click();
+
+    await page.getByTestId("comment-rail-c1-action-delete-thread").waitFor();
+    const removeSamplesPromise = sampleReviewLayoutAnimation(page);
+    await page.getByTestId("comment-rail-c1-action-delete-thread").click();
+    const removeSamples = await removeSamplesPromise;
+
+    expect(hasAnimatedReviewLayout(removeSamples)).toBe(true);
+
+    logE2eEvent("criticmarkup.layout-animation", {
+      file: "layout-animation.md",
+    });
+  });
+
   test("shows tooltips for selection menu formatting actions", async ({
     page,
   }) => {
@@ -170,3 +210,55 @@ test.describe("CriticMarkup review flows", () => {
     });
   });
 });
+
+type ReviewLayoutAnimationSample = {
+  shellAnimating: boolean;
+  headerAnimating: boolean;
+  shellTranslateX: number;
+  headerTranslateX: number;
+};
+
+async function sampleReviewLayoutAnimation(page: Page) {
+  return page.evaluate(async () => {
+    const readTranslateX = (element: Element | null) => {
+      if (!(element instanceof HTMLElement)) return 0;
+      const transform = getComputedStyle(element).transform;
+      if (transform === "none") return 0;
+      return new DOMMatrixReadOnly(transform).m41;
+    };
+    const samples: ReviewLayoutAnimationSample[] = [];
+    const start = performance.now();
+
+    while (performance.now() - start < 500) {
+      const shell = document.querySelector(
+        '[data-testid="document-page-shell"]',
+      );
+      const header = document.querySelector(
+        '[data-testid="document-page-header"]',
+      );
+      samples.push({
+        shellAnimating:
+          shell instanceof HTMLElement &&
+          shell.classList.contains("review-layout-grid--animating"),
+        headerAnimating:
+          header instanceof HTMLElement &&
+          header.classList.contains("review-layout-grid--animating"),
+        shellTranslateX: readTranslateX(shell),
+        headerTranslateX: readTranslateX(header),
+      });
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    }
+
+    return samples;
+  });
+}
+
+function hasAnimatedReviewLayout(samples: ReviewLayoutAnimationSample[]) {
+  return samples.some(
+    (sample) =>
+      sample.shellAnimating &&
+      sample.headerAnimating &&
+      Math.abs(sample.shellTranslateX) > 1 &&
+      Math.abs(sample.headerTranslateX) > 1,
+  );
+}

--- a/packages/app/src/CommentEditorList.tsx
+++ b/packages/app/src/CommentEditorList.tsx
@@ -38,6 +38,7 @@ interface CommentEditorListProps {
   onFocusComment?: (commentId: string) => void;
   onReplyComment?: (commentId: string) => void;
   pendingFocusCommentId?: string | null;
+  newCommentDraftIds?: string[];
   onAutoFocusComment?: (commentId: string) => void;
   renderCommentContent?: (context: CommentContentRenderContext) => ReactNode;
   getCommentActions?: (
@@ -49,6 +50,7 @@ export interface CommentActionDefinition {
   key: string;
   label: string;
   tone?: "neutral" | "danger";
+  presentation?: "default" | "popover";
   icon: ReactNode;
   compact?: boolean;
   onClick: (event: MouseEvent) => void;
@@ -103,6 +105,7 @@ export function CommentEditorList({
   onFocusComment,
   onReplyComment,
   pendingFocusCommentId = null,
+  newCommentDraftIds = [],
   onAutoFocusComment,
   renderCommentContent,
   getCommentActions,
@@ -281,7 +284,9 @@ export function CommentEditorList({
           variant={variant}
           interactive={interactive}
           drafts={drafts}
+          newCommentDraftIds={newCommentDraftIds}
           editingCommentIds={editingCommentIds}
+          pendingFocusCommentId={pendingFocusCommentId}
           selectedCommentId={selectedCommentId}
           hoveredCommentId={hoveredCommentId}
           textareaRefs={textareaRefs}
@@ -317,7 +322,9 @@ interface CommentThreadNodeProps {
   variant: "banner" | "rail";
   interactive: boolean;
   drafts: Record<string, string>;
+  newCommentDraftIds: string[];
   editingCommentIds: string[];
+  pendingFocusCommentId: string | null;
   selectedCommentId: string | null;
   hoveredCommentId: string | null;
   textareaRefs: MutableRefObject<Map<string, HTMLTextAreaElement>>;
@@ -347,6 +354,7 @@ function CommentActionButton({
   label,
   testId,
   tone = "neutral",
+  presentation = "default",
   icon,
   compact = false,
   className,
@@ -355,6 +363,7 @@ function CommentActionButton({
   label: string;
   testId?: string;
   tone?: "neutral" | "danger";
+  presentation?: "default" | "popover";
   icon: ReactNode;
   compact?: boolean;
   className?: string;
@@ -368,12 +377,16 @@ function CommentActionButton({
       variant="ghost"
       size={compact ? "icon-xs" : "sm"}
       className={cn(
-        compact
-          ? "rounded-full border border-transparent transition-colors duration-150"
-          : "h-7 rounded-full border border-transparent px-2.5 text-[11px] font-medium tracking-[0.08em] uppercase transition-colors duration-150",
-        tone === "danger"
-          ? "text-stone-400 hover:bg-rose-100 hover:text-rose-700 dark:text-stone-500 dark:hover:bg-rose-900/40 dark:hover:text-rose-400"
-          : "text-stone-400 hover:bg-[#DED8CE]/45 hover:text-stone-600 dark:text-stone-500 dark:hover:bg-slate-700 dark:hover:text-stone-300",
+        presentation === "popover" && !compact
+          ? "h-9 w-full rounded-xl bg-[#E8E3DB] px-3 py-2 text-sm font-bold normal-case tracking-normal text-black shadow-[inset_0_1px_0_rgba(255,251,245,0.72)] hover:bg-[#ded8ce] hover:text-black dark:bg-slate-700 dark:text-slate-100 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] dark:hover:bg-slate-600 dark:hover:text-slate-100"
+          : compact
+            ? "rounded-full border border-transparent transition-colors duration-150"
+            : "h-7 rounded-full border border-transparent px-2.5 text-[11px] font-medium tracking-[0.08em] uppercase transition-colors duration-150",
+        presentation === "popover"
+          ? ""
+          : tone === "danger"
+            ? "text-stone-400 hover:bg-rose-100 hover:text-rose-700 dark:text-stone-500 dark:hover:bg-rose-900/40 dark:hover:text-rose-400"
+            : "text-stone-400 hover:bg-[#DED8CE]/45 hover:text-stone-600 dark:text-stone-500 dark:hover:bg-slate-700 dark:hover:text-stone-300",
         className,
       )}
       onPointerDown={(event) => event.stopPropagation()}
@@ -403,7 +416,9 @@ function CommentThreadNode({
   variant,
   interactive,
   drafts,
+  newCommentDraftIds,
   editingCommentIds,
+  pendingFocusCommentId,
   selectedCommentId,
   hoveredCommentId,
   textareaRefs,
@@ -456,6 +471,11 @@ function CommentThreadNode({
       : "bg-[#DED8CE]/85 dark:bg-slate-600/85";
   const defaultContent =
     comment.content.trim().length > 0 ? comment.content : "Empty comment";
+  const isNewRootCommentDraft =
+    isEditing &&
+    depth === 0 &&
+    (comment.id === pendingFocusCommentId ||
+      newCommentDraftIds.includes(comment.id));
   const renderedContent =
     renderCommentContent?.({
       comment,
@@ -468,6 +488,7 @@ function CommentThreadNode({
         {
           key: "save",
           label: "Save",
+          presentation: isNewRootCommentDraft ? "popover" : "default",
           icon: <Check className="size-3.5" />,
           onClick: (event) => {
             event.stopPropagation();
@@ -517,13 +538,16 @@ function CommentThreadNode({
           },
         },
       ];
+  const defaultVisibleActions = isNewRootCommentDraft
+    ? defaultActions.filter((action) => action.key !== "cancel")
+    : defaultActions;
   const actions =
     getCommentActions?.({
       comment,
       depth,
       isEditing,
-      defaultActions,
-    }) ?? defaultActions;
+      defaultActions: defaultVisibleActions,
+    }) ?? defaultVisibleActions;
   const ancestorGuideOffsets = parentLines.reduce<number[]>(
     (offsets, showLine, guideIndex) => {
       if (showLine) {
@@ -735,6 +759,7 @@ function CommentThreadNode({
                     label={action.label}
                     testId={`comment-${variant}-${comment.id}-action-${action.key}`}
                     tone={action.tone}
+                    presentation={action.presentation}
                     icon={action.icon}
                     compact={action.compact}
                     onClick={action.onClick}
@@ -758,7 +783,9 @@ function CommentThreadNode({
               variant={variant}
               interactive={interactive}
               drafts={drafts}
+              newCommentDraftIds={newCommentDraftIds}
               editingCommentIds={editingCommentIds}
+              pendingFocusCommentId={pendingFocusCommentId}
               selectedCommentId={selectedCommentId}
               hoveredCommentId={hoveredCommentId}
               textareaRefs={textareaRefs}

--- a/packages/app/src/DocumentReviewRail.tsx
+++ b/packages/app/src/DocumentReviewRail.tsx
@@ -69,6 +69,7 @@ interface DocumentReviewRailProps {
   onFocusSuggestion: (changeId: string) => void;
   onHoverSuggestion: (changeId: string | null) => void;
   pendingFocusCommentId?: string | null;
+  newCommentDraftIds?: string[];
   onAutoFocusComment?: (commentId: string) => void;
   draftSuggestion?: DraftSuggestionState | null;
   onDraftSuggestionTextChange?: (text: string) => void;
@@ -198,6 +199,7 @@ export function DocumentReviewRail({
   onFocusSuggestion,
   onHoverSuggestion,
   pendingFocusCommentId = null,
+  newCommentDraftIds = [],
   onAutoFocusComment,
   draftSuggestion = null,
   onDraftSuggestionTextChange,
@@ -472,6 +474,7 @@ export function DocumentReviewRail({
                   onFocusComment={onFocusComment}
                   onHoverComment={onHoverComment}
                   pendingFocusCommentId={pendingFocusCommentId}
+                  newCommentDraftIds={newCommentDraftIds}
                   onAutoFocusComment={onAutoFocusComment}
                 />
               </div>
@@ -700,6 +703,7 @@ export function DocumentReviewRail({
                   onHoverComment(commentId);
                 }}
                 pendingFocusCommentId={pendingFocusCommentId}
+                newCommentDraftIds={newCommentDraftIds}
                 onAutoFocusComment={onAutoFocusComment}
                 renderCommentContent={renderCommentContent}
                 getCommentActions={getCommentActions}

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -43,6 +43,7 @@ import {
   PageCard,
 } from "./PageCard";
 import type { CompleteReviewOptions, Page, StorageBackend } from "./storage";
+import { useReviewLayoutShiftAnimation } from "./useReviewLayoutShiftAnimation";
 
 type DiskChangeState = "clean" | "changed" | "conflict" | "paused";
 type ReviewHandoffState =
@@ -305,6 +306,8 @@ export function DocumentWorkspace({
       !!documentPage?.content &&
       criticMarkdownHasReviewRail(documentPage.content),
   );
+  const documentHeaderRef =
+    useReviewLayoutShiftAnimation<HTMLDivElement>(documentHasComments);
 
   useEffect(() => {
     setDocumentHasComments(
@@ -528,12 +531,12 @@ export function DocumentWorkspace({
               open={reviewHandoffPopoverOpen}
               onOpenChange={setReviewHandoffPopoverOpen}
             >
-              <div className="relative flex items-center overflow-hidden rounded-[7px] shadow-[0_10px_28px_rgba(0,0,0,0.18)] after:pointer-events-none after:absolute after:top-px after:right-8 after:bottom-px after:z-10 after:w-px after:bg-[#d2cabd] after:content-[''] dark:after:bg-slate-600">
+              <div className="relative flex items-center overflow-hidden rounded-[7px] shadow-[0_10px_28px_rgba(0,0,0,0.18)] after:pointer-events-none after:absolute after:top-px after:right-8 after:bottom-px after:z-10 after:w-px after:bg-[#4a4038] after:content-[''] dark:after:bg-slate-600">
                 <Button
                   type="button"
                   data-testid="review-handoff-button"
                   size="lg"
-                  className="h-9 rounded-r-none rounded-l-[7px] border-0 bg-[#E8E3DB] px-3 text-sm font-bold text-black hover:bg-[#ded8ce] focus-visible:ring-slate-300 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 dark:focus-visible:ring-slate-600"
+                  className="h-9 rounded-r-none rounded-l-[7px] border-0 bg-[#2B2420] px-3 text-sm font-bold text-white hover:bg-[#3a322b] focus-visible:ring-slate-300 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 dark:focus-visible:ring-slate-600"
                   disabled={reviewHandoffDisabled}
                   onClick={() =>
                     void handleCompleteReview(
@@ -559,7 +562,7 @@ export function DocumentWorkspace({
                       type="button"
                       data-testid="review-handoff-comment-trigger"
                       size="icon-lg"
-                      className="h-9 w-8 rounded-l-none rounded-r-[7px] border-0 bg-[#E8E3DB] text-black hover:bg-[#ded8ce] focus-visible:ring-slate-300 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 dark:focus-visible:ring-slate-600"
+                      className="h-9 w-8 rounded-l-none rounded-r-[7px] border-0 bg-[#2B2420] text-white hover:bg-[#3a322b] focus-visible:ring-slate-300 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 dark:focus-visible:ring-slate-600"
                       disabled={reviewHandoffDisabled}
                       aria-label="Add overall handoff comment"
                     >
@@ -706,14 +709,15 @@ export function DocumentWorkspace({
       <div className="mx-auto min-h-full max-w-[1080px]">
         {documentPage ? (
           <div
+            ref={documentHeaderRef}
             data-testid="document-page-header"
             className={cn(
-              "document-page-shell mb-2 flex flex-col gap-6 text-[0.62rem] font-medium tracking-[0.01em] text-stone-400 min-[1100px]:grid min-[1100px]:grid-cols-[minmax(0,46.5rem)_minmax(24rem,1fr)] min-[1100px]:items-start min-[1100px]:justify-between min-[1100px]:gap-8",
+              "review-layout-grid document-page-shell mb-2 text-[0.62rem] font-medium tracking-[0.01em] text-stone-400",
               !documentHasComments &&
-                "document-page-shell-no-comments min-[1100px]:grid-cols-[minmax(0,46.5rem)] min-[1100px]:justify-center",
+                "review-layout-grid--centered document-page-shell-no-comments",
             )}
           >
-            <div className="document-page-main w-full max-w-[46.5rem] min-w-0">
+            <div className="review-layout-main document-page-main w-full max-w-[46.5rem] min-w-0">
               <div className="flex w-full flex-wrap items-center gap-1.5 px-1">
                 <Tooltip>
                   <TooltipTrigger
@@ -836,12 +840,6 @@ export function DocumentWorkspace({
                 </div>
               </div>
             </div>
-            {documentHasComments ? (
-              <div
-                className="document-comment-rail pointer-events-none invisible hidden min-[1100px]:block"
-                aria-hidden="true"
-              />
-            ) : null}
           </div>
         ) : null}
         {documentPage ? (

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -528,12 +528,12 @@ export function DocumentWorkspace({
               open={reviewHandoffPopoverOpen}
               onOpenChange={setReviewHandoffPopoverOpen}
             >
-              <div className="relative flex items-center overflow-hidden rounded-[7px] shadow-[0_10px_28px_rgba(0,0,0,0.18)] after:pointer-events-none after:absolute after:top-px after:right-8 after:bottom-px after:z-10 after:w-px after:bg-[#444] after:content-[''] dark:after:bg-[#444]">
+              <div className="relative flex items-center overflow-hidden rounded-[7px] shadow-[0_10px_28px_rgba(0,0,0,0.18)] after:pointer-events-none after:absolute after:top-px after:right-8 after:bottom-px after:z-10 after:w-px after:bg-[#d2cabd] after:content-[''] dark:after:bg-slate-600">
                 <Button
                   type="button"
                   data-testid="review-handoff-button"
                   size="lg"
-                  className="h-9 rounded-r-none rounded-l-[7px] border-0 bg-black px-3 text-sm font-bold text-white hover:bg-black/85 focus-visible:ring-black/25 dark:bg-black dark:text-white dark:hover:bg-black/85 dark:focus-visible:ring-white/30"
+                  className="h-9 rounded-r-none rounded-l-[7px] border-0 bg-[#E8E3DB] px-3 text-sm font-bold text-black hover:bg-[#ded8ce] focus-visible:ring-slate-300 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 dark:focus-visible:ring-slate-600"
                   disabled={reviewHandoffDisabled}
                   onClick={() =>
                     void handleCompleteReview(
@@ -559,7 +559,7 @@ export function DocumentWorkspace({
                       type="button"
                       data-testid="review-handoff-comment-trigger"
                       size="icon-lg"
-                      className="h-9 w-8 rounded-l-none rounded-r-[7px] border-0 bg-black text-white hover:bg-black/85 focus-visible:ring-black/25 dark:bg-black dark:text-white dark:hover:bg-black/85 dark:focus-visible:ring-white/30"
+                      className="h-9 w-8 rounded-l-none rounded-r-[7px] border-0 bg-[#E8E3DB] text-black hover:bg-[#ded8ce] focus-visible:ring-slate-300 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 dark:focus-visible:ring-slate-600"
                       disabled={reviewHandoffDisabled}
                       aria-label="Add overall handoff comment"
                     >
@@ -721,12 +721,12 @@ export function DocumentWorkspace({
                       <button
                         type="button"
                         data-testid="document-editor-view-toggle"
-                        className="grid shrink-0 grid-cols-2 rounded-[999px] bg-[#E8E3DB] dark:bg-slate-700 px-[2px] pt-[3px] pb-[2px] shadow-[inset_0_1px_0_rgba(255,251,245,0.72)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+                        className="grid shrink-0 grid-cols-2 rounded-[999px] bg-[#E8E3DB] dark:bg-slate-800 px-[2px] pt-[3px] pb-[2px] shadow-[inset_0_1px_0_rgba(255,251,245,0.72)] dark:border-b dark:border-b-slate-800 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
                       >
                         <span
                           className={`flex w-[1.375rem] items-center justify-center rounded-full py-[2px] transition ${
                             documentEditorViewMode === "rich-text"
-                              ? "bg-[#FFFDFC] dark:bg-slate-500 text-stone-700 dark:text-white shadow-[0_1px_2px_rgba(41,37,36,0.12)]"
+                              ? "bg-[#FFFDFC] dark:bg-slate-600 text-stone-700 dark:text-white shadow-[0_1px_2px_rgba(41,37,36,0.12)]"
                               : "text-stone-500 dark:text-slate-400"
                           }`}
                         >
@@ -735,7 +735,7 @@ export function DocumentWorkspace({
                         <span
                           className={`flex w-[1.375rem] items-center justify-center rounded-full py-[2px] transition ${
                             documentEditorViewMode === "code"
-                              ? "bg-[#FFFDFC] dark:bg-slate-500 text-stone-700 dark:text-white shadow-[0_1px_2px_rgba(41,37,36,0.12)]"
+                              ? "bg-[#FFFDFC] dark:bg-slate-600 text-stone-700 dark:text-white shadow-[0_1px_2px_rgba(41,37,36,0.12)]"
                               : "text-stone-500 dark:text-slate-400"
                           }`}
                         >
@@ -763,7 +763,7 @@ export function DocumentWorkspace({
                       <button
                         type="button"
                         data-testid="document-file-menu-trigger"
-                        className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-full px-1 py-0.5 font-mono text-[0.7rem] tracking-[0.01em] text-stone-400 outline-none transition hover:bg-[#EEE9E1] hover:text-stone-600 focus-visible:ring-2 focus-visible:ring-stone-300/70 dark:text-stone-500 dark:hover:bg-slate-800 dark:hover:text-stone-300 dark:focus-visible:ring-slate-600/70"
+                        className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-full px-1 py-0.5 font-mono text-[0.7rem] tracking-[0.01em] text-stone-400 outline-none transition hover:bg-[#EEE9E1] hover:text-stone-600 focus-visible:ring-2 focus-visible:ring-stone-300/70 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200 dark:focus-visible:ring-slate-600/70"
                         title={documentFilenameLabel}
                         aria-label="Document file actions"
                       >
@@ -815,7 +815,7 @@ export function DocumentWorkspace({
                     <SelectTrigger
                       data-testid="document-mode-trigger"
                       aria-label="Document mode"
-                      className="h-[1.5rem] px-1 font-mono text-[0.7rem] leading-[1.25rem] font-normal tracking-[0.01em] text-stone-400 dark:text-stone-500 hover:text-stone-500 dark:hover:text-stone-400"
+                      className="h-[1.5rem] px-1 font-mono text-[0.7rem] leading-[1.25rem] font-normal tracking-[0.01em] text-stone-400 dark:text-slate-400 hover:text-stone-500 dark:hover:text-slate-300"
                     >
                       <ActiveDocumentInteractionModeIcon className="size-[0.68rem]" />
                       <span className="truncate">
@@ -826,7 +826,7 @@ export function DocumentWorkspace({
                       {documentInteractionModeOptions.map(
                         ({ value, label, Icon }) => (
                           <SelectItem key={value} value={value} label={label}>
-                            <Icon className="size-3 text-stone-500 dark:text-stone-400" />
+                            <Icon className="size-3 text-stone-500 dark:text-slate-400" />
                             <SelectItemText>{label}</SelectItemText>
                           </SelectItem>
                         ),

--- a/packages/app/src/EditorContextMenu.tsx
+++ b/packages/app/src/EditorContextMenu.tsx
@@ -177,7 +177,7 @@ function SelectionMenuButton({
       data-testid={`selection-menu-action-${toTestIdSegment(label)}`}
       className={`inline-flex size-9 items-center justify-center rounded-xl border text-slate-600 dark:text-slate-400 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300 dark:focus-visible:ring-slate-600 ${
         active
-          ? "border-sky-200 bg-sky-100 text-sky-950 shadow-[0_8px_18px_rgba(14,116,144,0.14)] dark:border-sky-500/30 dark:bg-sky-400/20 dark:text-sky-100"
+          ? "border-[#dcd4c8] bg-[#E8E3DB] text-black shadow-[inset_0_1px_0_rgba(255,251,245,0.72)] dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
           : "border-transparent hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-900 dark:hover:text-slate-100"
       } disabled:cursor-not-allowed disabled:opacity-40`}
       onMouseDown={(event) => {

--- a/packages/app/src/EditorContextMenu.tsx
+++ b/packages/app/src/EditorContextMenu.tsx
@@ -177,7 +177,7 @@ function SelectionMenuButton({
       data-testid={`selection-menu-action-${toTestIdSegment(label)}`}
       className={`inline-flex size-9 items-center justify-center rounded-xl border text-slate-600 dark:text-slate-400 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300 dark:focus-visible:ring-slate-600 ${
         active
-          ? "border-[#dcd4c8] bg-[#E8E3DB] text-black shadow-[inset_0_1px_0_rgba(255,251,245,0.72)] dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+          ? "border-transparent bg-[#E8E3DB] text-black dark:bg-slate-700 dark:text-slate-100"
           : "border-transparent hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-900 dark:hover:text-slate-100"
       } disabled:cursor-not-allowed disabled:opacity-40`}
       onMouseDown={(event) => {
@@ -219,6 +219,23 @@ export function EditorContextMenu({
   const [linkPopoverState, setLinkPopoverState] =
     useState<LinkPopoverState | null>(null);
   const [linkDraft, setLinkDraft] = useState("");
+  // Keep the selection menu mounted through its exit animation. `renderedSelectionMenu`
+  // retains the last position while closing so the popover can animate out.
+  const selectionMenuVisible = Boolean(
+    selectionActionPosition && !linkPopoverState,
+  );
+  const [renderedSelectionMenu, setRenderedSelectionMenu] =
+    useState<SelectionActionPosition | null>(null);
+  useEffect(() => {
+    if (selectionMenuVisible && selectionActionPosition) {
+      setRenderedSelectionMenu(selectionActionPosition);
+      return;
+    }
+    if (!selectionMenuVisible && renderedSelectionMenu) {
+      const timeout = setTimeout(() => setRenderedSelectionMenu(null), 150);
+      return () => clearTimeout(timeout);
+    }
+  }, [selectionMenuVisible, selectionActionPosition, renderedSelectionMenu]);
   const menuRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const linkPopoverRef = useRef<HTMLDivElement>(null);
@@ -649,140 +666,147 @@ export function EditorContextMenu({
       }}
     >
       {children}
-      {selectionActionPosition && !linkPopoverState ? (
+      {renderedSelectionMenu ? (
         <div
-          data-testid="selection-menu"
-          className="absolute z-30 w-max max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-full rounded-2xl border border-slate-200/90 dark:border-slate-700/90 bg-white/95 dark:bg-slate-800/95 p-2 shadow-[0_18px_48px_rgba(15,23,42,0.16)] dark:shadow-[0_18px_48px_rgba(0,0,0,0.4)] backdrop-blur-xl"
+          className="absolute z-30 -translate-x-1/2 -translate-y-full"
           style={{
-            left: selectionActionPosition.left,
-            top: selectionActionPosition.top,
-          }}
-          onMouseDown={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
+            left: renderedSelectionMenu.left,
+            top: renderedSelectionMenu.top,
           }}
         >
-          <div className="flex flex-wrap items-center gap-1">
-            <SelectionMenuButton
-              label="Bold"
-              icon={<Bold className="size-4" />}
-              active={selectionMenuState.isBoldActive}
-              disabled={!selectionMenuState.canToggleBold}
-              onClick={() => editor?.chain().focus().toggleBold().run()}
-            />
-            <SelectionMenuButton
-              label="Italic"
-              icon={<Italic className="size-4" />}
-              active={selectionMenuState.isItalicActive}
-              disabled={!selectionMenuState.canToggleItalic}
-              onClick={() => editor?.chain().focus().toggleItalic().run()}
-            />
-            <SelectionMenuButton
-              label="Inline code"
-              icon={<Code2 className="size-4" />}
-              active={selectionMenuState.isCodeActive}
-              disabled={!selectionMenuState.canToggleCode}
-              onClick={() => editor?.chain().focus().toggleCode().run()}
-            />
-            <SelectionMenuButton
-              label="Blockquote"
-              icon={<Quote className="size-4" />}
-              active={selectionMenuState.isBlockquoteActive}
-              disabled={!selectionMenuState.canToggleBlockquote}
-              onClick={() => editor?.chain().focus().toggleBlockquote().run()}
-            />
-            <SelectionMenuButton
-              label="Bulleted list"
-              icon={<List className="size-4" />}
-              active={selectionMenuState.isBulletListActive}
-              disabled={!selectionMenuState.canToggleBulletList}
-              onClick={() => editor?.chain().focus().toggleBulletList().run()}
-            />
-            <SelectionMenuButton
-              label="Numbered list"
-              icon={<ListOrdered className="size-4" />}
-              active={selectionMenuState.isOrderedListActive}
-              disabled={!selectionMenuState.canToggleOrderedList}
-              onClick={() => editor?.chain().focus().toggleOrderedList().run()}
-            />
-            <SelectionMenuButton
-              label="Link"
-              icon={<Link2 className="size-4" />}
-              active={selectionMenuState.isLinkActive}
-              onClick={openLinkPopover}
-            />
-          </div>
-          {selectionMenuState.activeCriticChangeId ? (
-            <div className="grid grid-cols-2 gap-1">
-              <button
-                type="button"
-                data-testid="selection-menu-action-accept-suggestion"
-                className="inline-flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-emerald-700 transition hover:bg-emerald-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
-                onMouseDown={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                }}
-                onClick={() => {
-                  if (selectionMenuState.activeCriticChangeId) {
-                    editor
-                      ?.chain()
-                      .focus()
-                      .acceptCriticChange(
-                        selectionMenuState.activeCriticChangeId,
-                      )
-                      .run();
-                  }
-                  setSelectionActionPosition(null);
-                }}
-              >
-                <Check className="size-4" />
-                <span>Accept</span>
-              </button>
-              <button
-                type="button"
-                data-testid="selection-menu-action-reject-suggestion"
-                className="inline-flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-rose-700 transition hover:bg-rose-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-300"
-                onMouseDown={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                }}
-                onClick={() => {
-                  if (selectionMenuState.activeCriticChangeId) {
-                    editor
-                      ?.chain()
-                      .focus()
-                      .rejectCriticChange(
-                        selectionMenuState.activeCriticChangeId,
-                      )
-                      .run();
-                  }
-                  setSelectionActionPosition(null);
-                }}
-              >
-                <X className="size-4" />
-                <span>Reject</span>
-              </button>
-            </div>
-          ) : null}
-          <button
-            type="button"
-            data-testid="selection-menu-action-comment"
-            className="mt-2 flex w-full items-center justify-center gap-2 rounded-xl bg-[#E8E3DB] px-3 py-2 text-left text-sm font-bold text-black shadow-[inset_0_1px_0_rgba(255,251,245,0.72)] transition hover:bg-[#ded8ce] focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300 dark:bg-slate-700 dark:text-slate-100 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] dark:hover:bg-slate-600 dark:focus-visible:ring-slate-600 disabled:cursor-not-allowed disabled:opacity-40"
-            disabled={!onAddComment || editor?.state.selection.empty}
+          <div
+            data-testid="selection-menu"
+            data-state={selectionMenuVisible ? "open" : "closed"}
+            className="w-max max-w-[calc(100vw-2rem)] origin-bottom rounded-2xl border border-slate-200/90 dark:border-slate-700/90 bg-white/95 dark:bg-slate-800/95 p-2 shadow-[0_18px_48px_rgba(15,23,42,0.16)] dark:shadow-[0_18px_48px_rgba(0,0,0,0.4)] backdrop-blur-xl duration-150 ease-out data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-85 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-85"
             onMouseDown={(event) => {
               event.preventDefault();
               event.stopPropagation();
             }}
-            onClick={() => {
-              onAddComment?.();
-              setSelectionActionPosition(null);
-            }}
           >
-            <span className="inline-flex items-center gap-2">
-              <MessageSquarePlus className="size-4.5" />
-              <span>Comment</span>
-            </span>
-          </button>
+            <div className="flex flex-wrap items-center gap-1">
+              <SelectionMenuButton
+                label="Bold"
+                icon={<Bold className="size-4" />}
+                active={selectionMenuState.isBoldActive}
+                disabled={!selectionMenuState.canToggleBold}
+                onClick={() => editor?.chain().focus().toggleBold().run()}
+              />
+              <SelectionMenuButton
+                label="Italic"
+                icon={<Italic className="size-4" />}
+                active={selectionMenuState.isItalicActive}
+                disabled={!selectionMenuState.canToggleItalic}
+                onClick={() => editor?.chain().focus().toggleItalic().run()}
+              />
+              <SelectionMenuButton
+                label="Inline code"
+                icon={<Code2 className="size-4" />}
+                active={selectionMenuState.isCodeActive}
+                disabled={!selectionMenuState.canToggleCode}
+                onClick={() => editor?.chain().focus().toggleCode().run()}
+              />
+              <SelectionMenuButton
+                label="Blockquote"
+                icon={<Quote className="size-4" />}
+                active={selectionMenuState.isBlockquoteActive}
+                disabled={!selectionMenuState.canToggleBlockquote}
+                onClick={() => editor?.chain().focus().toggleBlockquote().run()}
+              />
+              <SelectionMenuButton
+                label="Bulleted list"
+                icon={<List className="size-4" />}
+                active={selectionMenuState.isBulletListActive}
+                disabled={!selectionMenuState.canToggleBulletList}
+                onClick={() => editor?.chain().focus().toggleBulletList().run()}
+              />
+              <SelectionMenuButton
+                label="Numbered list"
+                icon={<ListOrdered className="size-4" />}
+                active={selectionMenuState.isOrderedListActive}
+                disabled={!selectionMenuState.canToggleOrderedList}
+                onClick={() =>
+                  editor?.chain().focus().toggleOrderedList().run()
+                }
+              />
+              <SelectionMenuButton
+                label="Link"
+                icon={<Link2 className="size-4" />}
+                active={selectionMenuState.isLinkActive}
+                onClick={openLinkPopover}
+              />
+            </div>
+            {selectionMenuState.activeCriticChangeId ? (
+              <div className="grid grid-cols-2 gap-1">
+                <button
+                  type="button"
+                  data-testid="selection-menu-action-accept-suggestion"
+                  className="inline-flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-emerald-700 transition hover:bg-emerald-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                  }}
+                  onClick={() => {
+                    if (selectionMenuState.activeCriticChangeId) {
+                      editor
+                        ?.chain()
+                        .focus()
+                        .acceptCriticChange(
+                          selectionMenuState.activeCriticChangeId,
+                        )
+                        .run();
+                    }
+                    setSelectionActionPosition(null);
+                  }}
+                >
+                  <Check className="size-4" />
+                  <span>Accept</span>
+                </button>
+                <button
+                  type="button"
+                  data-testid="selection-menu-action-reject-suggestion"
+                  className="inline-flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-rose-700 transition hover:bg-rose-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-300"
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                  }}
+                  onClick={() => {
+                    if (selectionMenuState.activeCriticChangeId) {
+                      editor
+                        ?.chain()
+                        .focus()
+                        .rejectCriticChange(
+                          selectionMenuState.activeCriticChangeId,
+                        )
+                        .run();
+                    }
+                    setSelectionActionPosition(null);
+                  }}
+                >
+                  <X className="size-4" />
+                  <span>Reject</span>
+                </button>
+              </div>
+            ) : null}
+            <button
+              type="button"
+              data-testid="selection-menu-action-comment"
+              className="mt-2 flex w-full items-center justify-center gap-2 rounded-xl bg-[#E8E3DB] px-3 py-2 text-left text-sm font-bold text-black shadow-[inset_0_1px_0_rgba(255,251,245,0.72)] transition hover:bg-[#ded8ce] focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300 dark:bg-slate-700 dark:text-slate-100 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] dark:hover:bg-slate-600 dark:focus-visible:ring-slate-600 disabled:cursor-not-allowed disabled:opacity-40"
+              disabled={!onAddComment || editor?.state.selection.empty}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+              }}
+              onClick={() => {
+                onAddComment?.();
+                setSelectionActionPosition(null);
+              }}
+            >
+              <span className="inline-flex items-center gap-2">
+                <MessageSquarePlus className="size-4.5" />
+                <span>Comment</span>
+              </span>
+            </button>
+          </div>
         </div>
       ) : null}
       {linkPopoverState ? (

--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -624,6 +624,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
   const [pendingFocusCommentId, setPendingFocusCommentId] = useState<
     string | null
   >(null);
+  const [newCommentDraftIds, setNewCommentDraftIds] = useState<string[]>([]);
 
   const resolveFileUrl = useCallback(
     (path: string) => backend.resolveFileUrl(path),
@@ -1479,6 +1480,9 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
     nextComments.set(comment.id, comment);
     commentsRef.current = nextComments;
     setComments(nextComments);
+    setNewCommentDraftIds((current) =>
+      current.includes(comment.id) ? current : [...current, comment.id],
+    );
 
     suppressNextMarkdownUpdateRef.current = true;
     currentEditor
@@ -1624,6 +1628,9 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
       nextComments.set(commentId, updater(existingComment));
       commentsRef.current = nextComments;
       setComments(nextComments);
+      setNewCommentDraftIds((current) =>
+        current.filter((currentCommentId) => currentCommentId !== commentId),
+      );
       emitMarkdownChange(undefined, nextComments);
     },
     [emitMarkdownChange],
@@ -1803,6 +1810,9 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
       setPendingFocusCommentId((current) =>
         current && deletedIds.has(current) ? null : current,
       );
+      setNewCommentDraftIds((current) =>
+        current.filter((commentId) => !deletedIds.has(commentId)),
+      );
       emitMarkdownChange(currentEditor.getJSON(), nextComments);
       requestAnimationFrame(() => {
         measureLayout();
@@ -1925,6 +1935,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
               onSelectComment={selectComment}
               onHoverComment={setHoveredCommentId}
               pendingFocusCommentId={pendingFocusCommentId}
+              newCommentDraftIds={newCommentDraftIds}
               onAutoFocusComment={(commentId) => {
                 setPendingFocusCommentId((current) =>
                   current === commentId ? null : current,
@@ -1997,6 +2008,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
           onFocusSuggestion={focusSuggestion}
           onHoverSuggestion={setHoveredChangeId}
           pendingFocusCommentId={pendingFocusCommentId}
+          newCommentDraftIds={newCommentDraftIds}
           onAutoFocusComment={(commentId) => {
             setPendingFocusCommentId((current) =>
               current === commentId ? null : current,

--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -1864,7 +1864,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
     .map((commentId) => comments.get(commentId))
     .filter((comment): comment is CriticComment => Boolean(comment));
   const contentCardClass =
-    "rounded-[0.75rem] border border-[#E9E9E8] dark:border-slate-700 bg-white dark:bg-card shadow-[0_18px_44px_rgba(57,47,38,0.08)] dark:shadow-[0_18px_44px_rgba(0,0,0,0.35)]";
+    "rounded-[0.75rem] border border-[#E9E9E8] dark:border-slate-800 bg-white dark:bg-card shadow-[0_18px_44px_rgba(57,47,38,0.08)] dark:shadow-[0_18px_44px_rgba(0,0,0,0.35)]";
   const documentShellClass = cn(
     "document-page-shell",
     layout === "embedded-demo"
@@ -2043,7 +2043,7 @@ const CodeEditorSurface = memo(function CodeEditorSurface({
         <div className={documentMainClass}>
           <div className={contentInsetClass}>
             <div
-              className="min-h-[calc(70vh+4rem)] rounded-[0.75rem] border border-[#E9E9E8] dark:border-slate-700 bg-white dark:bg-card py-10 pr-6 pl-5 shadow-[0_18px_44px_rgba(57,47,38,0.08)] dark:shadow-[0_18px_44px_rgba(0,0,0,0.35)] sm:py-14 sm:pr-10 sm:pl-8"
+              className="min-h-[calc(70vh+4rem)] rounded-[0.75rem] border border-[#E9E9E8] dark:border-slate-800 bg-white dark:bg-card py-10 pr-6 pl-5 shadow-[0_18px_44px_rgba(57,47,38,0.08)] dark:shadow-[0_18px_44px_rgba(0,0,0,0.35)] sm:py-14 sm:pr-10 sm:pl-8"
               data-testid="document-content-card"
             >
               <MarkdownCodeEditor

--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -34,6 +34,7 @@ import { buildLocationForLinkedMarkdownDocument } from "./app-navigation";
 import { toHtml } from "./markdown";
 import type { Page, StorageBackend } from "./storage";
 import { useCommentAnchorLayout } from "./useCommentAnchorLayout";
+import { useReviewLayoutShiftAnimation } from "./useReviewLayoutShiftAnimation";
 
 export type DocumentSaveState = "saved" | "unsaved" | "saving" | "error";
 
@@ -1860,6 +1861,8 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
   }, []);
 
   const hasReviewRail = comments.size > 0 || criticChanges.length > 0;
+  const documentShellRef =
+    useReviewLayoutShiftAnimation<HTMLDivElement>(hasReviewRail);
   const activeComments = activeCommentIds
     .map((commentId) => comments.get(commentId))
     .filter((comment): comment is CriticComment => Boolean(comment));
@@ -1869,15 +1872,17 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
     "document-page-shell",
     layout === "embedded-demo"
       ? "grid grid-cols-1 gap-3 p-4 min-[900px]:grid-cols-[minmax(0,min(100%,42rem))_minmax(13rem,16rem)] min-[900px]:items-start min-[900px]:justify-start"
-      : "flex flex-col gap-6 min-[1100px]:grid min-[1100px]:grid-cols-[minmax(0,46.5rem)_minmax(24rem,1fr)] min-[1100px]:items-start min-[1100px]:justify-between min-[1100px]:gap-8",
+      : "review-layout-grid",
     !hasReviewRail && "document-page-shell-no-comments",
     layout !== "embedded-demo" &&
       !hasReviewRail &&
-      "min-[1100px]:grid-cols-[minmax(0,46.5rem)] min-[1100px]:justify-center",
+      "review-layout-grid--centered",
   );
   const documentMainClass = cn(
     "document-page-main w-full min-w-0",
-    layout === "embedded-demo" ? "max-w-none" : "max-w-[46.5rem]",
+    layout === "embedded-demo"
+      ? "max-w-none"
+      : "review-layout-main max-w-[46.5rem]",
   );
   const contentInsetClass = layout === "embedded-demo" ? "pb-0" : "pb-24";
   const fallbackClass = cn(
@@ -1888,7 +1893,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
     "document-comment-rail",
     layout === "embedded-demo"
       ? "block px-4 pb-4 min-[900px]:p-0"
-      : "hidden min-[1100px]:block",
+      : "review-layout-rail hidden min-[1100px]:block",
   );
 
   return (
@@ -1896,7 +1901,11 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
       className="cursor-text bg-transparent"
       data-testid="page-card-rich-text"
     >
-      <div data-testid="document-page-shell" className={documentShellClass}>
+      <div
+        ref={documentShellRef}
+        data-testid="document-page-shell"
+        className={documentShellClass}
+      >
         <div className={documentMainClass}>
           {activeComments.length > 0 ? (
             <CommentEditorList
@@ -2019,27 +2028,35 @@ const CodeEditorSurface = memo(function CodeEditorSurface({
     "document-page-shell",
     layout === "embedded-demo"
       ? "grid grid-cols-1 gap-3 p-4 min-[900px]:grid-cols-[minmax(0,min(100%,42rem))_minmax(13rem,16rem)] min-[900px]:items-start min-[900px]:justify-start"
-      : "flex flex-col gap-6 min-[1100px]:grid min-[1100px]:grid-cols-[minmax(0,46.5rem)_minmax(24rem,1fr)] min-[1100px]:items-start min-[1100px]:justify-between min-[1100px]:gap-8",
+      : "review-layout-grid",
     !hasCommentRailSpace && "document-page-shell-no-comments",
     layout !== "embedded-demo" &&
       !hasCommentRailSpace &&
-      "min-[1100px]:grid-cols-[minmax(0,46.5rem)] min-[1100px]:justify-center",
+      "review-layout-grid--centered",
   );
   const documentMainClass = cn(
     "document-page-main w-full min-w-0",
-    layout === "embedded-demo" ? "max-w-none" : "max-w-[46.5rem]",
+    layout === "embedded-demo"
+      ? "max-w-none"
+      : "review-layout-main max-w-[46.5rem]",
   );
   const contentInsetClass = layout === "embedded-demo" ? "pb-0" : "pb-24";
   const reviewRailClass = cn(
     "document-comment-rail pointer-events-none invisible",
     layout === "embedded-demo"
       ? "block px-4 pb-4 min-[900px]:p-0"
-      : "hidden min-[1100px]:block",
+      : "review-layout-rail hidden min-[1100px]:block",
   );
+  const documentShellRef =
+    useReviewLayoutShiftAnimation<HTMLDivElement>(hasCommentRailSpace);
 
   return (
     <div className="cursor-text bg-transparent" data-testid="page-card-code">
-      <div data-testid="document-page-shell" className={documentShellClass}>
+      <div
+        ref={documentShellRef}
+        data-testid="document-page-shell"
+        className={documentShellClass}
+      >
         <div className={documentMainClass}>
           <div className={contentInsetClass}>
             <div

--- a/packages/app/src/components/ui/select.tsx
+++ b/packages/app/src/components/ui/select.tsx
@@ -67,7 +67,7 @@ function SelectContent({
         <SelectPrimitive.Popup
           data-slot="select-content"
           className={cn(
-            "z-50 min-w-32 origin-(--transform-origin) rounded-lg border border-[#DCD6CC] dark:border-slate-700 bg-[#FFFDFC] dark:bg-slate-800 p-1 text-xs text-stone-700 dark:text-stone-300 shadow-[0_12px_32px_rgba(57,47,38,0.16)] dark:shadow-[0_12px_32px_rgba(0,0,0,0.4)] data-[ending-style]:animate-out data-[ending-style]:fade-out-0 data-[ending-style]:zoom-out-95 data-[starting-style]:animate-in data-[starting-style]:fade-in-0 data-[starting-style]:zoom-in-95",
+            "z-50 min-w-32 origin-(--transform-origin) rounded-lg border border-[#DCD6CC] dark:border-slate-700 bg-[#FFFDFC] dark:bg-slate-800 p-1 text-xs text-stone-700 dark:text-slate-300 shadow-[0_12px_32px_rgba(57,47,38,0.16)] dark:shadow-[0_12px_32px_rgba(0,0,0,0.4)] data-[ending-style]:animate-out data-[ending-style]:fade-out-0 data-[ending-style]:zoom-out-95 data-[starting-style]:animate-in data-[starting-style]:fade-in-0 data-[starting-style]:zoom-in-95",
             className,
           )}
           {...props}
@@ -90,7 +90,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "flex cursor-default items-center gap-2 rounded-md px-2 py-1.5 text-[0.72rem] leading-none outline-none transition select-none data-[highlighted]:bg-[#EEE9E1] dark:data-[highlighted]:bg-slate-700 data-[highlighted]:text-stone-900 dark:data-[highlighted]:text-stone-100 data-[selected]:text-stone-900 dark:data-[selected]:text-stone-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        "flex cursor-default items-center gap-2 rounded-md px-2 py-1.5 text-[0.72rem] leading-none outline-none transition select-none data-[highlighted]:bg-[#EEE9E1] dark:data-[highlighted]:bg-slate-700 data-[highlighted]:text-stone-900 dark:data-[highlighted]:text-slate-100 data-[selected]:text-stone-900 dark:data-[selected]:text-slate-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
         className,
       )}
       {...props}
@@ -98,7 +98,7 @@ function SelectItem({
       {children}
       <SelectPrimitive.ItemIndicator
         data-slot="select-item-indicator"
-        className="ml-auto flex size-3 items-center justify-center text-stone-700 dark:text-stone-300"
+        className="ml-auto flex size-3 items-center justify-center text-stone-700 dark:text-slate-300"
       >
         <Check className="size-3" />
       </SelectPrimitive.ItemIndicator>

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -733,3 +733,60 @@
 .document-save-status-saved {
   animation: document-save-status-saved-fade 2s ease-out forwards;
 }
+
+/*
+ * Review layout grid: a single document column that rests centered (no
+ * comments) or shifted-left with a review rail (comments present).
+ *
+ * The visible motion is FLIP-driven by useReviewLayoutShiftAnimation. The grid
+ * moves to its next resting layout immediately, then a temporary inverse
+ * translate animates back to zero. This avoids relying on grid-template-columns
+ * interpolation while the first comment UI mounts.
+ *
+ * Below the breakpoint the shell falls back to a simple stacked column.
+ */
+.review-layout-grid {
+  --review-layout-shift-x: 0px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  transform: translateX(var(--review-layout-shift-x));
+}
+
+@media (min-width: 1100px) {
+  .review-layout-grid {
+    display: grid;
+    /* comments present: document on the left, fixed-width rail on the right */
+    --review-rail-width: 24rem;
+    grid-template-columns: minmax(0, 46.5rem) var(--review-rail-width);
+    justify-content: center;
+    align-items: start;
+    column-gap: 2rem;
+  }
+
+  /* no comments: rail collapses to nothing and the document re-centers */
+  .review-layout-grid.review-layout-grid--centered {
+    --review-rail-width: 0rem;
+    column-gap: 0rem;
+  }
+
+  .review-layout-grid > .review-layout-main {
+    grid-column: 1;
+  }
+
+  .review-layout-grid > .review-layout-rail {
+    grid-column: 2;
+    min-width: 0;
+  }
+}
+
+.review-layout-grid.review-layout-grid--animating {
+  transition: transform 180ms cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: transform;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .review-layout-grid {
+    transition: none;
+  }
+}

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -685,9 +685,9 @@
 .dark {
   --background: oklch(0.141 0.006 67.1);
   --foreground: oklch(0.985 0 0);
-  --card: oklch(0.21 0.006 56.1);
+  --card: oklch(0.21 0.025 257);
   --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.21 0.006 56.1);
+  --popover: oklch(0.21 0.025 257);
   --popover-foreground: oklch(0.985 0 0);
   --primary: oklch(0.92 0.005 84.2);
   --primary-foreground: oklch(0.21 0.006 56.1);

--- a/packages/app/src/useReviewLayoutShiftAnimation.ts
+++ b/packages/app/src/useReviewLayoutShiftAnimation.ts
@@ -1,0 +1,87 @@
+import { useLayoutEffect, useRef, type RefObject } from "react";
+
+const animationClass = "review-layout-grid--animating";
+const shiftProperty = "--review-layout-shift-x";
+const reducedMotionQuery = "(prefers-reduced-motion: reduce)";
+const animationDurationMs = 180;
+
+export function useReviewLayoutShiftAnimation<TElement extends HTMLElement>(
+  layoutState: unknown,
+): RefObject<TElement | null> {
+  const elementRef = useRef<TElement>(null);
+  const previousLeftRef = useRef<number | null>(null);
+  const frameRef = useRef<number | null>(null);
+  const timeoutRef = useRef<number | null>(null);
+
+  useLayoutEffect(() => {
+    void layoutState;
+
+    const element = elementRef.current;
+    const main = element?.querySelector<HTMLElement>(".review-layout-main");
+    if (!element || !main) return;
+
+    const nextLeft = main.getBoundingClientRect().left;
+    const previousLeft = previousLeftRef.current;
+    previousLeftRef.current = nextLeft;
+
+    if (previousLeft === null) return;
+    if (
+      typeof window.matchMedia === "function" &&
+      window.matchMedia(reducedMotionQuery).matches
+    ) {
+      return;
+    }
+
+    const deltaX = previousLeft - nextLeft;
+    if (Math.abs(deltaX) < 1) return;
+
+    if (frameRef.current !== null) {
+      window.cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    }
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+
+    let finished = false;
+    const finish = () => {
+      if (finished) return;
+      finished = true;
+      element.classList.remove(animationClass);
+      element.style.removeProperty(shiftProperty);
+      element.removeEventListener("transitionend", handleTransitionEnd);
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+    const handleTransitionEnd = (event: TransitionEvent) => {
+      if (event.target === element && event.propertyName === "transform") {
+        finish();
+      }
+    };
+
+    element.classList.remove(animationClass);
+    element.style.setProperty(shiftProperty, `${deltaX}px`);
+    void element.offsetWidth;
+    element.classList.add(animationClass);
+    element.addEventListener("transitionend", handleTransitionEnd);
+
+    frameRef.current = window.requestAnimationFrame(() => {
+      frameRef.current = null;
+      element.style.setProperty(shiftProperty, "0px");
+    });
+    timeoutRef.current = window.setTimeout(finish, animationDurationMs + 100);
+
+    return () => {
+      if (frameRef.current !== null) {
+        window.cancelAnimationFrame(frameRef.current);
+        frameRef.current = null;
+      }
+      finish();
+    };
+  }, [layoutState]);
+
+  return elementRef;
+}

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -1600,6 +1600,17 @@ describe("PageCard editor integration", () => {
       "comment-banner-c1-action-save",
     );
     expect(saveButton).not.toBeNull();
+    expect(saveButton?.className).toContain("rounded-xl");
+    expect(saveButton?.className).toContain("bg-[#E8E3DB]");
+    expect(saveButton?.className).toContain("font-bold");
+    expect(saveButton?.className).toContain("w-full");
+    expect(saveButton?.className).toContain("text-sm");
+    expect(
+      queryByTestId<HTMLButtonElement>(
+        rendered.container,
+        "comment-banner-c1-action-cancel",
+      ),
+    ).toBeNull();
 
     await act(async () => {
       saveButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));


### PR DESCRIPTION
Polishes the dark-mode review UI with cooler slate accents, updated selection/comment action styling, and smoother review rail layout changes.
Adds FLIP-based animation for the document and header when the review rail appears or disappears, plus smoke coverage for that transition.
Updates comment draft behavior so new root comments use a popover-style Save action without a redundant footer Cancel button.
Validation: pnpm check and pnpm test:smoke.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI, layout animation, and comment draft presentation only; no auth, persistence, or API contract changes beyond existing comment save behavior.
> 
> **Overview**
> Polishes **dark-mode review UI** with cooler slate accents on the document chrome, handoff control, selection menu active states, cards, and select popovers, and tweaks dark `--card` / `--popover` tokens.
> 
> Adds **FLIP-based review layout animation** via `useReviewLayoutShiftAnimation` and shared `review-layout-grid` CSS on the document header and page shell so the main column eases when the review rail appears or disappears; a new smoke e2e test samples transform/classes during add/remove comment flows.
> 
> **New root comment drafts** track `newCommentDraftIds`, use a popover-style full-width Save (no footer Cancel—thread delete dismisses), and wire through the review rail. The **selection menu** stays mounted briefly on close for zoom/fade exit animation. Docs/README examples and the UI screenshot guide are updated for inline CriticMarkup and the new draft comment capture row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e013ea30f8a53b0ef5e78622b03cbbf1e92aeba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->