### PR TITLE
Add Roughdraft setup example document

### DIFF
--- a/packages/app/public/example.md
+++ b/packages/app/public/example.md
@@ -1,0 +1,19 @@
+# Roughdraft test document
+
+This is a quick test document to confirm Roughdraft is working with your AI agent.
+
+Try one of these:
+
+- Highlight a sentence and leave a comment or question.
+- Suggest a small edit.
+- Add a note below about a document you want to review next.
+
+When you click **Done Reviewing**, your agent should read this file, reply inline to any comments or questions, and open it in Roughdraft again so you can keep the conversation going in the document.
+
+{==Ask a question here, or tell your agent what you want to try next.==}{>>Hi, I am your AI agent. You can leave comments or questions like this, and I will reply inline in the document.<<}{#c1}
+
+---
+comments:
+  c1:
+    by: AI
+    at: "2026-06-19T22:20:00.000Z"

--- a/packages/app/public/prompt.md
+++ b/packages/app/public/prompt.md
@@ -18,7 +18,7 @@ If Roughdraft is not running, `roughdraft open` will start it automatically.
 
 After `roughdraft open` opens the document, leave the command running. Do not interrupt, kill, background, detach, or treat the waiting process as cleanup. The wait is intentional: Roughdraft will exit the command after the user clicks Done Reviewing, and that exit is your signal to resume.
 
-After the user finishes reviewing in Roughdraft, read the Markdown file from disk and respond to any CriticMarkup comments or suggested changes.
+After the user finishes reviewing in Roughdraft, read the Markdown file from disk and respond to any CriticMarkup comments or suggested changes. If the user left questions or comments in the document, reply inline in the Markdown file using Roughdraft-flavored CriticMarkup, save it, and open the file in Roughdraft again so the user can continue reviewing.
 
 Use Roughdraft-flavored CriticMarkup when reading or writing inline review feedback in Markdown. The base markers are:
 

--- a/packages/app/public/setup.md
+++ b/packages/app/public/setup.md
@@ -20,6 +20,20 @@ npm i -g roughdraft
 
 If the user did not explicitly ask you to install software, ask before installing a global npm package.
 
+## First, Open a Test Document
+
+Create a short example document and open it for the user so they can confirm the full review loop works:
+
+```bash
+example_file="$HOME/roughdraft-example.md"
+curl -fsSL https://roughdraft.md/example.md -o "$example_file"
+roughdraft open "$example_file"
+```
+
+If `curl` is unavailable, create a short Markdown file yourself with a heading, one or two sentences, and an invitation for the user to leave a comment or question.
+
+After `roughdraft open` opens the document, leave the command running. Tell the user they can leave comments, suggested edits, or questions in the document, then click **Done Reviewing**. When Roughdraft exits, read the Markdown file, reply inline to any comments or questions using Roughdraft-flavored CriticMarkup, save the file, and open it in Roughdraft again so the user can continue the conversation in the document.
+
 ## Update Your Persistent Instructions
 
 Add Roughdraft guidance to the persistent instruction file this agent will actually load. Prefer global or user-level instructions, because Roughdraft is a cross-project workflow.
@@ -108,7 +122,7 @@ If Roughdraft is not running, `roughdraft open` will start it automatically.
 
 After `roughdraft open` opens the document, leave the command running. Do not interrupt, kill, background, detach, or treat the waiting process as cleanup. The wait is intentional: Roughdraft will exit the command after the user clicks Done Reviewing, and that exit is your signal to resume.
 
-After the user finishes reviewing in Roughdraft, read the Markdown file from disk and respond to any CriticMarkup comments or suggested changes.
+After the user finishes reviewing in Roughdraft, read the Markdown file from disk and respond to any CriticMarkup comments or suggested changes. If the user left questions or comments in the document, reply inline in the Markdown file using Roughdraft-flavored CriticMarkup, save it, and open the file in Roughdraft again so the user can continue reviewing.
 
 Use Roughdraft-flavored CriticMarkup when reading or writing inline review feedback in Markdown. The base markers are:
 


### PR DESCRIPTION
Adds a public Roughdraft example document that agents can download and open during setup.

Updates the setup guide to make opening that test document the first onboarding step, including the wait, inline reply, and reopen loop.

Updates the reusable agent prompt so future comments and questions get inline CriticMarkup replies before the document is reopened for continued review.

Validated with pnpm check and pnpm test:smoke.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to public Markdown docs and the example asset; no runtime, auth, or application logic.
> 
> **Overview**
> Adds a hosted **`example.md`** test doc (with sample highlight, inline agent comment, and YAML endmatter) so onboarding can verify the full Roughdraft workflow.
> 
> **Setup** now leads with **First, Open a Test Document**: download from `https://roughdraft.md/example.md` (or hand-write if `curl` is missing), run `roughdraft open`, wait for **Done Reviewing**, then read the file, reply inline with CriticMarkup, save, and reopen for another round.
> 
> The reusable **`prompt.md`** block and the matching fallback text in **setup** extend the post-review step with that same **inline reply → save → reopen** loop, not only “respond to” comments in the chat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbb81f4efe3d31a4706d322af8f4d39af4740364. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->