### PR TITLE
Improve document status and handoff affordances

### DIFF
--- a/docs/spec/ui-state-screenshot-guide.md
+++ b/docs/spec/ui-state-screenshot-guide.md
@@ -126,7 +126,7 @@ suggestions:
 | Document | Review handoff idle | Open a local file while a watcher is connected | `review-handoff-button` | Header text: `Agent watching`. |
 | Document | Review handoff comment popover | Open a local file while a watcher is connected, then click the handoff dropdown trigger | `review-handoff-comment-trigger`, `review-handoff-comment-popover`, `review-handoff-overall-comment` | Capture the split handoff control and textarea with `Overall comment` placeholder before submission. |
 | Document | Review handoff sending | Click handoff button while watcher is connected | `review-handoff-button` | Button label: `Sending`. |
-| Document | Review handoff sent | Successful handoff | `review-handoff-status` | Popover title: `Your agent is now working`. |
+| Document | Review handoff sent | Successful handoff | `review-handoff-status`, `review-handoff-robots-toy`, `review-handoff-close-window`, `review-handoff-copy-message` | Capture the random completion title, robot toy, primary close button, and fallback copy hint below it. |
 | Document | Review handoff undelivered | Watcher disconnects before handoff | `review-handoff-status` | Popover title: `No agent is watching now`. |
 | Document | Review handoff error | Force handoff API error | `review-handoff-status` | Popover title: `Could not notify agent`. |
 | Remote | Connected banner | Open with `?session=<id>&token=<token>` and remote capability enabled | `role=status`, `aria-label="Remote session connected"` | Requires remote backend support in `/api/status`. |

--- a/docs/spec/ui-state-screenshot-guide.md
+++ b/docs/spec/ui-state-screenshot-guide.md
@@ -116,7 +116,7 @@ suggestions:
 | Document | Editing mode | Open mode menu and choose Editing | `document-mode-trigger` | Normal edit behavior. |
 | Document | Suggesting mode | Open mode menu and choose Suggesting | `document-mode-trigger` | Selection actions should create suggestions instead of direct edits. |
 | Document | Viewing mode | Open mode menu and choose Viewing | `document-mode-trigger` | Editing controls should look non-editable. |
-| Document | Save status: saved | Any clean document after autosave | `document-save-status` | Checkmark should sit next to the filename and fade out over 2 seconds; accessible label remains `Saved`. |
+| Document | Save status: saved | Any clean document after autosave | `document-save-status` | Checkmark should sit fixed in the top-left corner and fade out over 2 seconds; accessible label remains `Saved`. |
 | Document | Save status: unsaved | Type in a local document before save completes | `document-save-status` | Spinner-only pending state; accessible label is `Unsaved changes`. Transient; often easier with save throttling or network mocking. |
 | Document | Save status: saving | Type and capture during autosave | `document-save-status` | Spinner-only pending state; accessible label is `Saving`. Transient; easiest with mocked delayed save. |
 | Document | Save status: failed | Force save error | `document-save-status` | Icon-only error state; accessible label is `Save failed`. Use backend/API mocking or a component harness. |

--- a/packages/app/e2e/review-handoff.spec.ts
+++ b/packages/app/e2e/review-handoff.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 import {
   createMarkdownProject,
+  logE2eEvent,
   openMarkdownFile,
   readProjectFile,
   removeMarkdownProject,
@@ -70,5 +71,43 @@ test.describe("review handoff", () => {
         comments: 1,
       },
     });
+  });
+
+  test("reopens the sent handoff status from the muted primary button", async ({
+    page,
+    request,
+  }) => {
+    const filePath = writeProjectFile(
+      projectDir,
+      "sent-handoff.md",
+      ["# Sent Handoff", "", "Review already completed.", ""].join("\n"),
+    );
+    const relativePath = "sent-handoff.md";
+
+    pendingWatch = request.post("/api/review-events/watch", {
+      data: {
+        projectPath: projectDir,
+        path: relativePath,
+        timeoutSeconds: 10,
+      },
+    });
+
+    await openMarkdownFile(page, filePath);
+    await page.getByTestId("review-handoff-button").click();
+
+    await expect(page.getByTestId("review-handoff-button")).toHaveText("Sent");
+    await expect(page.getByTestId("review-handoff-status")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("review-handoff-status")).toBeHidden();
+
+    await page.getByTestId("review-handoff-button").click();
+
+    await expect(page.getByTestId("review-handoff-status")).toBeVisible();
+    logE2eEvent("review-handoff.sent-button-reopened-status", {
+      buttonLabel: await page.getByTestId("review-handoff-button").innerText(),
+    });
+
+    await pendingWatch;
   });
 });

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1451,6 +1451,7 @@ export function PreviewPage() {
       <DocumentWorkspace
         documentPage={previewPage}
         activeDocumentPath={PREVIEW_DOCUMENT_PATH}
+        documentCopyPath={PREVIEW_DOCUMENT_PATH}
         documentFilenameLabel={PREVIEW_DOCUMENT_PATH}
         documentEditorViewMode={editorViewMode}
         onDocumentEditorViewModeChange={setEditorViewMode}
@@ -1939,6 +1940,7 @@ export function App() {
       <DocumentWorkspace
         documentPage={documentPage}
         activeDocumentPath={activeDocumentPath}
+        documentCopyPath={documentAbsolutePath}
         documentFilenameLabel={documentFilenameLabel}
         documentEditorViewMode={documentEditorViewMode}
         onDocumentEditorViewModeChange={handleDocumentEditorViewModeChange}

--- a/packages/app/src/CommentEditorList.tsx
+++ b/packages/app/src/CommentEditorList.tsx
@@ -344,11 +344,11 @@ interface CommentThreadNodeProps {
   onChangeDraft: (commentId: string, nextContent: string) => void;
 }
 
-const COMMENT_TREE_INDENT = 20;
-const COMMENT_TREE_ELBOW_TOP = 14;
-const COMMENT_TREE_ROW_GAP = 12;
-const COMMENT_AVATAR_SIZE = 28;
-const COMMENT_AVATAR_CENTER = 16;
+const COMMENT_TREE_INDENT = 16;
+const COMMENT_TREE_ELBOW_TOP = 12;
+const COMMENT_TREE_ROW_GAP = 10;
+const COMMENT_AVATAR_SIZE = 20;
+const COMMENT_AVATAR_CENTER = 12;
 
 function CommentActionButton({
   label,
@@ -469,8 +469,8 @@ function CommentThreadNode({
     variant === "banner"
       ? "bg-[#DED8CE]/90 dark:bg-slate-600/90"
       : "bg-[#DED8CE]/85 dark:bg-slate-600/85";
-  const defaultContent =
-    comment.content.trim().length > 0 ? comment.content : "Empty comment";
+  const hasCommentContent = comment.content.trim().length > 0;
+  const defaultContent = hasCommentContent ? comment.content : "Empty comment";
   const isNewRootCommentDraft =
     isEditing &&
     depth === 0 &&
@@ -638,7 +638,7 @@ function CommentThreadNode({
           </div>
         ) : null}
         <div className="min-w-0 flex-1">
-          <div className="relative grid grid-cols-[2rem_minmax(0,1fr)] gap-x-2">
+          <div className="relative grid grid-cols-[1.5rem_minmax(0,1fr)] gap-x-1.5">
             {interactive && isRootThread ? (
               <CommentActionButton
                 label="Delete thread"
@@ -671,27 +671,28 @@ function CommentThreadNode({
             <div className="relative flex justify-center">
               <div
                 className={cn(
-                  "relative z-10 flex size-7 items-center justify-center rounded-full border shadow-[0_1px_2px_rgba(15,23,42,0.08)]",
+                  "relative z-10 flex size-5 items-center justify-center rounded-full border shadow-[0_1px_2px_rgba(15,23,42,0.08)]",
                   avatarTone,
                 )}
                 title={authorLabel}
               >
-                <AuthorIcon className="size-3.5 shrink-0" />
+                <AuthorIcon className="size-2.5 shrink-0" />
               </div>
             </div>
             <div
               className={cn(
                 "min-w-0 rounded-xl px-0.5",
-                isRootThread && interactive && "pr-7",
+                isRootThread && interactive && !isEditing && "pr-7",
                 bodyTone,
               )}
             >
-              <div className="truncate text-[13px] font-semibold text-slate-900 dark:text-slate-100">
+              <div className="truncate text-xs font-semibold text-slate-900 dark:text-slate-100">
                 {authorLabel}
               </div>
               <div
                 className={cn(
-                  "mt-1 text-sm leading-6 whitespace-pre-wrap",
+                  "mt-0.5 text-[13px] leading-5 whitespace-pre-wrap",
+                  !hasCommentContent && "italic",
                   variant === "banner"
                     ? "text-slate-800 dark:text-slate-200"
                     : "text-slate-700 dark:text-slate-300",
@@ -715,7 +716,7 @@ function CommentThreadNode({
                   }
                   rows={1}
                   className={cn(
-                    "mt-1 min-h-12 px-3 py-2 text-sm leading-6 md:text-sm md:leading-6",
+                    "mt-2 min-h-12 px-2.5 py-2 text-[13px] leading-5 md:text-[13px] md:leading-5",
                     variant === "banner"
                       ? "border-amber-200 dark:border-amber-700 bg-white/90 dark:bg-slate-800/90 text-slate-800 dark:text-slate-200"
                       : "border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 shadow-none",
@@ -771,7 +772,7 @@ function CommentThreadNode({
         </div>
       </div>
       {hasReplies ? (
-        <div className="mt-3 space-y-3">
+        <div className="mt-2.5 space-y-2.5">
           {replies.map((reply, replyIndex) => (
             <CommentThreadNode
               key={reply.comment.id}

--- a/packages/app/src/DocumentReviewRail.tsx
+++ b/packages/app/src/DocumentReviewRail.tsx
@@ -33,6 +33,8 @@ import { SUGGESTED_PARAGRAPH_SENTINEL } from "./editor-extensions";
 import { cn } from "./lib/utils";
 import type { DraftSuggestionState } from "./PageCard";
 
+const SUGGESTION_QUOTE_PREVIEW_LIMIT = 140;
+
 export interface CriticChangeRailItem {
   changeId: string;
   change: CriticChangeAttrs;
@@ -114,16 +116,22 @@ function getSuggestionRootComment(
   };
 }
 
+function truncateSuggestionQuote(text: string) {
+  if (text.length <= SUGGESTION_QUOTE_PREVIEW_LIMIT) return text;
+  return `${text.slice(0, SUGGESTION_QUOTE_PREVIEW_LIMIT)}...`;
+}
+
 function renderQuotedSuggestionText(text: string, fallback: string) {
   const withoutParagraphSentinels = text.replaceAll(
     SUGGESTED_PARAGRAPH_SENTINEL,
     "",
   );
-  const displayText =
+  const fullDisplayText =
     withoutParagraphSentinels.trim() ||
     (text.includes(SUGGESTED_PARAGRAPH_SENTINEL)
       ? "Inserted paragraph"
       : fallback);
+  const displayText = truncateSuggestionQuote(fullDisplayText);
 
   return (
     <span className="italic text-slate-600 dark:text-slate-400">

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -239,6 +239,34 @@ export function isReviewHandoffDisabled({
   );
 }
 
+export function getReviewHandoffButtonLabel({
+  reviewHandoffState,
+  documentChangedSinceOpen,
+}: {
+  reviewHandoffState: ReviewHandoffState;
+  documentChangedSinceOpen: boolean;
+}) {
+  return reviewHandoffState === "notifying"
+    ? "Sending"
+    : reviewHandoffState === "notified"
+      ? "Sent"
+      : reviewHandoffState === "error" || reviewHandoffState === "undelivered"
+        ? "Not sent"
+        : documentChangedSinceOpen
+          ? "I'm done"
+          : "Approve";
+}
+
+export function shouldLatchDocumentChangedSinceOpen({
+  isDirty,
+  documentChangeTrackingReady,
+}: {
+  isDirty: boolean;
+  documentChangeTrackingReady: boolean;
+}) {
+  return isDirty && documentChangeTrackingReady;
+}
+
 interface DocumentWorkspaceProps {
   documentPage: Page | null;
   activeDocumentPath: string | null;
@@ -279,7 +307,7 @@ export function DocumentWorkspace({
   backend,
 }: DocumentWorkspaceProps) {
   const [documentInteractionMode, setDocumentInteractionMode] =
-    useState<DocumentInteractionMode>("editing");
+    useState<DocumentInteractionMode>("suggesting");
   const [saveState, setSaveState] = useState<DocumentSaveState>("saved");
   const [reviewHandoffState, setReviewHandoffState] =
     useState<ReviewHandoffState>("idle");
@@ -290,8 +318,11 @@ export function DocumentWorkspace({
   const [copiedFileAction, setCopiedFileAction] =
     useState<FileCopyAction | null>(null);
   const [overallComment, setOverallComment] = useState("");
+  const [documentChangedSinceOpen, setDocumentChangedSinceOpen] =
+    useState(false);
   const sawNoWatcherAfterNotifiedRef = useRef(false);
   const saveControllerRef = useRef<DocumentSaveController | null>(null);
+  const documentChangeTrackingReadyRef = useRef(false);
 
   const handleSaveStateChange = useCallback(
     (state: DocumentSaveState) => {
@@ -319,7 +350,13 @@ export function DocumentWorkspace({
   useEffect(() => {
     const documentIdentity = `${activeDocumentPath ?? ""}:${documentPage?.id ?? ""}`;
     if (!documentIdentity) return;
+    documentChangeTrackingReadyRef.current = false;
     setReviewHandoffState("idle");
+    setDocumentChangedSinceOpen(false);
+    const readyTimer = window.setTimeout(() => {
+      documentChangeTrackingReadyRef.current = true;
+    }, 0);
+    return () => window.clearTimeout(readyTimer);
   }, [activeDocumentPath, documentPage?.id]);
 
   useEffect(() => {
@@ -430,6 +467,21 @@ export function DocumentWorkspace({
     [activeDocumentPath, onCompleteReview, reviewHandoffState],
   );
 
+  const handleDocumentDirtyStateChange = useCallback(
+    (isDirty: boolean) => {
+      if (
+        shouldLatchDocumentChangedSinceOpen({
+          isDirty,
+          documentChangeTrackingReady: documentChangeTrackingReadyRef.current,
+        })
+      ) {
+        setDocumentChangedSinceOpen(true);
+      }
+      onDocumentDirtyStateChange(isDirty);
+    },
+    [onDocumentDirtyStateChange],
+  );
+
   const handleCopyFileMenuAction = useCallback(
     async (action: FileCopyAction) => {
       if (!documentPage) return;
@@ -476,14 +528,10 @@ export function DocumentWorkspace({
   const showReviewHandoffButton =
     !!activeDocumentPath &&
     (reviewWatcherCount > 0 || reviewHandoffState !== "idle");
-  const reviewHandoffButtonLabel =
-    reviewHandoffState === "notifying"
-      ? "Sending"
-      : reviewHandoffState === "notified"
-        ? "Sent"
-        : reviewHandoffState === "error" || reviewHandoffState === "undelivered"
-          ? "Not sent"
-          : "I'm done";
+  const reviewHandoffButtonLabel = getReviewHandoffButtonLabel({
+    reviewHandoffState,
+    documentChangedSinceOpen,
+  });
   const ReviewHandoffButtonIcon =
     reviewHandoffState === "notifying"
       ? Loader2
@@ -517,6 +565,17 @@ export function DocumentWorkspace({
       )}
     >
       <RemoteSessionBanner backend={backend} />
+      {documentPage ? (
+        <div
+          className="fixed top-3 left-3 z-[60]"
+          data-testid="document-save-status-corner"
+        >
+          <DocumentSaveStatusIndicator
+            saveState={saveState}
+            diskChangeState={documentDiskChangeState}
+          />
+        </div>
+      ) : null}
       <div
         className={cn(
           "fixed right-3 z-[60] flex max-w-[min(16rem,calc(100vw-1rem))] flex-col items-end gap-1.5",
@@ -605,7 +664,7 @@ export function DocumentWorkspace({
                         }
                         maxLength={4000}
                         rows={4}
-                        className="min-h-24 resize-y"
+                        className="min-h-24 resize-none"
                       />
                     </div>
                     <Button
@@ -767,7 +826,7 @@ export function DocumentWorkspace({
                       <button
                         type="button"
                         data-testid="document-file-menu-trigger"
-                        className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-full px-1 py-0.5 font-mono text-[0.7rem] tracking-[0.01em] text-stone-400 outline-none transition hover:bg-[#EEE9E1] hover:text-stone-600 focus-visible:ring-2 focus-visible:ring-stone-300/70 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200 dark:focus-visible:ring-slate-600/70"
+                        className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-full px-1 py-0.5 font-mono text-[0.8rem] tracking-[0.01em] text-stone-400 outline-none transition hover:bg-[#EEE9E1] hover:text-stone-600 focus-visible:ring-2 focus-visible:ring-stone-300/70 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200 dark:focus-visible:ring-slate-600/70"
                         title={documentFilenameLabel}
                         aria-label="Document file actions"
                       >
@@ -805,10 +864,6 @@ export function DocumentWorkspace({
                     </div>
                   </PopoverContent>
                 </Popover>
-                <DocumentSaveStatusIndicator
-                  saveState={saveState}
-                  diskChangeState={documentDiskChangeState}
-                />
                 <div className="ml-auto inline-flex h-[1.25rem] shrink-0 items-center">
                   <Select<DocumentInteractionMode>
                     value={documentInteractionMode}
@@ -819,7 +874,7 @@ export function DocumentWorkspace({
                     <SelectTrigger
                       data-testid="document-mode-trigger"
                       aria-label="Document mode"
-                      className="h-[1.5rem] px-1 font-mono text-[0.7rem] leading-[1.25rem] font-normal tracking-[0.01em] text-stone-400 dark:text-slate-400 hover:text-stone-500 dark:hover:text-slate-300"
+                      className="h-[1.5rem] px-1 font-mono text-[0.8rem] leading-[1.25rem] font-normal tracking-[0.01em] text-stone-400 dark:text-slate-400 hover:text-stone-500 dark:hover:text-slate-300"
                     >
                       <ActiveDocumentInteractionModeIcon className="size-[0.68rem]" />
                       <span className="truncate">
@@ -855,7 +910,7 @@ export function DocumentWorkspace({
               interactionMode={documentInteractionMode}
               backend={backend}
               onCommentRailPresenceChange={setDocumentHasComments}
-              onDirtyStateChange={onDocumentDirtyStateChange}
+              onDirtyStateChange={handleDocumentDirtyStateChange}
               onLocalContentChange={onDocumentLocalContentChange}
               onSaveControllerChange={(controller) => {
                 saveControllerRef.current = controller;

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -4,6 +4,7 @@ import {
   CheckCheck,
   ChevronDown,
   CodeXml,
+  Copy,
   Eye,
   Loader2,
   MessageSquarePlus,
@@ -53,6 +54,7 @@ type ReviewHandoffState =
   | "undelivered"
   | "error";
 type FileCopyAction = "path" | "filename" | "markdown" | "rich-text";
+const FILE_COPY_PREVIEW_MAX_LENGTH = 34;
 
 const documentInteractionModeOptions = [
   { value: "editing", label: "Editing", Icon: PencilLine },
@@ -86,14 +88,20 @@ const conflictNoticeCopy: Record<
 };
 
 const fileCopyMenuOptions = [
-  { action: "path", label: "Copy path" },
-  { action: "filename", label: "Copy filename" },
-  { action: "markdown", label: "Copy markdown" },
-  { action: "rich-text", label: "Copy rich text" },
+  { action: "path", label: "Path" },
+  { action: "filename", label: "Filename" },
+  { action: "markdown", label: "Markdown" },
+  { action: "rich-text", label: "Rich text" },
 ] satisfies {
   action: FileCopyAction;
   label: string;
 }[];
+
+function formatFileCopyPreview(value: string) {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= FILE_COPY_PREVIEW_MAX_LENGTH) return normalized;
+  return `${normalized.slice(0, FILE_COPY_PREVIEW_MAX_LENGTH - 1)}...`;
+}
 
 async function writePlainTextToClipboard(text: string) {
   await navigator.clipboard.writeText(text);
@@ -321,6 +329,7 @@ export function DocumentWorkspace({
   const [documentChangedSinceOpen, setDocumentChangedSinceOpen] =
     useState(false);
   const sawNoWatcherAfterNotifiedRef = useRef(false);
+  const copiedFileActionTimeoutRef = useRef<number | null>(null);
   const saveControllerRef = useRef<DocumentSaveController | null>(null);
   const documentChangeTrackingReadyRef = useRef(false);
 
@@ -408,6 +417,14 @@ export function DocumentWorkspace({
       setReviewHandoffState("idle");
     }
   }, [reviewHandoffState, reviewWatcherCount]);
+
+  useEffect(() => {
+    return () => {
+      if (copiedFileActionTimeoutRef.current !== null) {
+        window.clearTimeout(copiedFileActionTimeoutRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (!documentPage) return;
@@ -503,8 +520,13 @@ export function DocumentWorkspace({
         }
 
         setCopiedFileAction(action);
-        window.setTimeout(() => setCopiedFileAction(null), 1400);
-        setFileCopyMenuOpen(false);
+        if (copiedFileActionTimeoutRef.current !== null) {
+          window.clearTimeout(copiedFileActionTimeoutRef.current);
+        }
+        copiedFileActionTimeoutRef.current = window.setTimeout(() => {
+          setCopiedFileAction(null);
+          copiedFileActionTimeoutRef.current = null;
+        }, 3000);
       } catch (error) {
         console.error("Failed to copy document data:", error);
       }
@@ -516,6 +538,12 @@ export function DocumentWorkspace({
     documentEditorViewMode === "rich-text"
       ? "Switch to code view"
       : "Switch to rich text view";
+  const fileCopyPreviewByAction: Record<FileCopyAction, string> = {
+    path: formatFileCopyPreview(activeDocumentPath ?? documentFilenameLabel),
+    filename: formatFileCopyPreview(documentFilenameLabel),
+    markdown: formatFileCopyPreview(documentPage?.content ?? ""),
+    "rich-text": formatFileCopyPreview(documentPage?.content ?? ""),
+  };
   const activeDocumentInteractionMode = documentInteractionModeOptions.find(
     (option) => option.value === documentInteractionMode,
   );
@@ -843,8 +871,9 @@ export function DocumentWorkspace({
                   <PopoverContent
                     aria-label="Document file actions"
                     data-testid="document-file-menu"
-                    className="w-44 p-1"
+                    className="w-56 p-1"
                     align="start"
+                    sideOffset={4}
                   >
                     <div className="flex flex-col">
                       {fileCopyMenuOptions.map(({ action, label }) => (
@@ -852,12 +881,25 @@ export function DocumentWorkspace({
                           key={action}
                           type="button"
                           data-testid={`document-file-menu-${action}`}
-                          className="flex h-8 items-center justify-between rounded-md px-2 text-left text-[0.72rem] leading-none text-stone-700 outline-none transition hover:bg-[#EEE9E1] focus-visible:bg-[#EEE9E1] dark:text-stone-300 dark:hover:bg-slate-700 dark:focus-visible:bg-slate-700"
+                          className="flex items-start gap-2 rounded-md px-2 py-1.5 text-left text-[0.72rem] leading-none text-stone-700 outline-none transition hover:bg-[#EEE9E1] focus-visible:bg-[#EEE9E1] dark:text-stone-300 dark:hover:bg-slate-700 dark:focus-visible:bg-slate-700"
                           onClick={() => void handleCopyFileMenuAction(action)}
                         >
-                          <span>{label}</span>
+                          <Copy
+                            className="mt-[0.06rem] size-4 shrink-0 text-stone-500 dark:text-slate-400"
+                            aria-hidden="true"
+                          />
+                          <span className="grid min-w-0 flex-1 gap-1">
+                            <span className="truncate font-semibold">
+                              {copiedFileAction === action
+                                ? "Copied!"
+                                : label}
+                            </span>
+                            <span className="truncate text-[0.66rem] leading-none text-stone-400 dark:text-slate-500">
+                              {fileCopyPreviewByAction[action]}
+                            </span>
+                          </span>
                           {copiedFileAction === action ? (
-                            <Check className="size-3 text-stone-500 dark:text-stone-400" />
+                            <Check className="mt-[0.06rem] ml-auto size-3 shrink-0 text-stone-500 dark:text-stone-400" />
                           ) : null}
                         </button>
                       ))}

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -34,9 +34,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "./components/ui/tooltip";
-import { criticMarkdownHasReviewRail } from "./critic-markup";
+import {
+  criticMarkdownHasReviewRail,
+  criticMarkdownToRenderedHtml,
+} from "./critic-markup";
 import { cn } from "./lib/utils";
-import { toHtml } from "./markdown";
 import {
   type DocumentInteractionMode,
   type DocumentSaveController,
@@ -107,22 +109,69 @@ async function writePlainTextToClipboard(text: string) {
   await navigator.clipboard.writeText(text);
 }
 
+function markdownToPlainText(markdown: string) {
+  const template = document.createElement("template");
+  template.innerHTML = markdownToCleanRichHtml(markdown);
+  return (template.content.textContent ?? "").trimEnd();
+}
+
+function unwrapElement(element: HTMLElement) {
+  element.replaceWith(...element.childNodes);
+}
+
+function markdownToCleanRichHtml(markdown: string) {
+  const template = document.createElement("template");
+  template.innerHTML = criticMarkdownToRenderedHtml(markdown).html;
+
+  for (const element of Array.from(
+    template.content.querySelectorAll<HTMLElement>(
+      "[data-comment-anchorless='true']",
+    ),
+  )) {
+    element.remove();
+  }
+
+  for (const element of Array.from(
+    template.content.querySelectorAll<HTMLElement>("[data-comment-ids]"),
+  )) {
+    unwrapElement(element);
+  }
+
+  for (const element of Array.from(
+    template.content.querySelectorAll<HTMLElement>(
+      "[data-critic-change-kind='addition'], [data-critic-change-kind='substitution-new']",
+    ),
+  )) {
+    element.remove();
+  }
+
+  for (const element of Array.from(
+    template.content.querySelectorAll<HTMLElement>("[data-critic-change-kind]"),
+  )) {
+    unwrapElement(element);
+  }
+
+  return template.innerHTML;
+}
+
 async function writeRichTextToClipboard(markdown: string) {
   const clipboardWithRichText = navigator.clipboard as Clipboard & {
     write?: Clipboard["write"];
   };
+  const html = markdownToCleanRichHtml(markdown);
+  const plainText = markdownToPlainText(markdown);
 
   if (clipboardWithRichText.write && typeof ClipboardItem !== "undefined") {
     await clipboardWithRichText.write([
       new ClipboardItem({
-        "text/html": new Blob([toHtml(markdown)], { type: "text/html" }),
-        "text/plain": new Blob([markdown], { type: "text/plain" }),
+        "text/html": new Blob([html], { type: "text/html" }),
+        "text/plain": new Blob([plainText], { type: "text/plain" }),
       }),
     ]);
     return;
   }
 
-  await writePlainTextToClipboard(markdown);
+  await writePlainTextToClipboard(plainText);
 }
 
 function getSaveStatusViewModel(
@@ -278,6 +327,7 @@ export function shouldLatchDocumentChangedSinceOpen({
 interface DocumentWorkspaceProps {
   documentPage: Page | null;
   activeDocumentPath: string | null;
+  documentCopyPath: string | null;
   documentFilenameLabel: string;
   documentEditorViewMode: DocumentEditorViewMode;
   onDocumentEditorViewModeChange: (mode: DocumentEditorViewMode) => void;
@@ -299,6 +349,7 @@ interface DocumentWorkspaceProps {
 export function DocumentWorkspace({
   documentPage,
   activeDocumentPath,
+  documentCopyPath,
   documentFilenameLabel,
   documentEditorViewMode,
   onDocumentEditorViewModeChange,
@@ -507,7 +558,7 @@ export function DocumentWorkspace({
         Exclude<FileCopyAction, "rich-text">,
         string
       > = {
-        path: activeDocumentPath ?? documentFilenameLabel,
+        path: documentCopyPath ?? activeDocumentPath ?? documentFilenameLabel,
         filename: documentFilenameLabel,
         markdown: documentPage.content,
       };
@@ -531,7 +582,7 @@ export function DocumentWorkspace({
         console.error("Failed to copy document data:", error);
       }
     },
-    [activeDocumentPath, documentFilenameLabel, documentPage],
+    [activeDocumentPath, documentCopyPath, documentFilenameLabel, documentPage],
   );
 
   const editorViewModeToggleLabel =
@@ -539,10 +590,14 @@ export function DocumentWorkspace({
       ? "Switch to code view"
       : "Switch to rich text view";
   const fileCopyPreviewByAction: Record<FileCopyAction, string> = {
-    path: formatFileCopyPreview(activeDocumentPath ?? documentFilenameLabel),
+    path: formatFileCopyPreview(
+      documentCopyPath ?? activeDocumentPath ?? documentFilenameLabel,
+    ),
     filename: formatFileCopyPreview(documentFilenameLabel),
     markdown: formatFileCopyPreview(documentPage?.content ?? ""),
-    "rich-text": formatFileCopyPreview(documentPage?.content ?? ""),
+    "rich-text": formatFileCopyPreview(
+      documentPage ? markdownToPlainText(documentPage.content) : "",
+    ),
   };
   const activeDocumentInteractionMode = documentInteractionModeOptions.find(
     (option) => option.value === documentInteractionMode,
@@ -854,7 +909,7 @@ export function DocumentWorkspace({
                       <button
                         type="button"
                         data-testid="document-file-menu-trigger"
-                        className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-full px-1 py-0.5 font-mono text-[0.8rem] tracking-[0.01em] text-stone-400 outline-none transition hover:bg-[#EEE9E1] hover:text-stone-600 focus-visible:ring-2 focus-visible:ring-stone-300/70 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200 dark:focus-visible:ring-slate-600/70"
+                        className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-full px-1 py-0.5 text-[0.8rem] font-medium tracking-[0.01em] text-stone-400 outline-none transition hover:text-stone-500 focus-visible:ring-2 focus-visible:ring-stone-300/70 dark:text-slate-400 dark:hover:text-slate-300 dark:focus-visible:ring-slate-600/70"
                         title={documentFilenameLabel}
                         aria-label="Document file actions"
                       >
@@ -889,7 +944,7 @@ export function DocumentWorkspace({
                             aria-hidden="true"
                           />
                           <span className="grid min-w-0 flex-1 gap-1">
-                            <span className="truncate font-semibold">
+                            <span className="truncate font-medium">
                               {copiedFileAction === action
                                 ? "Copied!"
                                 : label}
@@ -916,9 +971,9 @@ export function DocumentWorkspace({
                     <SelectTrigger
                       data-testid="document-mode-trigger"
                       aria-label="Document mode"
-                      className="h-[1.5rem] px-1 font-mono text-[0.8rem] leading-[1.25rem] font-normal tracking-[0.01em] text-stone-400 dark:text-slate-400 hover:text-stone-500 dark:hover:text-slate-300"
+                      className="h-[1.5rem] gap-1.5 px-1 text-[0.8rem] leading-[1.25rem] font-medium tracking-[0.01em] text-stone-400 dark:text-slate-400 hover:text-stone-500 dark:hover:text-slate-300"
                     >
-                      <ActiveDocumentInteractionModeIcon className="size-[0.68rem]" />
+                      <ActiveDocumentInteractionModeIcon className="size-[0.8rem]" />
                       <span className="truncate">
                         {activeDocumentInteractionMode?.label}
                       </span>
@@ -926,9 +981,16 @@ export function DocumentWorkspace({
                     <SelectContent>
                       {documentInteractionModeOptions.map(
                         ({ value, label, Icon }) => (
-                          <SelectItem key={value} value={value} label={label}>
+                          <SelectItem
+                            key={value}
+                            value={value}
+                            label={label}
+                            className="text-[0.8rem]"
+                          >
                             <Icon className="size-3 text-stone-500 dark:text-slate-400" />
-                            <SelectItemText>{label}</SelectItemText>
+                            <SelectItemText className="font-medium">
+                              {label}
+                            </SelectItemText>
                           </SelectItem>
                         ),
                       )}

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -45,6 +45,7 @@ import {
   type DocumentSaveState,
   PageCard,
 } from "./PageCard";
+import { RobotsHighFiveToy } from "./RobotsHighFiveToy";
 import type { CompleteReviewOptions, Page, StorageBackend } from "./storage";
 import { useReviewLayoutShiftAnimation } from "./useReviewLayoutShiftAnimation";
 
@@ -57,6 +58,58 @@ type ReviewHandoffState =
   | "error";
 type FileCopyAction = "path" | "filename" | "markdown" | "rich-text";
 const FILE_COPY_PREVIEW_MAX_LENGTH = 34;
+const reviewCompleteTitles = [
+  "Great work!",
+  "Nice one!",
+  "Well done!",
+  "All set!",
+  "Review complete!",
+  "That’ll do!",
+  "Lovely stuff!",
+  "Job done!",
+  "Done and dusted!",
+  "Nailed it!",
+  "Good stuff!",
+  "Sorted!",
+  "Cracking work!",
+  "Top work!",
+  "Brilliant!",
+  "Ace!",
+  "Spot on!",
+  "Beauty!",
+  "Too easy!",
+  "Good on ya!",
+  "You’re golden!",
+  "That’s the ticket!",
+  "And that’s that!",
+  "Wrapped!",
+  "In the bag!",
+  "Shipshape!",
+  "Right as rain!",
+] as const;
+type ReviewCompleteTitle = (typeof reviewCompleteTitles)[number];
+
+function buildReviewHandoffCopyMessage(documentPath: string) {
+  return `I am done reviewing this file: ${documentPath}`;
+}
+
+function getRandomReviewCompleteTitle(random: () => number = Math.random) {
+  const index = Math.floor(random() * reviewCompleteTitles.length);
+  return reviewCompleteTitles[Math.min(index, reviewCompleteTitles.length - 1)];
+}
+
+function getRandomReviewCompleteTitleExcept(
+  currentTitle: ReviewCompleteTitle,
+  random: () => number = Math.random,
+): ReviewCompleteTitle {
+  const otherTitles = reviewCompleteTitles.filter(
+    (title) => title !== currentTitle,
+  );
+  if (otherTitles.length === 0) return currentTitle;
+
+  const index = Math.floor(random() * otherTitles.length);
+  return otherTitles[Math.min(index, otherTitles.length - 1)];
+}
 
 const documentInteractionModeOptions = [
   { value: "editing", label: "Editing", Icon: PencilLine },
@@ -373,6 +426,9 @@ export function DocumentWorkspace({
   const [reviewWatcherCount, setReviewWatcherCount] = useState(0);
   const [reviewHandoffPopoverOpen, setReviewHandoffPopoverOpen] =
     useState(false);
+  const [reviewCompleteTitle, setReviewCompleteTitle] = useState(() =>
+    getRandomReviewCompleteTitle(),
+  );
   const [fileCopyMenuOpen, setFileCopyMenuOpen] = useState(false);
   const [copiedFileAction, setCopiedFileAction] =
     useState<FileCopyAction | null>(null);
@@ -412,6 +468,7 @@ export function DocumentWorkspace({
     if (!documentIdentity) return;
     documentChangeTrackingReadyRef.current = false;
     setReviewHandoffState("idle");
+    setReviewHandoffPopoverOpen(false);
     setDocumentChangedSinceOpen(false);
     const readyTimer = window.setTimeout(() => {
       documentChangeTrackingReadyRef.current = true;
@@ -468,6 +525,14 @@ export function DocumentWorkspace({
       setReviewHandoffState("idle");
     }
   }, [reviewHandoffState, reviewWatcherCount]);
+
+  useEffect(() => {
+    if (reviewHandoffState === "notified") {
+      setReviewCompleteTitle((currentTitle) =>
+        getRandomReviewCompleteTitleExcept(currentTitle),
+      );
+    }
+  }, [reviewHandoffState]);
 
   useEffect(() => {
     return () => {
@@ -626,18 +691,23 @@ export function DocumentWorkspace({
       ? "No agent is watching now"
       : reviewHandoffState === "error"
         ? "Could not notify agent"
-        : "Your agent is now working";
+        : reviewCompleteTitle;
   const reviewHandoffStatusBody =
     reviewHandoffState === "undelivered"
       ? "The handoff was not delivered because the watcher is no longer connected."
       : reviewHandoffState === "error"
         ? "Roughdraft could not send the handoff. Check that the local server is still running."
-        : "It will take the appropriate next action, including replying to comments, questions, and suggestions, and/or directly editing the doc.";
+        : null;
+  const reviewHandoffCopyMessage = buildReviewHandoffCopyMessage(
+    activeDocumentPath ?? documentFilenameLabel,
+  );
   const reviewHandoffDisabled = isReviewHandoffDisabled({
     saveState,
     documentDiskChangeState,
     reviewHandoffState,
   });
+  const reviewHandoffButtonDisabled =
+    reviewHandoffDisabled && reviewHandoffState !== "notified";
   const trimmedOverallComment = overallComment.trim();
 
   return (
@@ -673,20 +743,32 @@ export function DocumentWorkspace({
               open={reviewHandoffPopoverOpen}
               onOpenChange={setReviewHandoffPopoverOpen}
             >
-              <div className="relative flex items-center overflow-hidden rounded-[7px] shadow-[0_10px_28px_rgba(0,0,0,0.18)] after:pointer-events-none after:absolute after:top-px after:right-8 after:bottom-px after:z-10 after:w-px after:bg-[#4a4038] after:content-[''] dark:after:bg-slate-600">
+              <div
+                data-testid="review-handoff-split-button"
+                className={cn(
+                  "relative flex items-center overflow-hidden rounded-[7px] shadow-[0_10px_28px_rgba(0,0,0,0.18)] transition-opacity after:pointer-events-none after:absolute after:top-px after:right-8 after:bottom-px after:z-10 after:w-px after:bg-[#4a4038] after:content-[''] dark:after:bg-slate-600",
+                  reviewHandoffDisabled && "opacity-50",
+                )}
+              >
                 <Button
                   type="button"
                   data-testid="review-handoff-button"
                   size="lg"
-                  className="h-9 rounded-r-none rounded-l-[7px] border-0 bg-[#2B2420] px-3 text-sm font-bold text-white hover:bg-[#3a322b] focus-visible:ring-slate-300 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 dark:focus-visible:ring-slate-600"
-                  disabled={reviewHandoffDisabled}
-                  onClick={() =>
+                  className="h-9 rounded-r-none rounded-l-[7px] border-0 bg-[#2B2420] px-3 text-sm font-bold text-white hover:bg-[#3a322b] focus-visible:ring-slate-300 disabled:opacity-100 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 dark:focus-visible:ring-slate-600"
+                  disabled={reviewHandoffButtonDisabled}
+                  aria-disabled={reviewHandoffButtonDisabled || undefined}
+                  onClick={() => {
+                    if (reviewHandoffState === "notified") {
+                      setReviewHandoffPopoverOpen(true);
+                      return;
+                    }
+
                     void handleCompleteReview(
                       trimmedOverallComment
                         ? { overallComment: trimmedOverallComment }
                         : undefined,
-                    )
-                  }
+                    );
+                  }}
                 >
                   {ReviewHandoffButtonIcon ? (
                     <ReviewHandoffButtonIcon
@@ -704,7 +786,7 @@ export function DocumentWorkspace({
                       type="button"
                       data-testid="review-handoff-comment-trigger"
                       size="icon-lg"
-                      className="h-9 w-8 rounded-l-none rounded-r-[7px] border-0 bg-[#2B2420] text-white hover:bg-[#3a322b] focus-visible:ring-slate-300 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 dark:focus-visible:ring-slate-600"
+                      className="h-9 w-8 rounded-l-none rounded-r-[7px] border-0 bg-[#2B2420] text-white hover:bg-[#3a322b] focus-visible:ring-slate-300 disabled:opacity-100 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 dark:focus-visible:ring-slate-600"
                       disabled={reviewHandoffDisabled}
                       aria-label="Add overall handoff comment"
                     >
@@ -714,6 +796,7 @@ export function DocumentWorkspace({
                 />
               </div>
               <PopoverContent
+                className={reviewHandoffState === "idle" ? undefined : "pt-0"}
                 aria-label={
                   reviewHandoffState === "idle"
                     ? "Review handoff comment"
@@ -762,24 +845,69 @@ export function DocumentWorkspace({
                     </Button>
                   </form>
                 ) : (
-                  <div className="flex items-start gap-3">
-                    <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-black text-white dark:bg-white dark:text-black">
-                      {reviewHandoffState === "notifying" ? (
-                        <Loader2 className="size-4 animate-spin" />
-                      ) : reviewHandoffState === "error" ||
-                        reviewHandoffState === "undelivered" ? (
-                        <AlertTriangle className="size-4" />
-                      ) : (
-                        <CheckCheck className="size-4" />
-                      )}
-                    </span>
-                    <div>
-                      <div className="text-sm font-semibold text-stone-950 dark:text-slate-50">
-                        {reviewHandoffStatusTitle}
+                  <div>
+                    <div className="mb-3 flex h-[170px] items-center justify-center overflow-hidden">
+                      <RobotsHighFiveToy
+                        onHighFive={() =>
+                          setReviewCompleteTitle((currentTitle) =>
+                            getRandomReviewCompleteTitleExcept(currentTitle),
+                          )
+                        }
+                      />
+                    </div>
+                    <div className="flex items-start gap-3">
+                      {reviewHandoffState === "notifying" ||
+                      reviewHandoffState === "error" ||
+                      reviewHandoffState === "undelivered" ? (
+                        <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-black text-white dark:bg-white dark:text-black">
+                          {reviewHandoffState === "notifying" ? (
+                            <Loader2 className="size-4 animate-spin" />
+                          ) : (
+                            <AlertTriangle className="size-4" />
+                          )}
+                        </span>
+                      ) : null}
+                      <div>
+                        <div className="text-xl font-semibold leading-6 text-stone-950 dark:text-slate-50">
+                          {reviewHandoffStatusTitle}
+                        </div>
+                        {reviewHandoffStatusBody ? (
+                          <p className="mt-1 text-sm leading-6 text-stone-600 dark:text-slate-300">
+                            {reviewHandoffStatusBody}
+                          </p>
+                        ) : (
+                          <div className="mt-1">
+                            <p className="text-sm leading-[1.32rem] text-stone-500 dark:text-slate-400">
+                              Your agent is now working in the background on
+                              this, in all likelihood. If our signal didn't make
+                              it, just{" "}
+                              <button
+                                type="button"
+                                data-testid="review-handoff-copy-message"
+                                className="font-normal text-inherit underline decoration-stone-300 underline-offset-4 hover:decoration-stone-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-950/25 dark:decoration-slate-600 dark:hover:decoration-slate-200 dark:focus-visible:ring-slate-50/30"
+                                onClick={() =>
+                                  void writePlainTextToClipboard(
+                                    reviewHandoffCopyMessage,
+                                  )
+                                }
+                              >
+                                click here
+                              </button>{" "}
+                              to copy a line you can send it to keep going.
+                            </p>
+                            <Button
+                              type="button"
+                              data-testid="review-handoff-close-window"
+                              size="lg"
+                              variant="outline"
+                              className="mt-4 w-full rounded-[7px] text-sm font-semibold"
+                              onClick={() => window.close()}
+                            >
+                              Close window
+                            </Button>
+                          </div>
+                        )}
                       </div>
-                      <p className="mt-1 text-sm leading-6 text-stone-600 dark:text-slate-300">
-                        {reviewHandoffStatusBody}
-                      </p>
                     </div>
                   </div>
                 )}
@@ -945,9 +1073,7 @@ export function DocumentWorkspace({
                           />
                           <span className="grid min-w-0 flex-1 gap-1">
                             <span className="truncate font-medium">
-                              {copiedFileAction === action
-                                ? "Copied!"
-                                : label}
+                              {copiedFileAction === action ? "Copied!" : label}
                             </span>
                             <span className="truncate text-[0.66rem] leading-none text-stone-400 dark:text-slate-500">
                               {fileCopyPreviewByAction[action]}

--- a/packages/app/src/RobotsHighFiveToy.tsx
+++ b/packages/app/src/RobotsHighFiveToy.tsx
@@ -1,0 +1,533 @@
+import type { KeyboardEvent } from "react";
+import { useCallback, useEffect, useRef } from "react";
+
+type Pose = {
+  sh: number;
+  el: number;
+};
+
+const SHOULDER_L = [270, 230] as const;
+const ELBOW_L = [270, 276] as const;
+const SHOULDER_R = [410, 230] as const;
+const ELBOW_R = [410, 276] as const;
+
+const REST: Pose = { sh: 0, el: 0 };
+const COCK: Pose = { sh: -115, el: -80 };
+const IMPACT: Pose = { sh: -136, el: 0 };
+const RECOIL: Pose = { sh: -131, el: -18 };
+
+function ease(progress: number) {
+  return progress * progress * (3 - 2 * progress);
+}
+
+function wait(ms: number) {
+  return new Promise<void>((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+function replay(el: SVGElement | null, className: string) {
+  if (!el) return;
+  el.classList.remove(className);
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => el.classList.add(className));
+  });
+}
+
+export function RobotsHighFiveToy({ onHighFive }: { onHighFive?: () => void }) {
+  const upperLRef = useRef<SVGGElement | null>(null);
+  const foreLRef = useRef<SVGGElement | null>(null);
+  const upperRRef = useRef<SVGGElement | null>(null);
+  const foreRRef = useRef<SVGGElement | null>(null);
+  const bobLRef = useRef<SVGGElement | null>(null);
+  const bobRRef = useRef<SVGGElement | null>(null);
+  const flashRef = useRef<SVGGElement | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const currentRef = useRef<Pose>({ ...REST });
+  const tokenRef = useRef(0);
+  const readyRef = useRef(false);
+  const hoveringRef = useRef(false);
+
+  const render = useCallback(() => {
+    const current = currentRef.current;
+    upperLRef.current?.setAttribute(
+      "transform",
+      `rotate(${current.sh} ${SHOULDER_L[0]} ${SHOULDER_L[1]})`,
+    );
+    foreLRef.current?.setAttribute(
+      "transform",
+      `rotate(${current.el} ${ELBOW_L[0]} ${ELBOW_L[1]})`,
+    );
+    upperRRef.current?.setAttribute(
+      "transform",
+      `rotate(${-current.sh} ${SHOULDER_R[0]} ${SHOULDER_R[1]})`,
+    );
+    foreRRef.current?.setAttribute(
+      "transform",
+      `rotate(${-current.el} ${ELBOW_R[0]} ${ELBOW_R[1]})`,
+    );
+  }, []);
+
+  const tweenTo = useCallback(
+    (target: Pose, duration: number, token: number) => {
+      const from = { ...currentRef.current };
+      const start = performance.now();
+      return new Promise<void>((resolve) => {
+        function step(now: number) {
+          if (token !== tokenRef.current) {
+            resolve();
+            return;
+          }
+
+          const progress =
+            duration > 0 ? Math.min((now - start) / duration, 1) : 1;
+          const eased = ease(progress);
+          currentRef.current = {
+            sh: from.sh + (target.sh - from.sh) * eased,
+            el: from.el + (target.el - from.el) * eased,
+          };
+          render();
+
+          if (progress < 1) {
+            requestAnimationFrame(step);
+          } else {
+            resolve();
+          }
+        }
+
+        requestAnimationFrame(step);
+      });
+    },
+    [render],
+  );
+
+  const impactFX = useCallback(() => {
+    replay(flashRef.current, "pop");
+    replay(bobLRef.current, "hop");
+    replay(bobRRef.current, "hop");
+  }, []);
+
+  const slap = useCallback(
+    async (token: number) => {
+      await tweenTo(IMPACT, 110, token);
+      if (token !== tokenRef.current) return false;
+      impactFX();
+      await tweenTo(RECOIL, 90, token);
+      if (token !== tokenRef.current) return false;
+      await tweenTo({ sh: IMPACT.sh, el: -4 }, 90, token);
+      return token === tokenRef.current;
+    },
+    [impactFX, tweenTo],
+  );
+
+  const handleMouseEnter = useCallback(() => {
+    if (!readyRef.current) return;
+    hoveringRef.current = true;
+    const token = ++tokenRef.current;
+    void tweenTo(COCK, 260, token);
+  }, [tweenTo]);
+
+  const handleMouseLeave = useCallback(() => {
+    if (!readyRef.current) return;
+    hoveringRef.current = false;
+    const token = ++tokenRef.current;
+    void tweenTo(REST, 340, token);
+  }, [tweenTo]);
+
+  const handleClick = useCallback(async () => {
+    onHighFive?.();
+    if (!readyRef.current) return;
+    const token = ++tokenRef.current;
+    if (!(await slap(token))) return;
+    await tweenTo(hoveringRef.current ? COCK : REST, 240, token);
+  }, [onHighFive, slap, tweenTo]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      void handleClick();
+    },
+    [handleClick],
+  );
+
+  useEffect(() => {
+    render();
+    const token = ++tokenRef.current;
+    const isCurrent = () => token === tokenRef.current;
+
+    async function intro() {
+      await wait(500);
+      if (!isCurrent()) return;
+      await tweenTo(COCK, 380, token);
+      await wait(240);
+      if (!isCurrent()) return;
+      await slap(token);
+      await wait(160);
+      if (!isCurrent()) return;
+      await tweenTo(REST, 440, token);
+      if (!isCurrent()) return;
+      readyRef.current = true;
+      if (svgRef.current?.matches(":hover")) {
+        hoveringRef.current = true;
+        const hoverToken = ++tokenRef.current;
+        void tweenTo(COCK, 260, hoverToken);
+      }
+    }
+
+    void intro();
+
+    return () => {
+      tokenRef.current += 1;
+      readyRef.current = false;
+    };
+  }, [render, slap, tweenTo]);
+
+  return (
+    <button
+      type="button"
+      aria-label="High five the robots"
+      className="h-full w-full cursor-pointer appearance-none rounded-[7px] border-0 bg-transparent p-0 outline-none focus:outline-none focus-visible:ring-2 focus-visible:ring-stone-950/25 dark:focus-visible:ring-slate-50/30"
+      data-testid="review-handoff-robots-toy"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onClick={() => void handleClick()}
+      onKeyDown={handleKeyDown}
+    >
+      <svg
+        ref={svgRef}
+        viewBox="0 0 680 380"
+        xmlns="http://www.w3.org/2000/svg"
+        role="img"
+        aria-labelledby="robots-high-five-title robots-high-five-desc"
+        className="review-handoff-robots h-full w-full"
+      >
+        <title id="robots-high-five-title">Two robots high-fiving</title>
+        <desc id="robots-high-five-desc">
+          Two cartoon robots swing their arms up to meet in a high five, with a
+          sparkle flash at the moment of contact.
+        </desc>
+
+        <ellipse cx="230" cy="340" rx="56" ry="10" fill="rgba(0,0,0,0.13)" />
+        <ellipse cx="450" cy="340" rx="56" ry="10" fill="rgba(0,0,0,0.13)" />
+
+        <g className="bot-l">
+          <rect x="212" y="300" width="16" height="28" rx="4" fill="#3E5A77" />
+          <rect x="232" y="300" width="16" height="28" rx="4" fill="#3E5A77" />
+          <g ref={bobLRef} className="bob-l">
+            <rect
+              x="182.5"
+              y="230"
+              width="15"
+              height="46"
+              rx="7.5"
+              fill="#6E8FB0"
+              stroke="#3E5A77"
+              strokeWidth="2"
+            />
+            <g transform="rotate(16 190 276)">
+              <rect
+                x="182.5"
+                y="276"
+                width="15"
+                height="44"
+                rx="7.5"
+                fill="#6E8FB0"
+                stroke="#3E5A77"
+                strokeWidth="2"
+              />
+              <circle
+                cx="190"
+                cy="320"
+                r="11"
+                fill="#7E9DBC"
+                stroke="#3E5A77"
+                strokeWidth="2"
+              />
+            </g>
+            <circle
+              cx="190"
+              cy="276"
+              r="8"
+              fill="#6E8FB0"
+              stroke="#3E5A77"
+              strokeWidth="2"
+            />
+            <rect
+              x="195"
+              y="222"
+              width="70"
+              height="82"
+              rx="14"
+              fill="#6E8FB0"
+              stroke="#3E5A77"
+              strokeWidth="2"
+            />
+            <rect
+              x="215"
+              y="244"
+              width="30"
+              height="26"
+              rx="4"
+              fill="#3E5A77"
+            />
+            <circle cx="223" cy="257" r="2.5" fill="#E8A23D" />
+            <circle cx="237" cy="257" r="2.5" fill="#7ECBC4" />
+            <rect
+              x="202"
+              y="178"
+              width="56"
+              height="44"
+              rx="12"
+              fill="#7E9DBC"
+              stroke="#3E5A77"
+              strokeWidth="2"
+            />
+            <line
+              x1="230"
+              y1="178"
+              x2="230"
+              y2="162"
+              stroke="#3E5A77"
+              strokeWidth="3"
+            />
+            <circle cx="230" cy="158" r="5" fill="#E8A23D" />
+            <circle
+              cx="218"
+              cy="200"
+              r="8"
+              fill="#fff"
+              stroke="#3E5A77"
+              strokeWidth="1.5"
+            />
+            <circle cx="218" cy="200" r="3.5" fill="#1F3346" />
+            <circle
+              cx="242"
+              cy="200"
+              r="8"
+              fill="#fff"
+              stroke="#3E5A77"
+              strokeWidth="1.5"
+            />
+            <circle cx="242" cy="200" r="3.5" fill="#1F3346" />
+            <rect
+              x="220"
+              y="212"
+              width="20"
+              height="3"
+              rx="1.5"
+              fill="#3E5A77"
+            />
+          </g>
+          <g ref={upperLRef} data-robot-part="upper-left-arm">
+            <rect
+              x="262"
+              y="230"
+              width="16"
+              height="46"
+              rx="8"
+              fill="#6E8FB0"
+              stroke="#3E5A77"
+              strokeWidth="2"
+            />
+            <g ref={foreLRef} data-robot-part="fore-left-arm">
+              <rect
+                x="262"
+                y="276"
+                width="16"
+                height="44"
+                rx="8"
+                fill="#6E8FB0"
+                stroke="#3E5A77"
+                strokeWidth="2"
+              />
+              <circle
+                cx="270"
+                cy="320"
+                r="13"
+                fill="#7E9DBC"
+                stroke="#3E5A77"
+                strokeWidth="2"
+              />
+            </g>
+            <circle
+              cx="270"
+              cy="276"
+              r="9"
+              fill="#6E8FB0"
+              stroke="#3E5A77"
+              strokeWidth="2"
+            />
+          </g>
+        </g>
+
+        <g className="bot-r">
+          <rect x="432" y="300" width="16" height="28" rx="4" fill="#8A4A40" />
+          <rect x="452" y="300" width="16" height="28" rx="4" fill="#8A4A40" />
+          <g ref={bobRRef} className="bob-r">
+            <rect
+              x="482.5"
+              y="230"
+              width="15"
+              height="46"
+              rx="7.5"
+              fill="#C97B6E"
+              stroke="#8A4A40"
+              strokeWidth="2"
+            />
+            <g transform="rotate(-16 490 276)">
+              <rect
+                x="482.5"
+                y="276"
+                width="15"
+                height="44"
+                rx="7.5"
+                fill="#C97B6E"
+                stroke="#8A4A40"
+                strokeWidth="2"
+              />
+              <circle
+                cx="490"
+                cy="320"
+                r="11"
+                fill="#D88E80"
+                stroke="#8A4A40"
+                strokeWidth="2"
+              />
+            </g>
+            <circle
+              cx="490"
+              cy="276"
+              r="8"
+              fill="#C97B6E"
+              stroke="#8A4A40"
+              strokeWidth="2"
+            />
+            <rect
+              x="415"
+              y="222"
+              width="70"
+              height="82"
+              rx="14"
+              fill="#C97B6E"
+              stroke="#8A4A40"
+              strokeWidth="2"
+            />
+            <rect
+              x="435"
+              y="244"
+              width="30"
+              height="26"
+              rx="4"
+              fill="#8A4A40"
+            />
+            <circle cx="443" cy="257" r="2.5" fill="#7ECBC4" />
+            <circle cx="457" cy="257" r="2.5" fill="#E8A23D" />
+            <rect
+              x="422"
+              y="178"
+              width="56"
+              height="44"
+              rx="12"
+              fill="#D88E80"
+              stroke="#8A4A40"
+              strokeWidth="2"
+            />
+            <line
+              x1="450"
+              y1="178"
+              x2="450"
+              y2="162"
+              stroke="#8A4A40"
+              strokeWidth="3"
+            />
+            <circle cx="450" cy="158" r="5" fill="#7ECBC4" />
+            <circle
+              cx="438"
+              cy="200"
+              r="8"
+              fill="#fff"
+              stroke="#8A4A40"
+              strokeWidth="1.5"
+            />
+            <circle cx="438" cy="200" r="3.5" fill="#4A211C" />
+            <circle
+              cx="462"
+              cy="200"
+              r="8"
+              fill="#fff"
+              stroke="#8A4A40"
+              strokeWidth="1.5"
+            />
+            <circle cx="462" cy="200" r="3.5" fill="#4A211C" />
+            <rect
+              x="440"
+              y="212"
+              width="20"
+              height="3"
+              rx="1.5"
+              fill="#8A4A40"
+            />
+          </g>
+          <g ref={upperRRef} data-robot-part="upper-right-arm">
+            <rect
+              x="402"
+              y="230"
+              width="16"
+              height="46"
+              rx="8"
+              fill="#C97B6E"
+              stroke="#8A4A40"
+              strokeWidth="2"
+            />
+            <g ref={foreRRef} data-robot-part="fore-right-arm">
+              <rect
+                x="402"
+                y="276"
+                width="16"
+                height="44"
+                rx="8"
+                fill="#C97B6E"
+                stroke="#8A4A40"
+                strokeWidth="2"
+              />
+              <circle
+                cx="410"
+                cy="320"
+                r="13"
+                fill="#D88E80"
+                stroke="#8A4A40"
+                strokeWidth="2"
+              />
+            </g>
+            <circle
+              cx="410"
+              cy="276"
+              r="9"
+              fill="#C97B6E"
+              stroke="#8A4A40"
+              strokeWidth="2"
+            />
+          </g>
+        </g>
+
+        <g ref={flashRef} className="flash">
+          <g stroke="#E8A23D" strokeWidth="3" strokeLinecap="round">
+            <line x1="340" y1="133" x2="340" y2="119" />
+            <line x1="340" y1="197" x2="340" y2="211" />
+            <line x1="308" y1="165" x2="294" y2="165" />
+            <line x1="372" y1="165" x2="386" y2="165" />
+            <line x1="318" y1="143" x2="308" y2="133" />
+            <line x1="362" y1="143" x2="372" y2="133" />
+            <line x1="318" y1="187" x2="308" y2="197" />
+            <line x1="362" y1="187" x2="372" y2="197" />
+          </g>
+          <circle cx="302" cy="147" r="3" fill="#7ECBC4" />
+          <circle cx="378" cy="183" r="3" fill="#7ECBC4" />
+          <circle cx="380" cy="145" r="2.5" fill="#E8A23D" />
+          <circle cx="300" cy="185" r="2.5" fill="#E8A23D" />
+        </g>
+      </svg>
+    </button>
+  );
+}

--- a/packages/app/src/components/ui/popover.tsx
+++ b/packages/app/src/components/ui/popover.tsx
@@ -35,13 +35,13 @@ function PopoverContent({
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(
-            "z-50 w-80 max-w-[calc(100vw-1.5rem)] origin-(--transform-origin) rounded-lg border border-[#DCD6CC] dark:border-slate-700 bg-[#FFFDFC] dark:bg-slate-900 p-4 text-sm text-stone-800 dark:text-slate-200 shadow-[0_16px_44px_rgba(57,47,38,0.18)] dark:shadow-[0_16px_44px_rgba(0,0,0,0.45)] outline-none data-[ending-style]:animate-out data-[ending-style]:fade-out-0 data-[ending-style]:zoom-out-95 data-[starting-style]:animate-in data-[starting-style]:fade-in-0 data-[starting-style]:zoom-in-95",
+            "z-50 w-80 max-w-[calc(100vw-1.5rem)] origin-(--transform-origin) rounded-lg border border-[#DCD6CC] dark:border-slate-700 bg-[#FFFDFC] dark:bg-slate-900 p-4 text-sm text-stone-800 dark:text-slate-200 shadow-[0_16px_44px_rgba(57,47,38,0.18)] dark:shadow-[0_16px_44px_rgba(0,0,0,0.45)] outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[ending-style]:animate-out data-[ending-style]:fade-out-0 data-[ending-style]:zoom-out-95 data-[starting-style]:animate-in data-[starting-style]:fade-in-0 data-[starting-style]:zoom-in-95",
             className,
           )}
           {...props}
         >
           {children}
-          <PopoverPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-1px)] rotate-45 rounded-[2px] border-t border-l border-[#DCD6CC] dark:border-slate-700 bg-[#FFFDFC] dark:bg-slate-900 data-[side=bottom]:top-1 data-[side=top]:-bottom-2.5" />
+          <PopoverPrimitive.Arrow className="z-50 size-2.5 rotate-45 rounded-[2px] border-t border-l border-[#DCD6CC] dark:border-slate-700 bg-[#FFFDFC] dark:bg-slate-900 data-[side=bottom]:top-0 data-[side=bottom]:-translate-y-1/2 data-[side=top]:bottom-0 data-[side=top]:translate-y-1/2" />
         </PopoverPrimitive.Popup>
       </PopoverPrimitive.Positioner>
     </PopoverPrimitive.Portal>

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -757,7 +757,7 @@
   .review-layout-grid {
     display: grid;
     /* comments present: document on the left, fixed-width rail on the right */
-    --review-rail-width: 24rem;
+    --review-rail-width: 18rem;
     grid-template-columns: minmax(0, 46.5rem) var(--review-rail-width);
     justify-content: center;
     align-items: start;

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -73,6 +73,20 @@
 }
 
 @layer components {
+  .review-handoff-robots .flash {
+    transform-origin: 340px 165px;
+    opacity: 0;
+  }
+
+  .review-handoff-robots .flash.pop {
+    animation: review-handoff-robots-pop 450ms ease-out;
+  }
+
+  .review-handoff-robots .bob-l.hop,
+  .review-handoff-robots .bob-r.hop {
+    animation: review-handoff-robots-hop 400ms ease-out;
+  }
+
   .tiptap {
     @apply min-h-[120px] text-slate-800 dark:text-slate-200 outline-none;
     --editor-font-size: 16px;
@@ -593,6 +607,31 @@
   .rfm-result-editor .tiptap h3 {
     margin-top: 1em;
     font-size: 1.12em;
+  }
+}
+
+@keyframes review-handoff-robots-pop {
+  0% {
+    opacity: 0;
+    transform: scale(0.3);
+  }
+  35% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.6);
+  }
+}
+
+@keyframes review-handoff-robots-hop {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  45% {
+    transform: translateY(-7px);
   }
 }
 

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -1784,6 +1784,31 @@ describe("PageCard editor integration", () => {
     ).not.toBeNull();
   });
 
+  it("truncates long suggestion summaries in the review rail", async () => {
+    const longInsertedText =
+      "I do really like typing this way. It feels natural. It's a great way to collaborate with AI. What happens if this goes on super long. Will it just keep going? This is too much.";
+    const expectedPreview = `${longInsertedText.slice(0, 140)}...`;
+
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-long-suggestion-summary-1",
+        title: "Doc Long Suggestion Summary 1",
+        content: `This sentence includes {++${longInsertedText}++}{id="s1" by="AI" at="2026-04-25T23:55:00.000Z"}`,
+      },
+      selected: true,
+    });
+
+    await flushAnimationFrame();
+
+    const suggestionThread = rendered.container.querySelector<HTMLElement>(
+      '[data-suggestion-thread-container="true"]',
+    );
+    const suggestionText = suggestionThread?.textContent ?? "";
+
+    expect(suggestionText).toContain(`Insert: "${expectedPreview}"`);
+    expect(suggestionText).not.toContain(`Insert: "${longInsertedText}"`);
+  });
+
   it("saving a reply to a YAML endmatter-backed suggestion preserves split endmatter", async () => {
     const rendered = await renderPageCard({
       page: {

--- a/packages/app/test/view-toggle-bugs.test.tsx
+++ b/packages/app/test/view-toggle-bugs.test.tsx
@@ -9,7 +9,9 @@ import {
 import {
   DocumentSaveStatusIndicator,
   DocumentWorkspace,
+  getReviewHandoffButtonLabel,
   isReviewHandoffDisabled,
+  shouldLatchDocumentChangedSinceOpen,
 } from "../src/DocumentWorkspace";
 import type { DocumentSaveState } from "../src/PageCard";
 import type {
@@ -361,39 +363,43 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     expect(getByTestId(status, "document-save-status-icon")).not.toBeNull();
   });
 
-  it("renders save status next to the filename when handoff exists", async () => {
+  it("renders save status in the fixed corner when handoff exists", async () => {
     await renderWorkspace({ watcherCount: 1 });
 
     const stack = queryByTestId(container, "document-status-stack");
     const header = getByTestId(container, "document-page-header");
+    const corner = getByTestId(container, "document-save-status-corner");
     const doneReviewingButton = queryByTestId(
       container,
       "review-handoff-button",
     );
     expect(stack).not.toBeNull();
     expect(doneReviewingButton).toBeDefined();
-    expect(doneReviewingButton?.textContent).toContain("I'm done");
+    expect(doneReviewingButton?.textContent).toContain("Approve");
     expect(doneReviewingButton?.textContent).not.toContain("Saved");
     expect(stack?.textContent).not.toContain("Saved");
     expect(header.textContent).toContain("test.md");
     expect(header.textContent).not.toContain("Saved");
+    expect(queryByTestId(header, "document-save-status")).toBeNull();
     expect(
-      getByTestId(header, "document-save-status").getAttribute("aria-label"),
+      getByTestId(corner, "document-save-status").getAttribute("aria-label"),
     ).toBe("Saved");
   });
 
-  it("renders save status next to the filename without handoff", async () => {
+  it("renders save status in the fixed corner without handoff", async () => {
     await renderWorkspace();
 
     const stack = queryByTestId(container, "document-status-stack");
     const header = getByTestId(container, "document-page-header");
+    const corner = getByTestId(container, "document-save-status-corner");
     expect(stack).not.toBeNull();
     expect(stack?.textContent).not.toContain("I'm done");
     expect(stack?.textContent).not.toContain("Saved");
     expect(header.textContent).toContain("test.md");
     expect(header.textContent).not.toContain("Saved");
+    expect(queryByTestId(header, "document-save-status")).toBeNull();
     expect(
-      getByTestId(header, "document-save-status").getAttribute("aria-label"),
+      getByTestId(corner, "document-save-status").getAttribute("aria-label"),
     ).toBe("Saved");
   });
 
@@ -545,6 +551,36 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
       }),
     ).toBe(false);
   });
+
+  it("uses approve copy until the user has changed the document", () => {
+    expect(
+      getReviewHandoffButtonLabel({
+        reviewHandoffState: "idle",
+        documentChangedSinceOpen: false,
+      }),
+    ).toBe("Approve");
+    expect(
+      getReviewHandoffButtonLabel({
+        reviewHandoffState: "idle",
+        documentChangedSinceOpen: true,
+      }),
+    ).toBe("I'm done");
+  });
+
+  it("ignores initial editor dirty signals before user input is possible", () => {
+    expect(
+      shouldLatchDocumentChangedSinceOpen({
+        isDirty: true,
+        documentChangeTrackingReady: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldLatchDocumentChangedSinceOpen({
+        isDirty: true,
+        documentChangeTrackingReady: true,
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("interaction mode preserved across view toggle (issue 3 fix)", () => {
@@ -600,18 +636,18 @@ describe("interaction mode preserved across view toggle (issue 3 fix)", () => {
       });
     };
 
-    // Mount with rich-text -> mode is "Editing" by default
+    // Mount with rich-text -> mode is "Suggesting" by default
     await renderWorkspace("rich-text");
     expect(
       getByTestId(container, "document-mode-trigger").textContent,
-    ).toContain("Editing");
+    ).toContain("Suggesting");
 
     // Rerender with code view (same component instance, no remount) ->
-    // mode stays "Editing" because the component is not destroyed.
+    // mode stays "Suggesting" because the component is not destroyed.
     await renderWorkspace("code");
     expect(
       getByTestId(container, "document-mode-trigger").textContent,
-    ).toContain("Editing");
+    ).toContain("Suggesting");
   });
 });
 
@@ -678,6 +714,7 @@ describe("review handoff watcher affordance", () => {
 
     await renderWorkspace({ getWatcherCount: () => 0, onCompleteReview });
 
+    expect(container.textContent).not.toContain("Approve");
     expect(container.textContent).not.toContain("I'm done");
     expect(container.textContent).not.toContain("Review ready");
     expect(container.textContent).not.toContain("Copy prompt");
@@ -696,6 +733,7 @@ describe("review handoff watcher affordance", () => {
       "review-handoff-button",
     );
     expect(doneReviewingButton).toBeDefined();
+    expect(doneReviewingButton?.textContent).toContain("Approve");
     expect(container.textContent).not.toContain("Agent waiting");
     expect(queryByTestId(container, "review-handoff-status")).toBeNull();
 
@@ -731,6 +769,7 @@ describe("review handoff watcher affordance", () => {
 
     expect(onCompleteReview).toHaveBeenCalledOnce();
     expect(container.textContent).toContain("Not sent");
+    expect(container.textContent).not.toContain("Approve");
     expect(container.textContent).not.toContain("I'm done");
   });
 
@@ -852,6 +891,7 @@ describe("review handoff watcher affordance", () => {
     expect(onCompleteReview).toHaveBeenCalledOnce();
     expect(container.textContent).toContain("Sent");
     expect(container.textContent).not.toContain("Agent notified");
+    expect(container.textContent).not.toContain("Approve");
     expect(container.textContent).not.toContain("I'm done");
   });
 
@@ -884,6 +924,7 @@ describe("review handoff watcher affordance", () => {
     });
 
     expect(container.textContent).toContain("Sent");
+    expect(container.textContent).not.toContain("Approve");
     expect(container.textContent).not.toContain("I'm done");
 
     watcherCount = 1;
@@ -895,7 +936,7 @@ describe("review handoff watcher affordance", () => {
       await Promise.resolve();
     });
 
-    expect(container.textContent).toContain("I'm done");
+    expect(container.textContent).toContain("Approve");
     expect(container.textContent).not.toContain("Sent");
   });
 });

--- a/packages/app/test/view-toggle-bugs.test.tsx
+++ b/packages/app/test/view-toggle-bugs.test.tsx
@@ -265,6 +265,7 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     });
     container.remove();
     Reflect.deleteProperty(globalThis, "ClipboardItem");
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -419,6 +420,51 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     await click(getByTestId(document.body, `document-file-menu-${action}`));
 
     expect(writeText).toHaveBeenCalledWith(text);
+  });
+
+  it("keeps the file menu open and shows temporary copied feedback", async () => {
+    vi.useFakeTimers();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    await renderWorkspace({ documentContent: "# Heading\n\nBody" });
+    await openFileMenu();
+    await click(getByTestId(document.body, "document-file-menu-path"));
+
+    const menu = getByTestId(document.body, "document-file-menu");
+    expect(menu.textContent).toContain("Copied!");
+    expect(menu.textContent).not.toContain("Copy:");
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      await Promise.resolve();
+    });
+
+    expect(getByTestId(document.body, "document-file-menu").textContent).toContain(
+      "Path",
+    );
+    vi.useRealTimers();
+  });
+
+  it("shows copy previews below each file menu action", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+
+    await renderWorkspace({ documentContent: "# Heading\n\nBody" });
+    await openFileMenu();
+
+    const menu = getByTestId(document.body, "document-file-menu");
+    expect(menu.textContent).toContain("Path");
+    expect(menu.textContent).toContain("test.md");
+    expect(menu.textContent).toContain("Filename");
+    expect(menu.textContent).toContain("Markdown");
+    expect(menu.textContent).toContain("# Heading Body");
+    expect(menu.textContent).toContain("Rich text");
   });
 
   it("copies document rich text with html and plain markdown flavors", async () => {

--- a/packages/app/test/view-toggle-bugs.test.tsx
+++ b/packages/app/test/view-toggle-bugs.test.tsx
@@ -290,11 +290,13 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
   async function renderWorkspace({
     documentDiskChangeState = "clean",
     documentContent = "Hello world",
+    documentCopyPath = "test.md",
     watcherCount = 0,
     onSaveDocument = async () => {},
   }: {
     documentDiskChangeState?: "clean" | "changed" | "conflict" | "paused";
     documentContent?: string;
+    documentCopyPath?: string | null;
     watcherCount?: number;
     onSaveDocument?: (id: string, content: string) => Promise<void>;
   } = {}) {
@@ -307,6 +309,7 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
         <DocumentWorkspace
           documentPage={createPage(documentContent)}
           activeDocumentPath="test.md"
+          documentCopyPath={documentCopyPath}
           documentFilenameLabel="test.md"
           documentEditorViewMode="rich-text"
           onDocumentEditorViewModeChange={() => {}}
@@ -405,7 +408,7 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
   });
 
   it.each([
-    ["path", "test.md"],
+    ["path", "/Users/me/project/test.md"],
     ["filename", "test.md"],
     ["markdown", "# Heading\n\nBody"],
   ] as const)("copies document %s from the file menu", async (action, text) => {
@@ -415,7 +418,10 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
       value: { writeText },
     });
 
-    await renderWorkspace({ documentContent: "# Heading\n\nBody" });
+    await renderWorkspace({
+      documentContent: "# Heading\n\nBody",
+      documentCopyPath: "/Users/me/project/test.md",
+    });
     await openFileMenu();
     await click(getByTestId(document.body, `document-file-menu-${action}`));
 
@@ -465,6 +471,12 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     expect(menu.textContent).toContain("Markdown");
     expect(menu.textContent).toContain("# Heading Body");
     expect(menu.textContent).toContain("Rich text");
+    const richTextAction = getByTestId(
+      document.body,
+      "document-file-menu-rich-text",
+    );
+    expect(richTextAction.textContent).toContain("Heading Body");
+    expect(richTextAction.textContent).not.toContain("# Heading");
   });
 
   it("copies document rich text with html and plain markdown flavors", async () => {
@@ -496,9 +508,59 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
       "text/html": expect.any(Blob),
       "text/plain": expect.any(Blob),
     });
+    await expect(clipboardItems[0]["text/html"].text()).resolves.toContain(
+      "<h1>Heading</h1>",
+    );
+    await expect(clipboardItems[0]["text/plain"].text()).resolves.toBe(
+      "Heading\nBody",
+    );
     expect(write).toHaveBeenCalledWith([
       expect.objectContaining({ items: expect.any(Object) }),
     ]);
+  });
+
+  it("strips comments and suggestions from copied rich text", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const clipboardItems: Array<Record<string, Blob>> = [];
+    class ClipboardItemMock {
+      items: Record<string, Blob>;
+
+      constructor(items: Record<string, Blob>) {
+        this.items = items;
+        clipboardItems.push(items);
+      }
+    }
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { write },
+    });
+    Object.defineProperty(globalThis, "ClipboardItem", {
+      configurable: true,
+      value: ClipboardItemMock,
+    });
+
+    await renderWorkspace({
+      documentContent:
+        "Keep {==the launch date==}{>>Verify this.<<}{#c1}, omit {++new claim++}{#s1}, keep {--old claim--}{#s2}, and use {~~rough~>polished~~}{#s3} wording.\n\n{>>Standalone note<<}{#c2}\n\n---\ncomments:\n  c1:\n    by: user\n    at: \"2026-04-28T12:00:00.000Z\"\n  c2:\n    by: user\n    at: \"2026-04-28T12:01:00.000Z\"\nsuggestions:\n  s1:\n    by: AI\n    at: \"2026-04-28T12:02:00.000Z\"\n  s2:\n    by: AI\n    at: \"2026-04-28T12:03:00.000Z\"\n  s3:\n    by: AI\n    at: \"2026-04-28T12:04:00.000Z\"\n",
+    });
+    await openFileMenu();
+    await click(getByTestId(document.body, "document-file-menu-rich-text"));
+
+    const html = await clipboardItems[0]["text/html"].text();
+    const plain = await clipboardItems[0]["text/plain"].text();
+
+    expect(html).toContain("Keep the launch date");
+    expect(html).toContain("old claim");
+    expect(html).toContain("rough");
+    expect(html).not.toContain("Verify this");
+    expect(html).not.toContain("Standalone note");
+    expect(html).not.toContain("new claim");
+    expect(html).not.toContain("polished");
+    expect(html).not.toContain("data-comment-ids");
+    expect(html).not.toContain("data-critic-change-kind");
+    expect(plain).toBe(
+      "Keep the launch date, omit , keep old claim, and use rough wording.",
+    );
   });
 
   it.each([

--- a/packages/app/test/view-toggle-bugs.test.tsx
+++ b/packages/app/test/view-toggle-bugs.test.tsx
@@ -449,9 +449,9 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
       await Promise.resolve();
     });
 
-    expect(getByTestId(document.body, "document-file-menu").textContent).toContain(
-      "Path",
-    );
+    expect(
+      getByTestId(document.body, "document-file-menu").textContent,
+    ).toContain("Path");
     vi.useRealTimers();
   });
 
@@ -541,7 +541,7 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
 
     await renderWorkspace({
       documentContent:
-        "Keep {==the launch date==}{>>Verify this.<<}{#c1}, omit {++new claim++}{#s1}, keep {--old claim--}{#s2}, and use {~~rough~>polished~~}{#s3} wording.\n\n{>>Standalone note<<}{#c2}\n\n---\ncomments:\n  c1:\n    by: user\n    at: \"2026-04-28T12:00:00.000Z\"\n  c2:\n    by: user\n    at: \"2026-04-28T12:01:00.000Z\"\nsuggestions:\n  s1:\n    by: AI\n    at: \"2026-04-28T12:02:00.000Z\"\n  s2:\n    by: AI\n    at: \"2026-04-28T12:03:00.000Z\"\n  s3:\n    by: AI\n    at: \"2026-04-28T12:04:00.000Z\"\n",
+        'Keep {==the launch date==}{>>Verify this.<<}{#c1}, omit {++new claim++}{#s1}, keep {--old claim--}{#s2}, and use {~~rough~>polished~~}{#s3} wording.\n\n{>>Standalone note<<}{#c2}\n\n---\ncomments:\n  c1:\n    by: user\n    at: "2026-04-28T12:00:00.000Z"\n  c2:\n    by: user\n    at: "2026-04-28T12:01:00.000Z"\nsuggestions:\n  s1:\n    by: AI\n    at: "2026-04-28T12:02:00.000Z"\n  s2:\n    by: AI\n    at: "2026-04-28T12:03:00.000Z"\n  s3:\n    by: AI\n    at: "2026-04-28T12:04:00.000Z"\n',
     });
     await openFileMenu();
     await click(getByTestId(document.body, "document-file-menu-rich-text"));
@@ -778,7 +778,9 @@ describe("review handoff watcher affordance", () => {
       root.unmount();
     });
     container.remove();
+    document.body.replaceChildren();
     vi.restoreAllMocks();
+    window.history.replaceState(null, "", "/");
   });
 
   async function renderWorkspace({
@@ -857,6 +859,36 @@ describe("review handoff watcher affordance", () => {
     expect(container.textContent).not.toContain("Agent notified");
     expect(container.textContent).not.toContain("Review ready");
     expect(container.textContent).not.toContain("Copy prompt");
+  });
+
+  it("fades the whole handoff split button after sending", async () => {
+    const onCompleteReview = vi
+      .fn<() => Promise<CompleteReviewResult>>()
+      .mockResolvedValue({ delivered: true });
+
+    await renderWorkspace({ getWatcherCount: () => 1, onCompleteReview });
+
+    const splitButton = queryByTestId<HTMLDivElement>(
+      container,
+      "review-handoff-split-button",
+    );
+    const doneReviewingButton = queryByTestId<HTMLButtonElement>(
+      container,
+      "review-handoff-button",
+    );
+    const commentTrigger = queryByTestId<HTMLButtonElement>(
+      container,
+      "review-handoff-comment-trigger",
+    );
+    if (!splitButton || !doneReviewingButton || !commentTrigger) {
+      throw new Error("Review handoff split button not found");
+    }
+
+    await click(doneReviewingButton);
+
+    expect(splitButton.className).toContain("opacity-50");
+    expect(doneReviewingButton.className).toContain("disabled:opacity-100");
+    expect(commentTrigger.className).toContain("disabled:opacity-100");
   });
 
   it("shows visible feedback when the watcher disappears before handoff delivery", async () => {
@@ -1046,5 +1078,93 @@ describe("review handoff watcher affordance", () => {
 
     expect(container.textContent).toContain("Approve");
     expect(container.textContent).not.toContain("Sent");
+  });
+
+  it("reopens the sent popover from the muted primary button", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const writeText = vi.fn<Clipboard["writeText"]>().mockResolvedValue();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const closeWindow = vi.spyOn(window, "close").mockImplementation(() => {});
+    let watcherCount = 1;
+    const onCompleteReview = vi
+      .fn<() => Promise<CompleteReviewResult>>()
+      .mockImplementation(async () => {
+        watcherCount = 0;
+        return { delivered: true };
+      });
+
+    await renderWorkspace({
+      getWatcherCount: () => watcherCount,
+      onCompleteReview,
+    });
+
+    const doneReviewingButton = getByTestId<HTMLButtonElement>(
+      container,
+      "review-handoff-button",
+    );
+    await click(doneReviewingButton);
+
+    expect(onCompleteReview).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("Sent");
+    expect(document.body.textContent).toContain("Nice one!");
+    expect(document.body.textContent).toContain(
+      "Your agent is now working in the background on this, in all likelihood. If our signal didn't make it, just click here to copy a line you can send it to keep going.",
+    );
+    expect(queryByTestId(document.body, "review-handoff-status")).toBeDefined();
+    expect(
+      getByTestId(document.body, "review-handoff-status").querySelector(
+        ".h-\\[170px\\]",
+      ),
+    ).not.toBeNull();
+    expect(
+      queryByTestId(document.body, "review-handoff-robots-toy"),
+    ).toBeDefined();
+
+    await act(async () => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(queryByTestId(document.body, "review-handoff-status")).toBeNull();
+
+    const sentButton = getByTestId<HTMLButtonElement>(
+      container,
+      "review-handoff-button",
+    );
+    expect(sentButton.disabled).toBe(false);
+
+    await click(sentButton);
+
+    expect(onCompleteReview).toHaveBeenCalledTimes(1);
+    expect(queryByTestId(document.body, "review-handoff-status")).toBeDefined();
+
+    const toy = getByTestId(document.body, "review-handoff-robots-toy");
+    await click(toy);
+
+    expect(document.body.textContent).toContain("Great work!");
+
+    const copyLink = queryByTestId<HTMLButtonElement>(
+      document.body,
+      "review-handoff-copy-message",
+    );
+    expect(copyLink).toBeDefined();
+    if (!copyLink) {
+      throw new Error("Review handoff fallback copy link not found");
+    }
+
+    await click(copyLink);
+
+    expect(writeText).toHaveBeenCalledWith(
+      "I am done reviewing this file: test.md",
+    );
+
+    await click(getByTestId(document.body, "review-handoff-close-window"));
+
+    expect(closeWindow).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

This PR improves the document header affordances around saving, copying, and review handoff completion. It moves the save status into a fixed corner, adds a richer document copy menu with clean rich-text clipboard output, and makes unchanged documents use an `Approve` handoff label while changed documents still use `I'm done`. It also polishes the sent handoff popover with a completion title, robot high-five toy, fallback copy action, close-window action, and lets the muted `Sent` button reopen the popover without resubmitting. Tests cover the copy/menu behavior, handoff state transitions, sent-popover reopening, and screenshot guide expectations.

## Validation

- `pnpm check`
- `pnpm test:smoke`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI and clipboard/handoff UX; handoff still saves before notify, with broad test coverage for copy stripping and state transitions.
> 
> **Overview**
> Refines the document workspace around **save status**, **copy**, and **review handoff** completion.
> 
> **Save status** moves to a fixed top-left corner (`document-save-status-corner`) instead of sitting beside the filename. The screenshot guide reflects that placement.
> 
> **File copy menu** gains preview snippets per action, a longer “Copied!” state, and **rich-text copy** that strips critic markup (comments, additions, etc.) while producing cleaned HTML and plain text. `documentCopyPath` is wired from `App` so “Copy path” uses the absolute file path.
> 
> **Review handoff** shows **Approve** when the document is unchanged since open and **I'm done** after real edits (with a short grace period so initial dirty signals don’t flip the label). The success popover uses a random celebratory title, **`RobotsHighFiveToy`**, fallback “copy a line for your agent” text, and **Close window**; the muted **Sent** primary button reopens the popover without resubmitting. Default interaction mode is now **Suggesting**.
> 
> Smaller polish: tighter comment-thread layout in the rail, truncated long suggestion quotes in the review rail, narrower review rail width, popover open animation, plus unit/e2e tests and screenshot-guide updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14a5ebea34d423704a145976d7efdd4c7909da2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->