### PR TITLE
Add comment reactions (up/down/clarify)

### DIFF
--- a/docs/spec/roughdraft-flavored-markdown.md
+++ b/docs/spec/roughdraft-flavored-markdown.md
@@ -213,6 +213,7 @@ Known metadata attributes:
 | `re` | Comments | No | Parent comment or suggestion id for threaded replies. |
 | `status` | Comments and suggestions | No | Review state. Roughdraft currently writes `resolved` when an item has been addressed. |
 | `resolved` | Comments and suggestions | No | Optional short resolution summary for an item whose `status` is `resolved`. |
+| `reaction` | Comments | No | Reviewer reaction to a comment. One of `up`, `down`, or `clarify`. Applies to comments and replies only, never to suggestions (which carry Accept/Reject semantics instead). Readers MUST ignore an unknown reaction value rather than reject the document. |
 
 Example:
 
@@ -224,7 +225,10 @@ comments:
   c1:
     by: user
     at: "2026-04-28T12:00:00.000Z"
+    reaction: up
 ```
+
+The inline equivalent is `{>>Needs a source.<<}{id="c1" by="user" at="2026-04-28T12:00:00.000Z" reaction="up"}`.
 
 Implementations SHOULD generate simple document-local ids. Roughdraft uses `c1`, `c2`, and so on for comments and `s1`, `s2`, and so on for suggestions. Implementations MUST preserve unknown valid attributes or YAML keys when possible, but they MUST NOT require unknown metadata for correct review rendering.
 

--- a/docs/spec/roughdraft-flavored-markdown.schema.json
+++ b/docs/spec/roughdraft-flavored-markdown.schema.json
@@ -112,6 +112,9 @@
         "resolved": {
           "type": "string"
         },
+        "reaction": {
+          "enum": ["up", "down", "clarify"]
+        },
         "metadata": {
           "$ref": "#/$defs/metadata"
         }

--- a/packages/app/src/CommentEditorList.tsx
+++ b/packages/app/src/CommentEditorList.tsx
@@ -1,4 +1,15 @@
-import { Bot, Check, Pencil, Reply, Trash2, User, X } from "lucide-react";
+import {
+  Bot,
+  Check,
+  MessageCircleQuestion,
+  Pencil,
+  Reply,
+  ThumbsDown,
+  ThumbsUp,
+  Trash2,
+  User,
+  X,
+} from "lucide-react";
 import {
   type KeyboardEvent,
   type MouseEvent,
@@ -20,6 +31,7 @@ import {
   buildCommentThreads,
   type CriticComment,
   type CriticCommentThread,
+  type CriticReaction,
 } from "./critic-markup";
 import { cn } from "./lib/utils";
 
@@ -37,6 +49,7 @@ interface CommentEditorListProps {
   onHoverComment?: (commentId: string | null) => void;
   onFocusComment?: (commentId: string) => void;
   onReplyComment?: (commentId: string) => void;
+  onReactComment?: (commentId: string, reaction: CriticReaction | null) => void;
   pendingFocusCommentId?: string | null;
   newCommentDraftIds?: string[];
   onAutoFocusComment?: (commentId: string) => void;
@@ -104,6 +117,7 @@ export function CommentEditorList({
   onHoverComment,
   onFocusComment,
   onReplyComment,
+  onReactComment,
   pendingFocusCommentId = null,
   newCommentDraftIds = [],
   onAutoFocusComment,
@@ -296,6 +310,7 @@ export function CommentEditorList({
           onHoverComment={onHoverComment}
           onFocusComment={onFocusComment}
           onReplyComment={onReplyComment}
+          onReactComment={onReactComment}
           onStartEditingComment={startEditingComment}
           onSubmitEditingComment={submitEditingComment}
           onCancelEditingComment={cancelEditingComment}
@@ -334,6 +349,7 @@ interface CommentThreadNodeProps {
   onHoverComment?: (commentId: string | null) => void;
   onFocusComment?: (commentId: string) => void;
   onReplyComment?: (commentId: string) => void;
+  onReactComment?: (commentId: string, reaction: CriticReaction | null) => void;
   onStartEditingComment: (commentId: string) => void;
   onSubmitEditingComment: (commentId: string) => void;
   onCancelEditingComment: (commentId: string) => void;
@@ -428,6 +444,7 @@ function CommentThreadNode({
   onHoverComment,
   onFocusComment,
   onReplyComment,
+  onReactComment,
   onStartEditingComment,
   onSubmitEditingComment,
   onCancelEditingComment,
@@ -766,6 +783,64 @@ function CommentThreadNode({
                     onClick={action.onClick}
                   />
                 ))}
+                {!isEditing && onReactComment ? (
+                  <>
+                    <CommentActionButton
+                      label="Thumbs up"
+                      testId={`comment-${variant}-${comment.id}-reaction-up`}
+                      icon={<ThumbsUp className="size-3.5" />}
+                      compact
+                      className={
+                        comment.reaction === "up"
+                          ? "border-stone-300 bg-[#DED8CE]/45 text-stone-600 dark:border-slate-500 dark:bg-slate-700 dark:text-stone-300"
+                          : ""
+                      }
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onReactComment(
+                          comment.id,
+                          comment.reaction === "up" ? null : "up",
+                        );
+                      }}
+                    />
+                    <CommentActionButton
+                      label="Thumbs down"
+                      testId={`comment-${variant}-${comment.id}-reaction-down`}
+                      icon={<ThumbsDown className="size-3.5" />}
+                      compact
+                      className={
+                        comment.reaction === "down"
+                          ? "border-stone-300 bg-[#DED8CE]/45 text-stone-600 dark:border-slate-500 dark:bg-slate-700 dark:text-stone-300"
+                          : ""
+                      }
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onReactComment(
+                          comment.id,
+                          comment.reaction === "down" ? null : "down",
+                        );
+                      }}
+                    />
+                    <CommentActionButton
+                      label="Needs clarification"
+                      testId={`comment-${variant}-${comment.id}-reaction-clarify`}
+                      icon={<MessageCircleQuestion className="size-3.5" />}
+                      compact
+                      className={
+                        comment.reaction === "clarify"
+                          ? "border-stone-300 bg-[#DED8CE]/45 text-stone-600 dark:border-slate-500 dark:bg-slate-700 dark:text-stone-300"
+                          : ""
+                      }
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onReactComment(
+                          comment.id,
+                          comment.reaction === "clarify" ? null : "clarify",
+                        );
+                      }}
+                    />
+                  </>
+                ) : null}
               </div>
             </div>
           </div>
@@ -796,6 +871,7 @@ function CommentThreadNode({
               onHoverComment={onHoverComment}
               onFocusComment={onFocusComment}
               onReplyComment={onReplyComment}
+              onReactComment={onReactComment}
               onStartEditingComment={onStartEditingComment}
               onSubmitEditingComment={onSubmitEditingComment}
               onCancelEditingComment={onCancelEditingComment}

--- a/packages/app/src/DocumentCommentRail.tsx
+++ b/packages/app/src/DocumentCommentRail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { CommentEditorList } from "./CommentEditorList";
-import type { CriticComment } from "./critic-markup";
+import type { CriticComment, CriticReaction } from "./critic-markup";
 import {
   buildCommentThreadRailItems,
   type CommentGroupAnchor,
@@ -22,6 +22,7 @@ interface DocumentCommentRailProps {
   onDeleteComment: (commentId: string) => void;
   onUpdateComment: (commentId: string, nextContent: string) => void;
   onReplyComment: (commentId: string) => void;
+  onReactComment: (commentId: string, reaction: CriticReaction | null) => void;
   onSelectComment: (commentId: string) => void;
   onFocusComment: (commentId: string) => void;
   onHoverComment: (commentId: string | null) => void;
@@ -39,6 +40,7 @@ export function DocumentCommentRail({
   onDeleteComment,
   onUpdateComment,
   onReplyComment,
+  onReactComment,
   onSelectComment,
   onFocusComment,
   onHoverComment,
@@ -214,6 +216,7 @@ export function DocumentCommentRail({
                 onDeleteComment={onDeleteComment}
                 onUpdateComment={onUpdateComment}
                 onReplyComment={onReplyComment}
+                onReactComment={onReactComment}
                 onSelectComment={onSelectComment}
                 onFocusComment={onFocusComment}
                 onHoverComment={onHoverComment}

--- a/packages/app/src/DocumentReviewRail.tsx
+++ b/packages/app/src/DocumentReviewRail.tsx
@@ -19,6 +19,7 @@ import type {
   CriticChangeAttrs,
   CriticChangeKind,
   CriticComment,
+  CriticReaction,
 } from "./critic-markup";
 import {
   buildCommentThreadRailItems,
@@ -61,6 +62,7 @@ interface DocumentReviewRailProps {
   onDeleteComment: (commentId: string) => void;
   onUpdateComment: (commentId: string, nextContent: string) => void;
   onReplyComment: (commentId: string) => void;
+  onReactComment: (commentId: string, reaction: CriticReaction | null) => void;
   onSelectComment: (commentId: string) => void;
   onFocusComment: (commentId: string) => void;
   onHoverComment: (commentId: string | null) => void;
@@ -197,6 +199,7 @@ export function DocumentReviewRail({
   onDeleteComment,
   onUpdateComment,
   onReplyComment,
+  onReactComment,
   onSelectComment,
   onFocusComment,
   onHoverComment,
@@ -478,6 +481,7 @@ export function DocumentReviewRail({
                   onDeleteComment={onDeleteComment}
                   onUpdateComment={onUpdateComment}
                   onReplyComment={onReplyComment}
+                  onReactComment={onReactComment}
                   onSelectComment={onSelectComment}
                   onFocusComment={onFocusComment}
                   onHoverComment={onHoverComment}

--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -9,6 +9,7 @@ import { CommentEditorList } from "./CommentEditorList";
 import {
   type CriticChangeAttrs,
   type CriticComment,
+  type CriticReaction,
   createCriticChange,
   createCriticComment,
   criticMarkdownHasReviewRail,
@@ -1674,6 +1675,13 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
     [measureLayout],
   );
 
+  const reactToComment = useCallback(
+    (commentId: string, reaction: CriticReaction | null) => {
+      updateComment(commentId, (current) => ({ ...current, reaction }));
+    },
+    [updateComment],
+  );
+
   const removeSuggestionComments = useCallback(
     (changeId: string, currentEditor: Editor) => {
       const directCommentIds = [...commentsRef.current.values()]
@@ -1932,6 +1940,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
                 }));
               }}
               onReplyComment={replyToComment}
+              onReactComment={reactToComment}
               onSelectComment={selectComment}
               onHoverComment={setHoveredCommentId}
               pendingFocusCommentId={pendingFocusCommentId}
@@ -1998,6 +2007,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
             }));
           }}
           onReplyComment={replyToComment}
+          onReactComment={reactToComment}
           onSelectComment={selectComment}
           onFocusComment={focusComment}
           onHoverComment={setHoveredCommentId}

--- a/packages/app/src/critic-markup-reactions.test.ts
+++ b/packages/app/src/critic-markup-reactions.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  criticMarkdownToEditorState,
+  editorStateToCriticMarkdown,
+} from "./critic-markup";
+
+describe("comment reactions round-trip", () => {
+  it("parses reaction='up' from inline attribute metadata", () => {
+    const markdown =
+      'Hello {==world=={>>Nice!<<}{id="c1" by="user" at="2024-01-01T00:00:00.000Z" reaction="up"}\n';
+
+    const { comments } = criticMarkdownToEditorState(markdown);
+
+    expect(comments.get("c1")?.reaction).toBe("up");
+  });
+
+  it("parses reaction='down' from inline attribute metadata", () => {
+    const markdown =
+      'Hello {==world=={>>Needs work<<}{id="c1" by="user" at="2024-01-01T00:00:00.000Z" reaction="down"}\n';
+
+    const { comments } = criticMarkdownToEditorState(markdown);
+
+    expect(comments.get("c1")?.reaction).toBe("down");
+  });
+
+  it("parses reaction='clarify' from inline attribute metadata", () => {
+    const markdown =
+      'Hello {==world=={>>What?<<}{id="c1" by="user" at="2024-01-01T00:00:00.000Z" reaction="clarify"}\n';
+
+    const { comments } = criticMarkdownToEditorState(markdown);
+
+    expect(comments.get("c1")?.reaction).toBe("clarify");
+  });
+
+  it("parses null when reaction attribute is absent", () => {
+    const markdown =
+      'Hello {==world=={>>Comment<<}{id="c1" by="user" at="2024-01-01T00:00:00.000Z"}\n';
+
+    const { comments } = criticMarkdownToEditorState(markdown);
+
+    expect(comments.get("c1")?.reaction).toBeNull();
+  });
+
+  it("serializes reaction='up' back into inline metadata", () => {
+    const markdown =
+      'Hello {==world=={>>Nice!<<}{id="c1" by="user" at="2024-01-01T00:00:00.000Z" reaction="up"}\n';
+
+    const { doc, comments } = criticMarkdownToEditorState(markdown);
+    const serialized = editorStateToCriticMarkdown(doc, comments);
+
+    expect(serialized).toContain('reaction="up"');
+  });
+
+  it("serializes reaction='down' back into inline metadata", () => {
+    const markdown =
+      'Hello {==world=={>>Needs work<<}{id="c1" by="user" at="2024-01-01T00:00:00.000Z" reaction="down"}\n';
+
+    const { doc, comments } = criticMarkdownToEditorState(markdown);
+    const serialized = editorStateToCriticMarkdown(doc, comments);
+
+    expect(serialized).toContain('reaction="down"');
+  });
+
+  it("omits reaction key when reaction is null", () => {
+    const markdown =
+      'Hello {==world=={>>Comment<<}{id="c1" by="user" at="2024-01-01T00:00:00.000Z"}\n';
+
+    const { doc, comments } = criticMarkdownToEditorState(markdown);
+    const serialized = editorStateToCriticMarkdown(doc, comments);
+
+    expect(serialized).not.toContain("reaction=");
+  });
+
+  it("round-trips reaction through endmatter YAML", () => {
+    // Use reference syntax {#c1} so metadata comes entirely from endmatter
+    const markdown = [
+      "Hello {==world=={>>Nice!<<}{#c1}",
+      "",
+      "---",
+      "comments:",
+      "  c1:",
+      "    by: user",
+      '    at: "2024-01-01T00:00:00.000Z"',
+      "    reaction: up",
+      "",
+    ].join("\n");
+
+    const { comments } = criticMarkdownToEditorState(markdown);
+
+    expect(comments.get("c1")?.reaction).toBe("up");
+  });
+
+  it("serializes reaction into endmatter YAML when endmatter is present", () => {
+    // Use reference syntax so the comment is loaded from endmatter
+    const markdown = [
+      "Hello {==world=={>>Nice!<<}{#c1}",
+      "",
+      "---",
+      "comments:",
+      "  c1:",
+      "    by: user",
+      '    at: "2024-01-01T00:00:00.000Z"',
+      "",
+    ].join("\n");
+
+    const { doc, comments } = criticMarkdownToEditorState(markdown);
+
+    // Set reaction on the parsed comment
+    const comment = comments.get("c1");
+    if (!comment) throw new Error("comment c1 not found");
+    comments.set("c1", { ...comment, reaction: "clarify" });
+
+    const serialized = editorStateToCriticMarkdown(doc, comments);
+
+    expect(serialized).toContain("reaction: clarify");
+  });
+
+  it("removes reaction from endmatter YAML when set to null", () => {
+    const markdown = [
+      "Hello {==world=={>>Nice!<<}{#c1}",
+      "",
+      "---",
+      "comments:",
+      "  c1:",
+      "    by: user",
+      '    at: "2024-01-01T00:00:00.000Z"',
+      "    reaction: up",
+      "",
+    ].join("\n");
+
+    const { doc, comments } = criticMarkdownToEditorState(markdown);
+
+    // Clear reaction
+    const comment = comments.get("c1");
+    if (!comment) throw new Error("comment c1 not found");
+    comments.set("c1", { ...comment, reaction: null });
+
+    const serialized = editorStateToCriticMarkdown(doc, comments);
+
+    expect(serialized).not.toContain("reaction:");
+  });
+});

--- a/packages/app/src/critic-markup/index.ts
+++ b/packages/app/src/critic-markup/index.ts
@@ -25,6 +25,22 @@ import {
   type MarkdownOptions,
 } from "../markdown";
 
+export type CriticReaction = "up" | "down" | "clarify";
+
+export const CRITIC_REACTIONS: readonly CriticReaction[] = [
+  "up",
+  "down",
+  "clarify",
+];
+
+export function normalizeCriticReaction(
+  value: string | null | undefined,
+): CriticReaction | null {
+  return CRITIC_REACTIONS.includes(value as CriticReaction)
+    ? (value as CriticReaction)
+    : null;
+}
+
 export interface CriticComment {
   id: string;
   content: string;
@@ -33,6 +49,7 @@ export interface CriticComment {
   authorId?: string | null;
   parentCommentId?: string | null;
   scope?: "document";
+  reaction?: CriticReaction | null;
 }
 
 export interface CriticCommentThread {
@@ -115,6 +132,7 @@ function parseLegacyMetadata(
     authorType: author.toUpperCase() === "AI" ? "ai" : "user",
     authorId: author.toUpperCase() === "AI" ? null : author,
     parentCommentId: fields.get("re") ?? null,
+    reaction: normalizeCriticReaction(fields.get("reaction")),
   };
 }
 
@@ -148,6 +166,7 @@ function parseAttributeMetadata(
     authorType: author.toUpperCase() === "AI" ? "ai" : "user",
     authorId: author.toUpperCase() === "AI" ? null : author,
     parentCommentId: fields.get("re") ?? null,
+    reaction: normalizeCriticReaction(fields.get("reaction")),
   };
 }
 
@@ -167,6 +186,9 @@ function commentPartialFromEndmatterEntry(
     authorId: author.toUpperCase() === "AI" ? null : author,
     parentCommentId:
       includeParent && typeof entry?.re === "string" ? entry.re : null,
+    reaction: normalizeCriticReaction(
+      typeof entry?.reaction === "string" ? entry.reaction : null,
+    ),
   };
 }
 
@@ -205,6 +227,10 @@ function serializeMetadata(comment: CriticComment): string {
 
   if (comment.parentCommentId) {
     fields.push(["re", comment.parentCommentId]);
+  }
+
+  if (comment.reaction) {
+    fields.push(["reaction", comment.reaction]);
   }
 
   return `{${fields
@@ -339,6 +365,12 @@ function endmatterEntryForComment(
     delete next.re;
   }
 
+  if (comment.reaction) {
+    next.reaction = comment.reaction;
+  } else {
+    delete next.reaction;
+  }
+
   return next;
 }
 
@@ -454,6 +486,7 @@ function createCommentWithContext(
     authorId: partial?.authorId ?? (authorType === "ai" ? null : "user"),
     parentCommentId: partial?.parentCommentId ?? null,
     scope: partial?.scope,
+    reaction: partial?.reaction ?? null,
   };
 }
 

--- a/packages/rfm/src/index.test.ts
+++ b/packages/rfm/src/index.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
-  appendRoughdraftReply,
   appendRoughdraftDocumentComment,
+  appendRoughdraftReply,
   extractRoughdraftReviewIndex,
   markRoughdraftResolved,
+  setRoughdraftReaction,
   validateRoughdraftMarkdown,
 } from "./index";
 
@@ -615,5 +616,131 @@ describe("RFM mutation helpers", () => {
       id: "s1",
       status: "resolved",
     });
+  });
+});
+
+describe("comment reactions", () => {
+  it("extracts an inline comment reaction", () => {
+    const markdown =
+      'Keep {>>open question<<}{id="c1" by="user" at="2026-04-28T12:06:00.000Z" reaction="up"}.\n';
+
+    const comment = extractRoughdraftReviewIndex(markdown).items.find(
+      (item) => item.id === "c1",
+    );
+
+    expect(comment?.reaction).toBe("up");
+  });
+
+  it("extracts an endmatter-backed comment reaction", () => {
+    const markdown = [
+      "Keep {>>open question<<}{#c1}.",
+      "",
+      "---",
+      "comments:",
+      "  c1:",
+      "    by: user",
+      '    at: "2026-04-28T12:06:00.000Z"',
+      "    reaction: clarify",
+      "",
+    ].join("\n");
+
+    const comment = extractRoughdraftReviewIndex(markdown).items.find(
+      (item) => item.id === "c1",
+    );
+
+    expect(comment?.reaction).toBe("clarify");
+  });
+
+  it("defaults reaction to null when absent and ignores invalid values", () => {
+    const markdown =
+      'Keep {>>q1<<}{id="c1" by="user" at="2026-04-28T12:06:00.000Z"} and {>>q2<<}{id="c2" by="user" at="2026-04-28T12:07:00.000Z" reaction="meh"}.\n';
+
+    const index = extractRoughdraftReviewIndex(markdown);
+    expect(index.items.find((item) => item.id === "c1")?.reaction).toBeNull();
+    expect(index.items.find((item) => item.id === "c2")?.reaction).toBeNull();
+  });
+
+  it("tallies reactions in the review index summary", () => {
+    const markdown =
+      'Keep {>>q1<<}{id="c1" by="user" at="2026-04-28T12:06:00.000Z" reaction="up"} and {>>q2<<}{id="c2" by="user" at="2026-04-28T12:07:00.000Z" reaction="up"} and {>>q3<<}{id="c3" by="user" at="2026-04-28T12:08:00.000Z" reaction="clarify"} and {>>q4<<}{id="c4" by="user" at="2026-04-28T12:09:00.000Z"}.\n';
+
+    expect(extractRoughdraftReviewIndex(markdown).summary.reactions).toEqual({
+      up: 2,
+      down: 0,
+      clarify: 1,
+    });
+  });
+
+  it("sets a reaction on an inline comment without changing unrelated markup", () => {
+    const markdown =
+      'Add {++one example++}{id="s1" by="AI" at="2026-04-28T12:05:00.000Z"} and keep {>>open question<<}{id="c1" by="user" at="2026-04-28T12:06:00.000Z"}.\n';
+
+    const updated = setRoughdraftReaction(markdown, {
+      targetId: "c1",
+      reaction: "down",
+    });
+
+    expect(updated).toBe(
+      'Add {++one example++}{id="s1" by="AI" at="2026-04-28T12:05:00.000Z"} and keep {>>open question<<}{id="c1" by="user" at="2026-04-28T12:06:00.000Z" reaction="down"}.\n',
+    );
+  });
+
+  it("sets a reaction on an endmatter-backed comment in YAML", () => {
+    const markdown = [
+      "Keep {>>open question<<}{#c1}.",
+      "",
+      "---",
+      "comments:",
+      "  c1:",
+      "    by: user",
+      '    at: "2026-04-28T12:06:00.000Z"',
+      "",
+    ].join("\n");
+
+    const updated = setRoughdraftReaction(markdown, {
+      targetId: "c1",
+      reaction: "up",
+    });
+
+    expect(updated).toContain("reaction: up");
+    expect(extractRoughdraftReviewIndex(updated).items[0]).toMatchObject({
+      id: "c1",
+      reaction: "up",
+    });
+  });
+
+  it("clears a reaction when passed null", () => {
+    const markdown =
+      'Keep {>>open question<<}{id="c1" by="user" at="2026-04-28T12:06:00.000Z" reaction="up"}.\n';
+
+    const updated = setRoughdraftReaction(markdown, {
+      targetId: "c1",
+      reaction: null,
+    });
+
+    expect(updated).not.toContain("reaction=");
+    expect(extractRoughdraftReviewIndex(updated).items[0]?.reaction).toBeNull();
+  });
+
+  it("rejects reactions on suggestions", () => {
+    const markdown =
+      'Add {++one example++}{id="s1" by="AI" at="2026-04-28T12:05:00.000Z"}.\n';
+
+    expect(() =>
+      setRoughdraftReaction(markdown, { targetId: "s1", reaction: "up" }),
+    ).toThrow();
+  });
+
+  it("rejects an unknown reaction value", () => {
+    const markdown =
+      'Keep {>>open question<<}{id="c1" by="user" at="2026-04-28T12:06:00.000Z"}.\n';
+
+    expect(() =>
+      setRoughdraftReaction(markdown, {
+        targetId: "c1",
+        // @ts-expect-error invalid reaction
+        reaction: "love",
+      }),
+    ).toThrow();
   });
 });

--- a/packages/rfm/src/index.ts
+++ b/packages/rfm/src/index.ts
@@ -27,6 +27,17 @@ export interface RfmValidationResult {
 
 export type RfmReviewItemKind = "comment" | "suggestion" | "reply";
 export type RfmSuggestionKind = "addition" | "deletion" | "substitution";
+export type RfmReaction = "up" | "down" | "clarify";
+
+export const RFM_REACTIONS: readonly RfmReaction[] = ["up", "down", "clarify"];
+
+export function normalizeRfmReaction(
+  value: string | null | undefined,
+): RfmReaction | null {
+  return RFM_REACTIONS.includes(value as RfmReaction)
+    ? (value as RfmReaction)
+    : null;
+}
 
 export interface RfmReviewItem {
   id: string;
@@ -36,6 +47,7 @@ export interface RfmReviewItem {
   author: string | null;
   createdAt: string | null;
   status: string | null;
+  reaction: RfmReaction | null;
   text: string;
   originalText?: string;
   replacementText?: string;
@@ -51,6 +63,7 @@ export interface RfmReviewIndexSummary {
   replies: number;
   suggestions: number;
   unresolved: number;
+  reactions: Record<RfmReaction, number>;
 }
 
 export interface RfmReviewIndex {
@@ -79,6 +92,11 @@ export interface AppendRoughdraftDocumentCommentOptions {
 export interface MarkRoughdraftResolvedOptions {
   targetId: string;
   summary?: string;
+}
+
+export interface SetRoughdraftReactionOptions {
+  targetId: string;
+  reaction: RfmReaction | null;
 }
 
 interface Metadata {
@@ -133,6 +151,7 @@ interface YamlMetadataEntry {
   re?: string;
   status?: string;
   resolved?: string;
+  reaction?: string;
   [key: string]: unknown;
 }
 
@@ -467,6 +486,7 @@ export function extractRoughdraftReviewIndex(markdown: string): RfmReviewIndex {
       author: attrs.get("by") ?? null,
       createdAt: attrs.get("at") ?? null,
       status: attrs.get("status") ?? null,
+      reaction: normalizeRfmReaction(attrs.get("reaction")),
       text: parsed.content,
       anchorText,
       offset: parsed.offset,
@@ -491,6 +511,7 @@ export function extractRoughdraftReviewIndex(markdown: string): RfmReviewIndex {
       author: attrs.get("by") ?? null,
       createdAt: attrs.get("at") ?? null,
       status: attrs.get("status") ?? null,
+      reaction: null,
       text: parsed.text,
       originalText: parsed.originalText,
       replacementText: parsed.replacementText,
@@ -576,6 +597,9 @@ export function extractRoughdraftReviewIndex(markdown: string): RfmReviewIndex {
       author: typeof entry.by === "string" ? entry.by : null,
       createdAt: typeof entry.at === "string" ? entry.at : null,
       status: typeof entry.status === "string" ? entry.status : null,
+      reaction: normalizeRfmReaction(
+        typeof entry.reaction === "string" ? entry.reaction : null,
+      ),
       text: String(entry.body),
       offset: endmatter.offset ?? markdown.length,
       endOffset: endmatter.offset ?? markdown.length,
@@ -593,6 +617,15 @@ export function extractRoughdraftReviewIndex(markdown: string): RfmReviewIndex {
       replies: items.filter((item) => item.kind === "reply").length,
       suggestions: items.filter((item) => item.kind === "suggestion").length,
       unresolved: items.filter((item) => item.status !== "resolved").length,
+      reactions: RFM_REACTIONS.reduce(
+        (counts, reaction) => {
+          counts[reaction] = items.filter(
+            (item) => item.reaction === reaction,
+          ).length;
+          return counts;
+        },
+        { up: 0, down: 0, clarify: 0 } as Record<RfmReaction, number>,
+      ),
     },
   };
 }
@@ -711,6 +744,62 @@ export function markRoughdraftResolved(
   metadata.attrs.set("status", "resolved");
   if (options.summary) {
     metadata.attrs.set("resolved", options.summary);
+  }
+
+  return `${markdown.slice(0, metadata.offset)}${serializeMetadataAttributes(
+    Object.fromEntries(metadata.attrs),
+  )}${markdown.slice(metadata.endOffset)}`;
+}
+
+export function setRoughdraftReaction(
+  markdown: string,
+  options: SetRoughdraftReactionOptions,
+): string {
+  if (options.reaction !== null && !RFM_REACTIONS.includes(options.reaction)) {
+    throw new Error(`Unknown reaction: ${String(options.reaction)}`);
+  }
+
+  const index = extractRoughdraftReviewIndex(markdown);
+  const target = index.items.find((item) => item.id === options.targetId);
+  if (!target) {
+    throw new Error(`Review item not found: ${options.targetId}`);
+  }
+  if (target.kind === "suggestion") {
+    throw new Error(
+      `Reactions are only supported on comments: ${options.targetId}`,
+    );
+  }
+
+  const endmatter = parseRoughdraftEndmatter(markdown);
+  if (endmatter.comments.has(options.targetId)) {
+    const comments = new Map(endmatter.comments);
+    const suggestions = new Map(endmatter.suggestions);
+    const current = { ...(comments.get(options.targetId) ?? {}) };
+    if (options.reaction === null) {
+      delete current.reaction;
+    } else {
+      current.reaction = options.reaction;
+    }
+    comments.set(options.targetId, current);
+    return writeRoughdraftEndmatter(markdown, { comments, suggestions });
+  }
+
+  const metadataStart = findCanonicalMetadataStart(markdown, target.endOffset);
+  if (metadataStart === null) {
+    throw new Error(
+      `Review item has no canonical metadata: ${options.targetId}`,
+    );
+  }
+
+  const metadata = parseCanonicalMetadata(markdown, metadataStart);
+  if (!metadata) {
+    throw new Error(`Review item has invalid metadata: ${options.targetId}`);
+  }
+
+  if (options.reaction === null) {
+    metadata.attrs.delete("reaction");
+  } else {
+    metadata.attrs.set("reaction", options.reaction);
   }
 
   return `${markdown.slice(0, metadata.offset)}${serializeMetadataAttributes(
@@ -1360,4 +1449,5 @@ function findCanonicalMetadataStart(
 function isValidDateTime(value: string): boolean {
   return dateTimePattern.test(value) && !Number.isNaN(Date.parse(value));
 }
+
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";

--- a/packages/server/src/review-events.test.ts
+++ b/packages/server/src/review-events.test.ts
@@ -13,6 +13,7 @@ function eventInput(documentPath = "/tmp/project/draft.md") {
       replies: 0,
       suggestions: 1,
       unresolved: 2,
+      reactions: { up: 0, down: 0, clarify: 0 },
     },
   };
 }

--- a/packages/server/src/review-events.ts
+++ b/packages/server/src/review-events.ts
@@ -1,17 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
+import type { RfmReviewIndexSummary } from "@roughdraft/rfm";
 
 export interface ReviewCompletedEventInput {
   documentPath: string;
   projectPath: string;
   relativePath: string;
   version: string;
-  summary: {
-    comments: number;
-    replies: number;
-    suggestions: number;
-    unresolved: number;
-  };
+  summary: RfmReviewIndexSummary;
   overallComment?: string;
 }
 


### PR DESCRIPTION
## What

Adds a lightweight **reaction** to review comments — 👍 thumbs up, 👎 thumbs down, or ❓ needs-clarification — so an agent reading back a review learns the reviewer's stance on a comment without requiring a written reply.

Reactions apply to **comments and replies only**. Suggestions keep their Accept/Reject semantics and never render reaction buttons.

## Why

Today the only signals an agent gets back from a review are resolved/unresolved status, replies, and suggestion accept/reject. A reviewer who simply agrees or disagrees with an agent's comment has to type a reply. A one-click reaction captures that stance and surfaces it in the review index the agent consumes.

## How

- **`rfm`** — `reaction` field (`up` | `down` | `clarify` | `null`) on review items; `setRoughdraftReaction()` mutation; parse + serialize for both inline metadata (`reaction="up"`) and YAML endmatter (`reaction: up`); a `summary.reactions` tally (`{ up, down, clarify }`) on the review index. Unknown values are ignored, not rejected.
- **`app`** — reaction action buttons rendered in the comment action row (lucide `ThumbsUp` / `ThumbsDown` / `MessageCircleQuestion`, matching the existing reply/edit/delete icons), wired through both the comment rail and the review rail. Clicking an active reaction toggles it off. Buttons are gated to comments — suggestions never show them.
- **`server`** — `review.completed` events carry `summary.reactions`, so an agent watching for Done Reviewing sees the tally straight from the completion event (per-item reactions remain available via the review index / pending-feedback endpoints).
- **`spec`** — documents the `reaction` metadata attribute and the round-trip rules.

## Persistence / round-trip

Inline:
```markdown
{>>Should we keep this?<<}{id="c1" by="user" at="…" reaction="up"}
```
Endmatter:
```markdown
{>>Should we keep this?<<}{#c1}

---
comments:
  c1:
    by: user
    at: "…"
    reaction: up
```

## Testing

- `pnpm test` — 393 pass (rfm 38, app 235, server 120)
- `pnpm lint`, `pnpm build`, `pnpm test:selectors` — clean
- Manual end-to-end against a live build: click persists to the file, survives reload, toggles off; suggestions show no reaction buttons; `extractRoughdraftReviewIndex()` and the MCP review tools return the reaction per item, and `summary.reactions` tallies correctly.

New reaction buttons carry `data-testid` attributes (`comment-{variant}-{id}-reaction-{up|down|clarify}`).