### PR TITLE
Refine homepage design

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -400,7 +400,7 @@ export function Homepage({
         </div>
       ) : null}
       <div className="w-full">
-        <div className="font-die-grotesk-a mx-auto max-w-[100rem] text-left">
+        <div className="font-die-grotesk-a mx-auto max-w-[1500px] text-left">
           <p
             className="text-[clamp(1.125rem,0.9rem+0.35vw,1.375rem)] font-bold text-stone-500 dark:text-stone-500"
             data-testid="homepage-logo"
@@ -416,7 +416,7 @@ export function Homepage({
               <br data-testid="homepage-heading-break" />
               with your agent
             </h1>
-            <p className="mt-5 max-w-5xl text-[clamp(1.25rem,0.9rem+1vw,1.75rem)] leading-none text-slate-950 dark:text-slate-50">
+            <p className="mt-7 max-w-5xl font-sans text-[clamp(1.125rem,0.85rem+0.8vw,1.5rem)] leading-none font-medium text-slate-950 dark:text-slate-50">
               {message}
             </p>
 
@@ -494,7 +494,7 @@ export function Homepage({
           </div>
         </div>
 
-        <div className="mt-10 w-screen max-w-none -translate-x-6 overflow-hidden border-y border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-[0_20px_60px_rgba(15,23,42,0.12)] dark:shadow-[0_20px_60px_rgba(0,0,0,0.4)] min-[1000px]:mx-auto min-[1000px]:w-full min-[1000px]:max-w-[100rem] min-[1000px]:translate-x-0 min-[1000px]:rounded-lg min-[1000px]:border">
+        <div className="mt-10 w-screen max-w-none -translate-x-6 overflow-hidden border-y border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-[0_20px_60px_rgba(15,23,42,0.12)] dark:shadow-[0_20px_60px_rgba(0,0,0,0.4)] min-[1000px]:mx-auto min-[1000px]:w-full min-[1000px]:max-w-[1500px] min-[1000px]:translate-x-0 min-[1000px]:rounded-lg min-[1000px]:border">
           <img
             data-testid="homepage-sneak-peek-image"
             src="/sneak-peek.png"

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -588,7 +588,7 @@ function HomepageWorkflowScene({
         <h3 className="font-die-grotesk-b mt-5 text-[clamp(2rem,1.5rem+1.5vw,2.5rem)] leading-tight font-bold text-balance text-slate-950 dark:text-slate-50">
           {title}
         </h3>
-        <p className="mt-4 max-w-md text-base leading-7 text-stone-600 dark:text-stone-400">
+        <p className="mt-4 max-w-md font-sans text-[clamp(1rem,0.95rem+0.25vw,1.125rem)] leading-7 font-medium text-slate-950 dark:text-slate-50">
           {description}
         </p>
       </div>

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -409,7 +409,7 @@ export function Homepage({
           </p>
           <div className="mt-20 sm:mt-28">
             <h1
-              className="font-die-grotesk-b text-[clamp(2.875rem,14.2vw,5rem)] leading-[0.88] font-bold text-slate-950 dark:text-slate-50"
+              className="font-die-grotesk-b text-[clamp(2.875rem,14.2vw,5rem)] leading-[0.88] font-bold tracking-[-0.02em] text-slate-950 dark:text-slate-50"
               data-testid="homepage-heading"
             >
               Easier collaboration
@@ -624,12 +624,12 @@ function AgentChatMock({
 
   return (
     <div
-      className="homepage-workflow-terminal w-full overflow-hidden rounded-lg border border-slate-950/70 bg-[#1F232B] font-mono text-slate-50 shadow-[0_20px_48px_rgba(15,23,42,0.16)] max-[899px]:h-full max-[899px]:border-slate-950/60 dark:shadow-[0_18px_44px_rgba(0,0,0,0.35)]"
+      className="homepage-workflow-terminal w-full overflow-hidden rounded-xl border border-slate-950/70 bg-[#1F232B] font-mono text-slate-50 shadow-[0_20px_48px_rgba(15,23,42,0.16)] max-[899px]:h-full max-[899px]:border-slate-950/60 dark:shadow-[0_18px_44px_rgba(0,0,0,0.35)]"
       data-homepage-workflow-terminal-stage={workflowStage}
       data-testid="homepage-workflow-terminal"
       ref={terminalRef}
     >
-      <div className="flex min-h-10 items-center justify-between gap-4 border-b border-slate-400/20 px-3.5 text-xs font-bold text-slate-300 max-[899px]:min-h-8 max-[899px]:px-3 max-[899px]:text-[0.68rem]">
+      <div className="flex min-h-8 items-center justify-between gap-3 border-b border-slate-400/20 px-3 text-xs font-bold text-slate-300 max-[899px]:min-h-7 max-[899px]:px-2.5 max-[899px]:text-[0.68rem]">
         <div className="flex items-center gap-1.5" aria-hidden="true">
           <span className="inline-flex size-[0.65rem] rounded-full bg-rose-500" />
           <span className="inline-flex size-[0.65rem] rounded-full bg-amber-400" />
@@ -919,13 +919,13 @@ function RoughdraftPopupMock({ workflowStage }: { workflowStage: number }) {
   return (
     <div
       aria-hidden={visible ? undefined : true}
-      className="absolute right-[calc(-1*var(--homepage-workflow-popup-overhang))] bottom-4 left-[clamp(0.5rem,3vw,1.5rem)] z-[2] w-auto min-w-0 overflow-hidden rounded-lg border border-slate-200 bg-slate-50 shadow-[0_18px_44px_rgba(15,23,42,0.08)] transition-[opacity,transform] duration-200 [--homepage-workflow-popup-overhang:clamp(0rem,calc((100vw-72rem)*0.5),4rem)] data-[popup-visible=false]:translate-y-3 data-[popup-visible=false]:scale-[0.98] data-[popup-visible=false]:pointer-events-none data-[popup-visible=false]:opacity-0 data-[popup-visible=true]:translate-y-0 data-[popup-visible=true]:scale-100 data-[popup-visible=true]:opacity-100 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-50 dark:shadow-[0_18px_44px_rgba(0,0,0,0.28)] max-[899px]:right-2 max-[899px]:bottom-2 max-[899px]:left-2 max-[899px]:[--homepage-workflow-popup-overhang:0rem] max-[520px]:right-1.5 max-[520px]:bottom-1.5 max-[520px]:left-1.5"
+      className="homepage-workflow-popup absolute right-[calc(-1*var(--homepage-workflow-popup-overhang))] bottom-4 left-[clamp(0.5rem,3vw,1.5rem)] z-[2] w-auto min-w-0 overflow-hidden rounded-xl border border-slate-200 bg-slate-50 shadow-[0_18px_44px_rgba(15,23,42,0.08)] transition-[opacity,transform] duration-200 [--homepage-workflow-popup-overhang:clamp(0rem,calc((100vw-72rem)*0.5),4rem)] data-[popup-visible=false]:translate-y-3 data-[popup-visible=false]:scale-[0.98] data-[popup-visible=false]:pointer-events-none data-[popup-visible=false]:opacity-0 data-[popup-visible=true]:translate-y-0 data-[popup-visible=true]:scale-100 data-[popup-visible=true]:opacity-100 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-50 dark:shadow-[0_18px_44px_rgba(0,0,0,0.28)] max-[899px]:right-2 max-[899px]:bottom-2 max-[899px]:left-2 max-[899px]:[--homepage-workflow-popup-overhang:0rem] max-[520px]:right-1.5 max-[520px]:bottom-1.5 max-[520px]:left-1.5"
       data-homepage-workflow-popup=""
       data-popup-visible={visible ? "true" : "false"}
       data-testid="homepage-workflow-popup"
     >
       <div
-        className="flex h-10 items-center justify-between gap-4 border-b border-slate-200 bg-white px-4 text-xs font-bold text-stone-500 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-400 max-[520px]:px-3"
+        className="homepage-workflow-panel-header flex h-8 items-center justify-between gap-3 border-b border-slate-200 bg-white px-3 text-xs font-bold text-stone-500 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-400 max-[520px]:px-2.5"
         data-testid="homepage-workflow-popup-header"
       >
         <div

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -588,7 +588,10 @@ function HomepageWorkflowScene({
         <h3 className="font-die-grotesk-b mt-5 text-[clamp(2rem,1.5rem+1.5vw,2.5rem)] leading-tight font-bold text-balance text-slate-950 dark:text-slate-50">
           {title}
         </h3>
-        <p className="mt-4 max-w-md font-sans text-[clamp(1rem,0.95rem+0.25vw,1.125rem)] leading-7 font-medium text-slate-950 dark:text-slate-50">
+        <p
+          className="mt-4 max-w-md font-sans text-[clamp(1rem,0.95rem+0.25vw,1.125rem)] leading-7 font-medium text-slate-950 dark:text-slate-50"
+          data-testid="homepage-workflow-scene-description"
+        >
           {description}
         </p>
       </div>

--- a/packages/app/src/components/ui/dialog.tsx
+++ b/packages/app/src/components/ui/dialog.tsx
@@ -28,7 +28,7 @@ function DialogOverlay({
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/30 data-[ending-style]:animate-out data-[ending-style]:fade-out-0 data-[starting-style]:animate-in data-[starting-style]:fade-in-0",
+        "fixed inset-0 z-50 bg-black/30 data-open:animate-in data-open:fade-in-0 data-[ending-style]:animate-out data-[ending-style]:fade-out-0 data-[starting-style]:animate-in data-[starting-style]:fade-in-0",
         className,
       )}
       {...props}
@@ -50,7 +50,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border bg-background p-6 text-foreground shadow-lg outline-none data-[ending-style]:animate-out data-[ending-style]:fade-out-0 data-[ending-style]:zoom-out-95 data-[starting-style]:animate-in data-[starting-style]:fade-in-0 data-[starting-style]:zoom-in-95",
+          "fixed top-1/2 left-1/2 z-50 grid w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border bg-background p-6 text-foreground shadow-lg outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[ending-style]:animate-out data-[ending-style]:fade-out-0 data-[ending-style]:zoom-out-95 data-[starting-style]:animate-in data-[starting-style]:fade-in-0 data-[starting-style]:zoom-in-95",
           className,
         )}
         {...props}

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -509,6 +509,18 @@ describe("Homepage", () => {
       expect(sceneNodes[index]?.textContent).toContain(scene);
     });
 
+    const firstSceneDescription = sceneNodes[0]?.querySelector("p");
+    expect(firstSceneDescription?.textContent).toContain(
+      "Start in the same agent chat you already use.",
+    );
+    expect(firstSceneDescription?.className).toContain("font-sans");
+    expect(firstSceneDescription?.className).toContain(
+      "text-[clamp(1rem,0.95rem+0.25vw,1.125rem)]",
+    );
+    expect(firstSceneDescription?.className).toContain("leading-7");
+    expect(firstSceneDescription?.className).toContain("font-medium");
+    expect(firstSceneDescription?.className).toContain("text-slate-950");
+
     expect(storyboard.textContent).toContain(
       "Let's make the homepage more persuasive. Write a plan first.",
     );

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -173,7 +173,7 @@ describe("Homepage", () => {
     expect(homepageHeading?.parentElement?.className).toContain("mt-20");
     expect(homepageHeading?.parentElement?.className).toContain("sm:mt-28");
     expect(homepageTextWrapper?.className).toContain("text-left");
-    expect(homepageTextWrapper?.className).toContain("max-w-[100rem]");
+    expect(homepageTextWrapper?.className).toContain("max-w-[1500px]");
     expect(homepageTextWrapper?.className).not.toContain("font-bold");
     expect(homepageHeading?.className).not.toContain("max-w-");
     expect(homepageHeading?.className).toContain("text-[clamp(");
@@ -183,10 +183,22 @@ describe("Homepage", () => {
     expect(homepageHeading?.className).toContain("leading-[0.88]");
     expect(homepageHeading?.className).not.toContain("text-balance");
     expect(homepageHeading?.nextElementSibling?.className).toContain(
-      "text-[clamp(",
+      "mt-7",
+    );
+    expect(homepageHeading?.nextElementSibling?.className).not.toContain(
+      "mt-5",
+    );
+    expect(homepageHeading?.nextElementSibling?.className).toContain(
+      "text-[clamp(1.125rem,0.85rem+0.8vw,1.5rem)]",
     );
     expect(homepageHeading?.nextElementSibling?.className).toContain(
       "leading-none",
+    );
+    expect(homepageHeading?.nextElementSibling?.className).toContain(
+      "font-sans",
+    );
+    expect(homepageHeading?.nextElementSibling?.className).toContain(
+      "font-medium",
     );
     expect(homepageHeading?.nextElementSibling?.className).toContain(
       "max-w-5xl",
@@ -297,7 +309,7 @@ describe("Homepage", () => {
     expect(
       getByTestId(container, "homepage-sneak-peek-image").parentElement
         ?.className,
-    ).toContain("max-w-[100rem]");
+    ).toContain("max-w-[1500px]");
     expect(document.body.textContent).not.toContain(AGENT_SETUP_PROMPT);
 
     const cta = getByTestId<HTMLButtonElement>(

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -182,9 +182,7 @@ describe("Homepage", () => {
     );
     expect(homepageHeading?.className).toContain("leading-[0.88]");
     expect(homepageHeading?.className).not.toContain("text-balance");
-    expect(homepageHeading?.nextElementSibling?.className).toContain(
-      "mt-7",
-    );
+    expect(homepageHeading?.nextElementSibling?.className).toContain("mt-7");
     expect(homepageHeading?.nextElementSibling?.className).not.toContain(
       "mt-5",
     );
@@ -509,7 +507,10 @@ describe("Homepage", () => {
       expect(sceneNodes[index]?.textContent).toContain(scene);
     });
 
-    const firstSceneDescription = sceneNodes[0]?.querySelector("p");
+    const firstSceneDescription = getByTestId(
+      sceneNodes[0],
+      "homepage-workflow-scene-description",
+    );
     expect(firstSceneDescription?.textContent).toContain(
       "Start in the same agent chat you already use.",
     );

--- a/packages/app/test/homepage.test.tsx
+++ b/packages/app/test/homepage.test.tsx
@@ -356,6 +356,19 @@ describe("Homepage", () => {
       "Give this to your coding agent",
     );
     expect(document.body.textContent).toContain(AGENT_SETUP_PROMPT);
+    const dialogContent = document.body.querySelector(
+      '[data-slot="dialog-content"]',
+    );
+    const dialogOverlay = document.body.querySelector(
+      '[data-slot="dialog-overlay"]',
+    );
+    expect(dialogContent?.getAttribute("data-open")).toBe("");
+    expect(dialogContent?.className).toContain("data-open:animate-in");
+    expect(dialogContent?.className).toContain("data-open:fade-in-0");
+    expect(dialogContent?.className).toContain("data-open:zoom-in-95");
+    expect(dialogOverlay?.getAttribute("data-open")).toBe("");
+    expect(dialogOverlay?.className).toContain("data-open:animate-in");
+    expect(dialogOverlay?.className).toContain("data-open:fade-in-0");
 
     const copyButton = getByTestId<HTMLButtonElement>(
       document.body,


### PR DESCRIPTION
Updates the homepage hero and workflow storyboard styling with tighter typography, a 1500px content width, and refined mock window chrome. Fixes the install dialog so open-state animations run through the `data-open` attributes emitted by the dialog primitives. Updates homepage tests to cover the layout, dialog animation classes, and stable workflow description selector.

Validation: `pnpm check` and `pnpm test:smoke`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and animation-class changes on the marketing homepage and shared dialog component; no auth, data, or core editor logic touched.
> 
> **Overview**
> **Homepage polish:** Main content and sneak-peek width cap moves from `100rem` to **`1500px`**. The hero gets tighter heading **tracking**, and the subtitle / workflow step copy use **sans**, **medium** weight, updated **clamp** sizes, and slightly more spacing (`mt-7` on the subtitle).
> 
> **Workflow mocks:** Terminal and Roughdraft popup chrome is slimmer (shorter title bars, `rounded-xl`), with shared utility classes on the popup header. Step descriptions gain `data-testid="homepage-workflow-scene-description"` for stable tests.
> 
> **Install dialog:** `DialogOverlay` and `DialogContent` add Tailwind **`data-open:`** enter animations (fade/zoom) alongside existing start/end styles so open-state motion matches Base UI’s `data-open` attribute.
> 
> **Tests:** Homepage tests assert the new layout classes, workflow description styling, and that the install dialog sets `data-open` and the new animation class names when opened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e896f3b4ae92979843b860796f25364a27955cc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->