### PR TITLE
Fix: roughdraft open/watch crashes on undici idle headers timeout before Done Reviewing

### DIFF
--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -2133,27 +2133,76 @@ async function runWatch(
     body.timeoutSeconds = options.timeoutSeconds;
   }
 
-  const response = await deps.fetchImpl(
-    new URL("/api/review-events/watch", serverUrl),
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-      ...(options.timeoutSeconds !== undefined
-        ? { signal: AbortSignal.timeout((options.timeoutSeconds + 5) * 1000) }
-        : {}),
-    },
-  );
+  // Idle-timeout error codes from undici (Node's built-in fetch) that fire
+  // when the server holds a long-poll connection open longer than undici's
+  // default headersTimeout / bodyTimeout (~5 min). These are transient — the
+  // server is still alive and the session is still valid — so we re-poll
+  // instead of letting the unhandled rejection crash the CLI process.
+  const IDLE_TIMEOUT_CODES = new Set([
+    "UND_ERR_HEADERS_TIMEOUT",
+    "UND_ERR_BODY_TIMEOUT",
+    "UND_ERR_SOCKET",
+    "ECONNRESET",
+    "UND_ERR_CONNECT_TIMEOUT",
+  ]);
 
-  if (!response.ok) {
-    throw new Error(`Failed to watch review events: ${response.status}`);
-  }
+  const doWatch = async () => {
+    const response = await deps.fetchImpl(
+      new URL("/api/review-events/watch", serverUrl),
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        ...(options.timeoutSeconds !== undefined
+          ? {
+              signal: AbortSignal.timeout((options.timeoutSeconds + 5) * 1000),
+            }
+          : {}),
+      },
+    );
+    if (!response.ok) {
+      throw new Error(`Failed to watch review events: ${response.status}`);
+    }
+    return response.json() as Promise<{
+      events?: unknown[];
+      timedOut?: boolean;
+      nextSequence?: number;
+    }>;
+  };
 
-  const payload = (await response.json()) as {
+  let payload: {
     events?: unknown[];
     timedOut?: boolean;
     nextSequence?: number;
   };
+
+  if (options.timeoutSeconds !== undefined) {
+    // Explicit timeout: a single attempt is correct; AbortSignal.timeout
+    // already guards the wall-clock budget.
+    payload = await doWatch();
+  } else {
+    // No explicit timeout (the normal `roughdraft open` flow): retry on idle
+    // timeout errors so that reviewers who leave the document open longer
+    // than undici's default idle timeout don't crash the CLI before they
+    // click "Done Reviewing".
+    for (;;) {
+      try {
+        payload = await doWatch();
+        break;
+      } catch (err) {
+        const code =
+          (err as { cause?: { code?: string }; code?: string })?.cause?.code ??
+          (err as { code?: string })?.code;
+        if (typeof code === "string" && IDLE_TIMEOUT_CODES.has(code)) {
+          // Replay from session start so a Done event fired during the
+          // reconnect window is not missed.
+          body.fromNow = false;
+          continue;
+        }
+        throw err;
+      }
+    }
+  }
 
   if (json) {
     emitJson(deps.log, payload);


### PR DESCRIPTION
## Problem

`roughdraft open <file>` (and `roughdraft watch`) crashes with an unhandled `TypeError: fetch failed` / `HeadersTimeoutError` (`UND_ERR_HEADERS_TIMEOUT`) whenever the reviewer leaves the document open longer than undici's default idle headers timeout (~5 minutes) before clicking **Done Reviewing**. Because the CLI process dies on that rejection, the Done Reviewing signal is never delivered to the caller.

Stack trace points to `runWatch` in `packages/server/src/cli.ts`.

## Root cause

In `runWatch`, the long-poll request to `POST /api/review-events/watch` only attaches an `AbortSignal.timeout(...)` when `options.timeoutSeconds` is set (i.e. when `--timeout` is passed). In the **default case** (no explicit timeout — the normal `roughdraft open` flow) there is no signal, so undici's global dispatcher fires its internal `headersTimeout` / `bodyTimeout` (~5 min) while the server is legitimately holding the connection open waiting for the human reviewer. The resulting unhandled rejection kills the CLI process before Done Reviewing is ever received.

## Fix

Extract the fetch into a `doWatch` helper and wrap it in a retry loop used only when no explicit `--timeout` is set:

- On recognised idle-timeout error codes (`UND_ERR_HEADERS_TIMEOUT`, `UND_ERR_BODY_TIMEOUT`, `UND_ERR_SOCKET`, `ECONNRESET`, `UND_ERR_CONNECT_TIMEOUT`) the loop sets `body.fromNow = false` and re-polls, replaying from session start so a Done event fired during the reconnect gap is not missed.
- All other errors are re-thrown unchanged.
- When `--timeout` is supplied the existing single-shot path (already guarded by `AbortSignal.timeout`) is used without modification.

## How to reproduce

```bash
roughdraft open ./draft.md   # open a file, then wait ~5 minutes without clicking Done Reviewing
# CLI exits with: TypeError: fetch failed (UND_ERR_HEADERS_TIMEOUT)
# "Done Reviewing" is never delivered
```

## Changes

- `packages/server/src/cli.ts` — `runWatch`: wrapped the watch fetch in a `doWatch` helper with a retry loop for idle-timeout errors in the no-explicit-timeout path.

## Checklist

- [x] TypeScript source updated (not just compiled dist)
- [x] `pnpm build` passes
- [x] `pnpm lint` passes (biome, no issues)
- [x] `pnpm --filter @roughdraft/server test` passes (120 tests)
- [x] `pnpm --filter @roughdraft/rfm test` passes (29 tests)

---

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)