### PR TITLE
feat: render LaTeX math with KaTeX

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,40 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(make:*)",
+      "Bash(grep:*)",
+      "Bash(rg:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(wc:*)",
+      "Bash(ls:*)",
+      "Bash(sed -n:*)",
+      "Bash(lsof:*)",
+      "Bash(ps:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git rev-list:*)",
+      "Bash(git check-ignore:*)",
+      "Bash(git merge-base:*)",
+      "Bash(git branch:*)",
+      "Bash(git remote -v)",
+      "Bash(git fetch:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)"
+    ],
+    "deny": [
+      "Bash(awk:*)",
+      "Bash(sed -i:*)",
+      "Edit(./Makefile)",
+      "Write(./Makefile)",
+      "MultiEdit(./Makefile)",
+      "Edit(./scripts/dev/verify-ui.mjs)",
+      "Write(./scripts/dev/verify-ui.mjs)",
+      "MultiEdit(./scripts/dev/verify-ui.mjs)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,10 @@ sandbox
 !.codex/skills/
 !.codex/skills/**
 .conductor/
-.claude/
+.claude/*
+# Keep the shared permission policy under version control; everything else in
+# .claude/ (settings.local.json, transcripts, etc.) stays ignored.
+!.claude/settings.json
 .agents/
 .mcp.json
 .roughdraft-state

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,44 @@ pnpm dev:install-cli
 
 Then recompute `roughdraft_cmd` and use it.
 
+## Trusted Commands (avoid permission prompts)
+
+`.claude/settings.json` defines a small trusted command surface so routine work
+runs without prompts. Prefer these paths over raw equivalents — the raw forms
+are intentionally left prompting (or denied), so reaching for them just stalls
+on a confirmation:
+
+- **Tests / build / lint / typecheck** — use the `Makefile`: `make check`,
+  `make test`, `make test-app`, `make test-server`, `make lint`, `make typecheck`,
+  `make build`, `make build-app`. Run raw `pnpm`/`vitest` only for something the
+  Makefile does not cover.
+- **Dev server** — `make rd-start` / `make rd-stop` / `make rd-status` /
+  `make rd-restart` (the last one also clears an unmanaged process on `:7373`).
+- **Browser checks** — `make verify-ui URL=... [TESTIDS=a,b]` (wraps
+  `scripts/dev/verify-ui.mjs`). Don't hand-write one-off `node *.mjs` playwright
+  scripts.
+- **Dev-server API** — `make api Q='/api/...'` or `make api-files P=relative/path`
+  instead of raw `curl`.
+- **Search / read** — `grep`/`rg`, `cat`/`head`/`tail`, `ls`, `sed -n`,
+  `lsof`/`ps`, and `git` (`status`, `diff`, `log`, `show`, `rev-parse`, `add`,
+  `commit`, …) are allowed.
+
+Permission rules match the **command-string prefix**, so invocation form matters:
+- Run `git` bare from the repo root (`git commit …`, `git add …`), not
+  `git -C <path> …` — the latter starts with `git -C`, misses the `git commit`
+  prefix, and re-prompts. (Allowing `git -C:*` is rejected: it would permit any
+  git subcommand in any repo.)
+- Don't chain an allowed command with an un-allowed one (`make … && echo …`):
+  each segment of a `;`/`&&`/`|` chain is checked separately, so one
+  un-allowlisted segment (e.g. bare `echo`) re-prompts the whole line.
+
+Deliberately **denied** (do not attempt — wrap the safe intent in a Makefile
+target or `scripts/dev/` helper instead): `awk` (can `system()`), `sed -i`
+(in-place mutation). The `Makefile` and `scripts/dev/verify-ui.mjs` are
+**write-denied** so the trusted surface can't be silently widened — to add a
+target or edit the script, ask the user to lift that deny for the one edit, then
+restore it. When you add a new target or wrapper, update this section too.
+
 ## Pull Request Workflow
 
 Before creating or updating a PR:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,10 @@ Preferred flow:
 "$roughdraft_cmd" open "/absolute/path/to/file.md"
 ```
 
+`open` prints the document URL and waits for Done Reviewing; it does **not**
+launch a browser by default (the user opens the printed URL themselves). Pass
+`--open` to launch a browser, or `--print-url` to print the URL and exit.
+
 4. After the user finishes reviewing in Roughdraft, read the markdown file from disk and make the requested changes there.
 
 Useful commands:

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ install: ## Install workspace dependencies
 build: ## Build rfm, app, and server
 	pnpm build
 
+.PHONY: build-app
+build-app: ## Build only the app package
+	pnpm --filter @roughdraft/app build
+
 .PHONY: build-global
 build-global: build ## Build and restart the global roughdraft server
 			-roughdraft stop
@@ -93,6 +97,13 @@ rd-open: ## Open a file or directory in Roughdraft (PATH=/abs/path)
 	@test -n "$(PATH_)" || { echo "Usage: make rd-open PATH_=/abs/path"; exit 2; }
 	"$(RD)" open "$(PATH_)"
 
+.PHONY: rd-restart
+rd-restart: ## Stop (incl. an unmanaged process on :7373) and start the dev server
+	-"$(RD)" stop
+	@pids="$$(lsof -ti tcp:7373 2>/dev/null)"; if [ -n "$$pids" ]; then kill $$pids; fi
+	@sleep 1
+	"$(RD)" start
+
 # --- Git (read-only) ---------------------------------------------------------
 
 .PHONY: status
@@ -109,3 +120,16 @@ diff: ## Show diff (F=path to scope, default unstaged tree)
 api-files: ## Fetch a file via the running dev server (P=relative/path)
 	@test -n "$(P)" || { echo "Usage: make api-files P=relative/path"; exit 2; }
 	curl -s "http://localhost:7373/api/files?projectPath=$(WORKTREE_ROOT)&path=$(P)"
+
+.PHONY: api
+api: ## GET an API path on the dev server (Q='/api/...'); prints status + body head
+	@test -n "$(Q)" || { echo "Usage: make api Q='/api/file-tree?projectPath=/abs/dir'"; exit 2; }
+	@curl -s -o /dev/null -w "status=%{http_code} type=%{content_type}\n" "http://localhost:7373$(Q)"
+	@curl -s "http://localhost:7373$(Q)" | head -20
+
+# --- Browser checks ----------------------------------------------------------
+
+.PHONY: verify-ui
+verify-ui: ## Headless browser check of a URL (URL=..., optional TESTIDS=a,b)
+	@test -n "$(URL)" || { echo "Usage: make verify-ui URL=http://localhost:7373/... [TESTIDS=a,b]"; exit 2; }
+	node scripts/dev/verify-ui.mjs "$(URL)" "$(TESTIDS)"

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,11 @@ install: ## Install workspace dependencies
 build: ## Build rfm, app, and server
 	pnpm build
 
+.PHONY: build-global
+build-global: build ## Build and restart the global roughdraft server
+			-roughdraft stop
+			roughdraft start
+
 # --- Quality gates -----------------------------------------------------------
 
 .PHONY: check
@@ -87,3 +92,20 @@ rd-status: ## Show dev server status
 rd-open: ## Open a file or directory in Roughdraft (PATH=/abs/path)
 	@test -n "$(PATH_)" || { echo "Usage: make rd-open PATH_=/abs/path"; exit 2; }
 	"$(RD)" open "$(PATH_)"
+
+# --- Git (read-only) ---------------------------------------------------------
+
+.PHONY: status
+status: ## Show working tree status (short)
+	git status --short
+
+.PHONY: diff
+diff: ## Show diff (F=path to scope, default unstaged tree)
+	git diff $(F)
+
+# --- API smoke ---------------------------------------------------------------
+
+.PHONY: api-files
+api-files: ## Fetch a file via the running dev server (P=relative/path)
+	@test -n "$(P)" || { echo "Usage: make api-files P=relative/path"; exit 2; }
+	curl -s "http://localhost:7373/api/files?projectPath=$(WORKTREE_ROOT)&path=$(P)"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,89 @@
+# Roughdraft dev tasks.
+#
+# This Makefile is the explicit, reviewable surface of commands the agent runs.
+# Allow `Bash(make:*)` once and every target here runs without a prompt, while
+# you keep full control by editing the targets below.
+#
+# NODE_OPTIONS note: the local Node (22.7.0) needs --experimental-require-module
+# for jsdom-based vitest runs; the test targets set it for you.
+
+NODE_TEST_OPTIONS := NODE_OPTIONS=--experimental-require-module
+WORKTREE_ROOT := $(shell git rev-parse --show-toplevel)
+RD := roughdraft-dev-$(notdir $(WORKTREE_ROOT))
+
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## List available targets
+	@grep -hE '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) \
+		| sort \
+		| awk 'BEGIN {FS = ":.*?## "} {printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
+
+# --- Install / build ---------------------------------------------------------
+
+.PHONY: install
+install: ## Install workspace dependencies
+	pnpm install
+
+.PHONY: build
+build: ## Build rfm, app, and server
+	pnpm build
+
+# --- Quality gates -----------------------------------------------------------
+
+.PHONY: check
+check: ## Full check: lint, selectors, unit tests, build
+	$(NODE_TEST_OPTIONS) pnpm check
+
+.PHONY: lint
+lint: ## Lint with biome
+	pnpm lint
+
+.PHONY: fmt
+fmt: ## Auto-format and apply safe lint fixes
+	pnpm lint:fix
+
+.PHONY: typecheck
+typecheck: ## Type-check the app package
+	$(NODE_TEST_OPTIONS) pnpm --filter @roughdraft/app exec tsc --noEmit
+
+# --- Tests -------------------------------------------------------------------
+
+.PHONY: test
+test: ## Run all unit tests (rfm + app + server)
+	$(NODE_TEST_OPTIONS) pnpm test
+
+.PHONY: test-app
+test-app: ## Run app unit tests (pass T="name" to filter)
+	$(NODE_TEST_OPTIONS) pnpm --filter @roughdraft/app exec vitest run $(if $(T),-t "$(T)",)
+
+.PHONY: test-server
+test-server: ## Run server unit tests (pass T="name" to filter)
+	$(NODE_TEST_OPTIONS) pnpm --filter @roughdraft/server exec vitest run $(if $(T),-t "$(T)",)
+
+.PHONY: smoke
+smoke: ## Run @smoke Playwright tests (pass G="grep" to narrow)
+	pnpm exec playwright test --config packages/app/playwright.config.ts --grep "$(if $(G),$(G),@smoke)"
+
+.PHONY: e2e
+e2e: ## Run the full Playwright e2e suite
+	pnpm test:e2e
+
+# --- Roughdraft dev CLI ------------------------------------------------------
+
+.PHONY: rd-start
+rd-start: ## Start the worktree dev server
+	"$(RD)" start
+
+.PHONY: rd-stop
+rd-stop: ## Stop the worktree dev server
+	"$(RD)" stop
+
+.PHONY: rd-status
+rd-status: ## Show dev server status
+	"$(RD)" status
+
+.PHONY: rd-open
+rd-open: ## Open a file or directory in Roughdraft (PATH=/abs/path)
+	@test -n "$(PATH_)" || { echo "Usage: make rd-open PATH_=/abs/path"; exit 2; }
+	"$(RD)" open "$(PATH_)"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ Roughdraft is a local-first markdown editor and viewer that runs on your compute
 Its job is to make markdown files easy to open, read, edit, review, and discuss with your AI agent without moving them into a proprietary format or a hosted app.
 
 Roughdraft opens a single markdown file directly for CriticMarkup comments and suggested changes.
+## What's different in this fork
+This is a fork of [Lex-Inc/roughdraft](https://github.com/Lex-Inc/roughdraft). It keeps everything upstream does and adds directory browsing plus read-only viewing for non-Markdown files, so you can review a whole folder — not just one file at a time.
+
+- **Directory review mode** — `roughdraft open <dir>` opens a folder and shows a persistent sidebar tree, so you can move between files without re-invoking the CLI. The tree live-refreshes while you browse.
+- **Browse every file, not just Markdown** — the tree lists all files. Markdown still opens in the full review/comment/edit workspace; every other file opens **read-only**: code with syntax highlighting, plain text as-is, images as a preview, and other binaries as a "preview unavailable" stub. Non-Markdown files can't be commented on, edited, or saved.
+- **Reload from disk** — an always-available button in the document header re-reads the open file from disk, and file reads are no longer HTTP-cached, so external edits (e.g. by your agent) show up reliably.
+- **Mermaid diagrams** — fenced ` ```mermaid ` blocks render as diagrams in the rich-text view.
+
+Bug fixes carried in this fork:
+
+- Files now load for projects opened under a dot-directory (e.g. `~/.claude/skills/...`); upstream's `/api/files` 404'd every file in such projects.
+- Tables whose rows contain two or more code-span links no longer disappear from the rich-text view.
 ## How it works
 - **Local-first markdown editor** — Open normal `.md` files from your machine and edit them directly
   

--- a/biome.json
+++ b/biome.json
@@ -3,6 +3,7 @@
   "files": {
     "includes": [
       "**",
+      "!.claude",
       "!.context",
       "!.roughdraft-state",
       "!**/coverage",

--- a/docs/adr/0005-directory-review-mode.md
+++ b/docs/adr/0005-directory-review-mode.md
@@ -1,0 +1,42 @@
+# 0005: Directory Review Mode
+
+## Context
+
+ADR 0001 establishes a single Markdown file as Roughdraft's unit of work and
+explicitly excludes a multi-document workspace. In practice, reviewers often
+keep a set of related Markdown files in one directory (plans, specs, notes) and
+want to move between them without re-invoking the CLI for each file.
+
+## Decision
+
+Roughdraft may open a directory as a **navigation context** over the same
+single-file unit of work. `roughdraft open <dir>` shows a read-only tree of the
+Markdown files under that directory in a persistent sidebar; selecting a file
+opens it in the existing single-document workspace, where review, edit, save,
+and "Done" behave exactly as in single-file mode.
+
+The directory is addressed in the app by a `dir` query parameter that scopes the
+sidebar tree and the server's `projectPath`. A selected file is still carried by
+the existing `path` parameter. Single-file mode (`?path=` with no `?dir=`) is
+unchanged.
+
+## Consequences
+
+The file tree is built on demand from the filesystem on each request. The server
+resolves and reads one Markdown file at a time within the directory's local-file
+boundary; the existing path-boundary checks continue to apply with the directory
+as the project root. No persistent index, database, or sync is introduced. One
+file is open at a time; switching files tears down the previous file's watcher
+and save state.
+
+## What This Explicitly Does Not Mean
+
+This does not make Roughdraft a vault manager, note database, git client, desktop
+shell, or general multi-document editor. There is no project-wide search,
+cross-file operation, persistent project model, or background indexing. The
+directory tree is a transient, read-only listing that exists only to navigate to
+the next single file to review.
+
+This refines — it does not override — ADR 0001: the unit of work is still one
+Markdown file. The directory is only the context from which that one file is
+chosen.

--- a/docs/adr/0005-directory-review-mode.md
+++ b/docs/adr/0005-directory-review-mode.md
@@ -1,42 +1,18 @@
 # 0005: Directory Review Mode
-
 ## Context
-
-ADR 0001 establishes a single Markdown file as Roughdraft's unit of work and
-explicitly excludes a multi-document workspace. In practice, reviewers often
-keep a set of related Markdown files in one directory (plans, specs, notes) and
-want to move between them without re-invoking the CLI for each file.
-
+ADR 0001 establishes a single Markdown file as Roughdraft's unit of work and explicitly excludes a multi-document workspace. In practice, reviewers often keep a set of related Markdown files in one directory (plans, specs, notes) and want to move between them without re-invoking the CLI for each file.
 ## Decision
+Roughdraft may open a directory as a **navigation context** over the same single-file unit of work. `roughdraft open <dir>` shows a read-only tree of the directory's contents in a persistent sidebar; selecting a file opens it.
 
-Roughdraft may open a directory as a **navigation context** over the same
-single-file unit of work. `roughdraft open <dir>` shows a read-only tree of the
-Markdown files under that directory in a persistent sidebar; selecting a file
-opens it in the existing single-document workspace, where review, edit, save,
-and "Done" behave exactly as in single-file mode.
+The tree lists **all** files under the directory, not only Markdown, so the directory can be browsed in full. How a selected file opens depends on its type:
 
-The directory is addressed in the app by a `dir` query parameter that scopes the
-sidebar tree and the server's `projectPath`. A selected file is still carried by
-the existing `path` parameter. Single-file mode (`?path=` with no `?dir=`) is
-unchanged.
+- **Markdown** (`.md`) opens in the existing single-document workspace, where review, edit, comment, save, and "Done" behave exactly as in single-file mode. Markdown remains the only interactive unit of work.
+- **Every other file opens read-only.** Code renders with on-demand syntax highlighting, plain text renders as monospaced text, images render as a preview, and other binaries fall back to a "preview unavailable" stub. Read-only files cannot be commented on, edited, or saved.
 
+The directory is addressed in the app by a `dir` query parameter that scopes the sidebar tree and the server's `projectPath`. A selected file is still carried by the existing `path` parameter. Single-file mode (`?path=` with no `?dir=`) is unchanged.
 ## Consequences
-
-The file tree is built on demand from the filesystem on each request. The server
-resolves and reads one Markdown file at a time within the directory's local-file
-boundary; the existing path-boundary checks continue to apply with the directory
-as the project root. No persistent index, database, or sync is introduced. One
-file is open at a time; switching files tears down the previous file's watcher
-and save state.
-
+The file tree is built on demand from the filesystem on each request. The server resolves and reads one file at a time within the directory's local-file boundary; the existing path-boundary checks continue to apply with the directory as the project root. Markdown is still served by the `.md`-gated `/api/markdown-file` endpoint; read-only files reuse the existing `/api/files` byte-serving endpoint, so no new server surface is introduced. File type is classified on the client by extension. No persistent index, database, or sync is introduced. One file is open at a time; markdown and the read-only viewer are mutually exclusive, and switching files tears down the previous file's watcher and save state.
 ## What This Explicitly Does Not Mean
+This does not make Roughdraft a vault manager, note database, git client, desktop shell, or general multi-document editor. There is no project-wide search, cross-file operation, persistent project model, or background indexing. The directory tree is a transient, read-only listing that exists only to navigate to the next file to open. Non-Markdown files are shown for context and reference only; they are never an editable or reviewable unit of work.
 
-This does not make Roughdraft a vault manager, note database, git client, desktop
-shell, or general multi-document editor. There is no project-wide search,
-cross-file operation, persistent project model, or background indexing. The
-directory tree is a transient, read-only listing that exists only to navigate to
-the next single file to review.
-
-This refines — it does not override — ADR 0001: the unit of work is still one
-Markdown file. The directory is only the context from which that one file is
-chosen.
+This refines — it does not override — ADR 0001: the editable, reviewable unit of work is still one Markdown file. Other files are read-only context, and the directory is only the place from which a file is chosen.

--- a/docs/spec/ui-state-screenshot-guide.md
+++ b/docs/spec/ui-state-screenshot-guide.md
@@ -66,6 +66,15 @@ Paragraph with **bold**, [link](https://example.com), `inline code`.
 ```markdown
 # Fenced examples This page should not show a review rail just because examples appear inside code fences. ```text example {++inserted++} {--deleted--} {~~old~>new~~} ```
 ```
+### Math Document
+```markdown
+# Math rendering
+Inline LaTeX such as $BP \cdot \exp(\sum_{n=1}^{N} w_n \ln p_n)$ renders via KaTeX, while a lone $5 stays literal text.
+
+$$
+F = \frac{(1 + \beta^2) \cdot P \cdot R}{R + \beta^2 \cdot P}
+$$
+```
 ## Capture Matrix
 | Area | State | How to reach it | Useful selectors | Notes |
 | --- | --- | --- | --- | --- |
@@ -110,6 +119,7 @@ Paragraph with **bold**, [link](https://example.com), `inline code`.
 | Editor | Selection menu on suggestion | Select existing suggestion text | `selection-menu-action-accept-suggestion`, `selection-menu-action-reject-suggestion` | Requires review fixture. |
 | Editor | Link popover | Click a link or choose Link from selection menu | `link-popover`, `link-url-input`, `link-action-open`, `link-action-delete` | Use the plain fixture link. |
 | Editor | Context menu | Right-click in rich editor | `editor-context-menu` | Capture comment, suggestion, paste, and paste-markdown actions. |
+| Editor | LaTeX math | Open the Math fixture in rich and code modes | `math-inline`, `math-block` | Inline `$…$` and block `$$…$$` render via KaTeX; a lone `$5` stays literal. Capture rich-text rendering and the raw `$…$` source in the code editor. |
 | Review rail | Comments | Open review fixture in rich mode | `document-review-rail`, `comment-thread-root` | Thread containers use `data-comment-thread-container="true"`. |
 | Review rail | Suggestions | Open review fixture in rich mode | `suggestion-thread-s1`, `suggestion-thread-s2`, `suggestion-thread-s3` | Thread containers use `data-suggestion-thread-container="true"`. |
 | Review rail | Draft suggestion | Select text and choose a suggestion action | `draft-suggestion-thread`, `draft-suggestion-editor` | Capture dismiss/cancel/apply actions. |

--- a/docs/spec/ui-state-screenshot-guide.md
+++ b/docs/spec/ui-state-screenshot-guide.md
@@ -60,37 +60,11 @@ Paragraph with **bold**, [link](https://example.com), `inline code`.
 ```
 ### Review Document
 ```markdown
-# Review document {==Select this sentence==}{>>Root comment<<}{#root} This sentence includes {++clearer wording++}{#s1}. Replace {~~old phrase~>new phrase~~}{#s2} and remove {--dead text--}{#s3}.
-
----
-comments:
-  root:
-    by: Nora
-    at: "2026-04-28T12:00:00.000Z"
-  child:
-    body: Nested reply
-    by: AI
-    at: "2026-04-28T12:01:00.000Z"
-    re: root
-  c1:
-    body: Looks good.
-    by: Nora
-    at: "2026-04-28T12:03:00.000Z"
-    re: s1
-suggestions:
-  s1:
-    by: AI
-    at: "2026-04-28T12:02:00.000Z"
-  s2:
-    by: AI
-    at: "2026-04-28T12:04:00.000Z"
-  s3:
-    by: AI
-    at: "2026-04-28T12:05:00.000Z"
+# Review document Select this sentence This sentence includes {++clearer wording++}{#s1}. Replace {~~old phrase~>new phrase~~}{#s2} and remove {--dead text--}{#s3}. --- comments: root: by: Nora at: "2026-04-28T12:00:00.000Z" child: body: Nested reply by: AI at: "2026-04-28T12:01:00.000Z" re: root c1: body: Looks good. by: Nora at: "2026-04-28T12:03:00.000Z" re: s1 suggestions: s1: by: AI at: "2026-04-28T12:02:00.000Z" s2: by: AI at: "2026-04-28T12:04:00.000Z" s3: by: AI at: "2026-04-28T12:05:00.000Z"
 ```
 ### Fenced CriticMarkup Document
 ```markdown
-# Fenced examples This page should not show a review rail just because examples appear inside code fences. ```text {==example==}{>>comment<<}{#c1} {++inserted++} {--deleted--} {~~old~>new~~} ```
+# Fenced examples This page should not show a review rail just because examples appear inside code fences. ```text example {++inserted++} {--deleted--} {~~old~>new~~} ```
 ```
 ## Capture Matrix
 | Area | State | How to reach it | Useful selectors | Notes |
@@ -142,29 +116,24 @@ suggestions:
 | Comment editor | Reply editing | Use a reply action | `comment-rail-child-editor` | Useful for nested thread spacing. |
 | Code mode | Review rail present | Open review fixture with `?editor=code` | `page-card-code`, `markdown-code-editor` | Confirms code editor and rail can coexist. |
 | Code mode | Review rail absent | Open fenced fixture with `?editor=code` | `page-card-code`, `markdown-code-editor` | Confirms fenced CriticMarkup alone does not create review rail. |
-| Directory | Sidebar, no file selected | Open URL with `?dir=<directory>` (or `rd open <dir>`) | `role=navigation[name="Directory files"]`, empty-state text | Empty state copy: `Select a Markdown file from the sidebar to review it.` |
-| Directory | File open from sidebar | In directory mode, click a file in the tree | `role=navigation[name="Directory files"]`, `rich-text-editor` | Active file button has `aria-current="true"`; URL gains `&path=`. |
-| Directory | Nested folder expanded | In directory mode with nested `.md` files | `role=navigation[name="Directory files"]` | Folders toggle open/closed; capture an expanded subfolder with a highlighted active file. |
-| Directory | Empty directory | Open `?dir=<dir>` with no `.md` files | `role=navigation[name="Directory files"]` | Sidebar copy: `No Markdown files here.` |
+| Directory | Sidebar, no file selected | Open URL with `?dir=<directory>` (or `rd open <dir>`) | `role=navigation[name="Directory files"]`, empty-state text | Empty state copy: `Select a file from the sidebar. Markdown opens for review; other files open read-only.` |
+| Directory | Mixed file types in tree | Open `?dir=<dir>` containing `.md`, code, image, and binary files | `role=navigation[name="Directory files"]` | Tree lists all files; icons differ by kind (markdown/text, code, image, other). |
+| Directory | Markdown file open | In directory mode, click a `.md` file | `role=navigation[name="Directory files"]`, `rich-text-editor` | Active file button has `aria-current="true"`; URL gains `&path=`. |
+| Directory | Code file read-only viewer | In directory mode, click a source file (e.g. `.ts`) | `file-viewer-workspace`, `file-viewer-code`, `file-viewer-readonly-badge` | Syntax-highlighted, `Read-only` badge, no comment/edit affordances. |
+| Directory | Text file read-only viewer | In directory mode, click a `.txt`/`LICENSE` file | `file-viewer-workspace`, `file-viewer-code` | Monospaced plain text, no highlighting language matched. |
+| Directory | Image preview | In directory mode, click an image (e.g. `.png`) | `file-viewer-workspace`, `file-viewer-image` | Centered image preview, `Read-only` badge. |
+| Directory | Binary stub | In directory mode, click a binary (e.g. `.pdf`/`.zip`) | `file-viewer-workspace`, `file-viewer-stub` | Stub copy: `Preview unavailable`. |
+| Directory | Nested folder expanded | In directory mode with nested files | `role=navigation[name="Directory files"]` | Folders toggle open/closed; capture an expanded subfolder with a highlighted active file. |
+| Directory | Empty directory | Open `?dir=<dir>` with no files | `role=navigation[name="Directory files"]` | Sidebar copy: `No files here.` |
 | Error/home fallback | Non-Markdown path | Open URL with `?path=/tmp/file.txt` | homepage error message | Copy: `Roughdraft now opens one .md file at a time.` |
 | Error/home fallback | Missing/unloadable path | Open URL with invalid markdown path through local backend | homepage error message | Captures load-error homepage variant. |
-## Playwright Capture Skeleton
-```ts
-import { chromium, devices } from "playwright";
+## Playwright Capture Skeleton ```ts import { chromium, devices } from "playwright"; const baseUrl = process.env.ROUGHDRAFT_BASE_URL ?? "[http://127.0.0.1:5173](http://127.0.0.1:5173)"; const outDir = process.env.ROUGHDRAFT_SCREENSHOT_DIR ?? ".context/ui-state-screenshots/manual";
+const browser = await chromium.launch(); const desktop = await browser.newPage({ viewport: { width: 1440, height: 1000 } }); await desktop.goto(`${baseUrl}/`); await desktop.screenshot({ path: `${outDir}/01-home-desktop.png`, fullPage: true });
 
-const baseUrl = process.env.ROUGHDRAFT_BASE_URL ?? "http://127.0.0.1:5173";
-const outDir = process.env.ROUGHDRAFT_SCREENSHOT_DIR ?? ".context/ui-state-screenshots/manual";
-
-const browser = await chromium.launch();
-const desktop = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
-await desktop.goto(`${baseUrl}/`);
-await desktop.screenshot({ path: `${outDir}/01-home-desktop.png`, fullPage: true });
-
-const mobile = await browser.newPage({ ...devices["iPhone 13"] });
-await mobile.goto(`${baseUrl}/`);
-await mobile.screenshot({ path: `${outDir}/01-home-mobile.png`, fullPage: true });
+const mobile = await browser.newPage({ ...devices["iPhone 13"] }); await mobile.goto(`${baseUrl}/`); await mobile.screenshot({ path: `${outDir}/01-home-mobile.png`, fullPage: true });
 
 await browser.close();
+
 ```
 
 For interaction-heavy states, prefer selectors over coordinates. The current code has stable `data-testid` hooks for the homepage storyboard, editor view toggle, mode trigger, conflict banner/actions, review rail, rich editor, code editor, selection menu, link popover, and context menu.
@@ -197,3 +166,4 @@ The most reliable long-term solution is a dedicated screenshot harness route or 
 - Capture both rich-text and code editor for document states that affect the editor surface or review rail.
   
 - Keep screenshots in `.context/` unless the run is intentionally being committed as visual documentation.
+```

--- a/docs/spec/ui-state-screenshot-guide.md
+++ b/docs/spec/ui-state-screenshot-guide.md
@@ -90,6 +90,7 @@ Paragraph with **bold**, [link](https://example.com), `inline code`.
 | Document | Editing mode | Open mode menu and choose Editing | `document-mode-trigger` | Normal edit behavior. |
 | Document | Suggesting mode | Open mode menu and choose Suggesting | `document-mode-trigger` | Selection actions should create suggestions instead of direct edits. |
 | Document | Viewing mode | Open mode menu and choose Viewing | `document-mode-trigger` | Editing controls should look non-editable. |
+| Document | Reload from disk | Click the reload control in the header | `document-reload-button` | Always available; re-reads the file from disk (bypasses HTTP cache). Tooltip/label `Reload from disk`. |
 | Document | Save status: saved | Any clean document after autosave | `document-save-status` | Checkmark should sit next to the filename and fade out over 2 seconds; accessible label remains `Saved`. |
 | Document | Save status: unsaved | Type in a local document before save completes | `document-save-status` | Spinner-only pending state; accessible label is `Unsaved changes`. Transient; often easier with save throttling or network mocking. |
 | Document | Save status: saving | Type and capture during autosave | `document-save-status` | Spinner-only pending state; accessible label is `Saving`. Transient; easiest with mocked delayed save. |

--- a/docs/spec/ui-state-screenshot-guide.md
+++ b/docs/spec/ui-state-screenshot-guide.md
@@ -142,6 +142,10 @@ suggestions:
 | Comment editor | Reply editing | Use a reply action | `comment-rail-child-editor` | Useful for nested thread spacing. |
 | Code mode | Review rail present | Open review fixture with `?editor=code` | `page-card-code`, `markdown-code-editor` | Confirms code editor and rail can coexist. |
 | Code mode | Review rail absent | Open fenced fixture with `?editor=code` | `page-card-code`, `markdown-code-editor` | Confirms fenced CriticMarkup alone does not create review rail. |
+| Directory | Sidebar, no file selected | Open URL with `?dir=<directory>` (or `rd open <dir>`) | `role=navigation[name="Directory files"]`, empty-state text | Empty state copy: `Select a Markdown file from the sidebar to review it.` |
+| Directory | File open from sidebar | In directory mode, click a file in the tree | `role=navigation[name="Directory files"]`, `rich-text-editor` | Active file button has `aria-current="true"`; URL gains `&path=`. |
+| Directory | Nested folder expanded | In directory mode with nested `.md` files | `role=navigation[name="Directory files"]` | Folders toggle open/closed; capture an expanded subfolder with a highlighted active file. |
+| Directory | Empty directory | Open `?dir=<dir>` with no `.md` files | `role=navigation[name="Directory files"]` | Sidebar copy: `No Markdown files here.` |
 | Error/home fallback | Non-Markdown path | Open URL with `?path=/tmp/file.txt` | homepage error message | Copy: `Roughdraft now opens one .md file at a time.` |
 | Error/home fallback | Missing/unloadable path | Open URL with invalid markdown path through local backend | homepage error message | Captures load-error homepage variant. |
 ## Playwright Capture Skeleton

--- a/packages/app/e2e/directory-browse.spec.ts
+++ b/packages/app/e2e/directory-browse.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test";
+import {
+  createMarkdownProject,
+  logE2eEvent,
+  removeMarkdownProject,
+  writeProjectFile,
+} from "./helpers";
+
+test.describe("browsing a directory of markdown files", () => {
+  let projectDir: string;
+
+  test.beforeEach(() => {
+    projectDir = createMarkdownProject("directory-browse");
+  });
+
+  test.afterEach(() => {
+    removeMarkdownProject(projectDir);
+  });
+
+  test("lists, opens, switches, and navigates back between files @smoke", async ({
+    page,
+  }) => {
+    writeProjectFile(projectDir, "alpha.md", "# Alpha\n\nAlpha body text.\n");
+    writeProjectFile(
+      projectDir,
+      "notes/beta.md",
+      "# Beta\n\nBeta body text.\n",
+    );
+
+    await page.goto(`/?${new URLSearchParams({ dir: projectDir }).toString()}`);
+
+    // The tree lists both the top-level file and the nested folder.
+    await expect(page.getByTestId("directory-file-alpha.md")).toBeVisible();
+    await expect(page.getByTestId("directory-folder-notes")).toBeVisible();
+    await expect(
+      page.getByTestId("directory-file-notes/beta.md"),
+    ).toBeVisible();
+
+    // No file selected yet.
+    await expect(page.getByTestId("directory-empty-state")).toBeVisible();
+
+    // Open the top-level file.
+    await page.getByTestId("directory-file-alpha.md").click();
+    const editor = page.getByTestId("rich-text-editor");
+    await expect(editor).toContainText("Alpha body text.");
+    await expect(page).toHaveURL(/path=.*alpha\.md/);
+
+    // Switch to the nested file.
+    await page.getByTestId("directory-file-notes/beta.md").click();
+    await expect(editor).toContainText("Beta body text.");
+    await expect(page).toHaveURL(/path=.*beta\.md/);
+
+    // Browser back returns to the previously opened file.
+    await page.goBack();
+    await expect(editor).toContainText("Alpha body text.");
+    await expect(page).toHaveURL(/path=.*alpha\.md/);
+
+    logE2eEvent("directory-browse.navigated", {
+      projectDir,
+      files: ["alpha.md", "notes/beta.md"],
+    });
+  });
+});

--- a/packages/app/e2e/directory-browse.spec.ts
+++ b/packages/app/e2e/directory-browse.spec.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import { expect, test } from "@playwright/test";
 import {
+  appendInCodeEditor,
   codeEditor,
   createMarkdownProject,
   logE2eEvent,
@@ -109,5 +110,39 @@ test.describe("browsing a directory of markdown files", () => {
     });
 
     logE2eEvent("directory-browse.live-file", { projectDir, file: "alpha.md" });
+  });
+
+  test("switches files even when the current file has unsaved edits @smoke", async ({
+    page,
+  }) => {
+    const alpha = writeProjectFile(
+      projectDir,
+      "alpha.md",
+      "# Alpha\n\nAlpha body.\n",
+    );
+    writeProjectFile(projectDir, "beta.md", "# Beta\n\nBeta body.\n");
+
+    await page.goto(
+      `/?${new URLSearchParams({
+        dir: projectDir,
+        path: alpha,
+        editor: "code",
+      }).toString()}`,
+    );
+    await expect(codeEditor(page)).toContainText("Alpha body.");
+
+    // Leave an unsaved local edit in the current file.
+    await appendInCodeEditor(page, "\nLocal unsaved edit.\n");
+
+    // Switching files must still work (no blocking confirm dialog).
+    await page.getByTestId("directory-file-beta.md").click();
+    await expect(codeEditor(page)).toContainText("Beta body.");
+    await expect(page).toHaveURL(/path=.*beta\.md/);
+
+    logE2eEvent("directory-browse.switch-with-unsaved", {
+      projectDir,
+      from: "alpha.md",
+      to: "beta.md",
+    });
   });
 });

--- a/packages/app/e2e/directory-browse.spec.ts
+++ b/packages/app/e2e/directory-browse.spec.ts
@@ -145,4 +145,24 @@ test.describe("browsing a directory of markdown files", () => {
       to: "beta.md",
     });
   });
+
+  test("reuses an existing window for a repeated directory open request @smoke", async ({
+    page,
+  }) => {
+    writeProjectFile(projectDir, "alpha.md", "# Alpha\n");
+
+    await page.goto(`/?${new URLSearchParams({ dir: projectDir }).toString()}`);
+    await expect(page.getByTestId("directory-file-alpha.md")).toBeVisible();
+
+    // The CLI keys the open request on the directory path.
+    const targetUrl = `/?${new URLSearchParams({ dir: projectDir }).toString()}`;
+    const response = await page.request.post("/api/open-request", {
+      data: { path: projectDir, url: targetUrl },
+    });
+
+    expect(response.ok()).toBe(true);
+    await expect(response.json()).resolves.toEqual({ delivered: true });
+
+    logE2eEvent("directory-browse.reused-window", { projectDir });
+  });
 });

--- a/packages/app/e2e/directory-browse.spec.ts
+++ b/packages/app/e2e/directory-browse.spec.ts
@@ -1,5 +1,7 @@
+import fs from "node:fs";
 import { expect, test } from "@playwright/test";
 import {
+  codeEditor,
   createMarkdownProject,
   logE2eEvent,
   removeMarkdownProject,
@@ -59,5 +61,53 @@ test.describe("browsing a directory of markdown files", () => {
       projectDir,
       files: ["alpha.md", "notes/beta.md"],
     });
+  });
+
+  test("shows markdown files created on disk after the directory loads @smoke", async ({
+    page,
+  }) => {
+    writeProjectFile(projectDir, "alpha.md", "# Alpha\n");
+
+    await page.goto(`/?${new URLSearchParams({ dir: projectDir }).toString()}`);
+    await expect(page.getByTestId("directory-file-alpha.md")).toBeVisible();
+
+    // A coding agent (or any process) writes a new file into the directory.
+    writeProjectFile(projectDir, "gamma.md", "# Gamma\n");
+
+    await expect(page.getByTestId("directory-file-gamma.md")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    logE2eEvent("directory-browse.live-tree", {
+      projectDir,
+      added: "gamma.md",
+    });
+  });
+
+  test("live-reloads the open file when it changes on disk @smoke", async ({
+    page,
+  }) => {
+    const filePath = writeProjectFile(
+      projectDir,
+      "alpha.md",
+      "# Alpha\n\nOriginal body.\n",
+    );
+
+    const params = new URLSearchParams({
+      dir: projectDir,
+      path: filePath,
+      editor: "code",
+    });
+    await page.goto(`/?${params.toString()}`);
+    await expect(codeEditor(page)).toContainText("Original body.");
+
+    // The file is rewritten on disk while the browser copy is clean.
+    fs.writeFileSync(filePath, "# Alpha\n\nUpdated body.\n");
+
+    await expect(codeEditor(page)).toContainText("Updated body.", {
+      timeout: 10_000,
+    });
+
+    logE2eEvent("directory-browse.live-file", { projectDir, file: "alpha.md" });
   });
 });

--- a/packages/app/e2e/links-and-layout.spec.ts
+++ b/packages/app/e2e/links-and-layout.spec.ts
@@ -71,17 +71,50 @@ test.describe("markdown links and layout", () => {
     await expect(page).toHaveURL(/[?&]path=.*beta\.md/);
   });
 
-  test("full-width toggle persists across reloads @smoke", async ({ page }) => {
+  test("a code-span sibling link with an anchor resolves @smoke", async ({
+    page,
+  }) => {
+    writeProjectFile(
+      projectDir,
+      "index.md",
+      "# Index\n\nSee ([`AC-E`](beta.md#AC-E)) for details.\n",
+    );
+    writeProjectFile(projectDir, "beta.md", "# Beta\n\nBeta body text.\n");
+
+    await page.goto(`/?${new URLSearchParams({ dir: projectDir }).toString()}`);
+    await page.getByTestId("directory-file-index.md").click();
+
+    const editor = richTextEditor(page);
+    const link = editor.getByRole("link", { name: "AC-E" });
+    await expect(link).toBeVisible();
+
+    await link.click();
+    await expect(editor).toContainText("Beta body text.");
+    await expect(page).toHaveURL(/[?&]path=.*beta\.md/);
+  });
+
+  test("full-width toggle widens the document and persists @smoke", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
     writeProjectFile(projectDir, "alpha.md", "# Alpha\n\nAlpha body.\n");
 
     await page.goto(`/?${new URLSearchParams({ dir: projectDir }).toString()}`);
     await page.getByTestId("directory-file-alpha.md").click();
 
+    const editor = page.getByTestId("rich-text-editor");
+    await expect(editor).toBeVisible();
     const toggle = page.getByTestId("document-full-width-toggle");
     await expect(toggle).toHaveAttribute("aria-pressed", "false");
 
+    const cappedWidth = (await editor.boundingBox())?.width ?? 0;
+
+    // Enabling full width actually widens the document body, not just the chip.
     await toggle.click();
     await expect(toggle).toHaveAttribute("aria-pressed", "true");
+    await expect
+      .poll(async () => (await editor.boundingBox())?.width ?? 0)
+      .toBeGreaterThan(cappedWidth + 40);
 
     // The preference survives a full reload (persisted in localStorage).
     await page.reload();
@@ -89,5 +122,8 @@ test.describe("markdown links and layout", () => {
     await expect(
       page.getByTestId("document-full-width-toggle"),
     ).toHaveAttribute("aria-pressed", "true");
+    await expect
+      .poll(async () => (await editor.boundingBox())?.width ?? 0)
+      .toBeGreaterThan(cappedWidth + 40);
   });
 });

--- a/packages/app/e2e/links-and-layout.spec.ts
+++ b/packages/app/e2e/links-and-layout.spec.ts
@@ -93,6 +93,37 @@ test.describe("markdown links and layout", () => {
     await expect(page).toHaveURL(/[?&]path=.*beta\.md/);
   });
 
+  test("a link to an anchor in another document scrolls to it @smoke", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    const filler = Array.from(
+      { length: 60 },
+      (_, i) => `Filler line ${i}.`,
+    ).join("\n\n");
+    writeProjectFile(
+      projectDir,
+      "index.md",
+      "# Index\n\nGo to [the rule](target.md#REQ-11).\n",
+    );
+    writeProjectFile(
+      projectDir,
+      "target.md",
+      `# Target\n\n${filler}\n\n**<a id="REQ-11"></a>REQ-11** is the rule.\n`,
+    );
+
+    await page.goto(`/?${new URLSearchParams({ dir: projectDir }).toString()}`);
+    await page.getByTestId("directory-file-index.md").click();
+
+    const editor = richTextEditor(page);
+    await editor.getByRole("link", { name: "the rule" }).click();
+    await expect(page).toHaveURL(/[?&]path=.*target\.md/);
+
+    // The anchor target exists and the view scrolled to it.
+    await expect(editor.locator("#REQ-11")).toHaveCount(1);
+    await expect(editor.getByText("REQ-11 is the rule.")).toBeInViewport();
+  });
+
   test("full-width toggle widens the document and persists @smoke", async ({
     page,
   }) => {

--- a/packages/app/e2e/links-and-layout.spec.ts
+++ b/packages/app/e2e/links-and-layout.spec.ts
@@ -64,7 +64,8 @@ test.describe("markdown links and layout", () => {
     await page.getByTestId("directory-file-index.md").click();
 
     const editor = richTextEditor(page);
-    await expect(editor.locator("table")).toBeVisible();
+    // A markdown-rendered <table> has no data-testid by design.
+    await expect(editor.locator("table")).toBeVisible(); // selector-check-ignore
 
     await editor.getByRole("link", { name: "the beta doc" }).click();
     await expect(editor).toContainText("Beta body text.");
@@ -119,8 +120,9 @@ test.describe("markdown links and layout", () => {
     await editor.getByRole("link", { name: "the rule" }).click();
     await expect(page).toHaveURL(/[?&]path=.*target\.md/);
 
-    // The anchor target exists and the view scrolled to it.
-    await expect(editor.locator("#REQ-11")).toHaveCount(1);
+    // The anchor target exists and the view scrolled to it. The in-document
+    // anchor is addressed by its id, which is the behavior under test.
+    await expect(editor.locator("#REQ-11")).toHaveCount(1); // selector-check-ignore
     await expect(editor.getByText("REQ-11 is the rule.")).toBeInViewport();
   });
 

--- a/packages/app/e2e/links-and-layout.spec.ts
+++ b/packages/app/e2e/links-and-layout.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "@playwright/test";
+import {
+  createMarkdownProject,
+  removeMarkdownProject,
+  richTextEditor,
+  writeProjectFile,
+} from "./helpers";
+
+test.describe("markdown links and layout", () => {
+  let projectDir: string;
+
+  test.beforeEach(() => {
+    projectDir = createMarkdownProject("links-and-layout");
+  });
+
+  test.afterEach(() => {
+    removeMarkdownProject(projectDir);
+  });
+
+  test("clicking a sibling markdown link navigates and keeps directory mode @smoke", async ({
+    page,
+  }) => {
+    writeProjectFile(
+      projectDir,
+      "alpha.md",
+      "# Alpha\n\nSee [the beta doc](beta.md) for more.\n",
+    );
+    writeProjectFile(projectDir, "beta.md", "# Beta\n\nBeta body text.\n");
+
+    await page.goto(`/?${new URLSearchParams({ dir: projectDir }).toString()}`);
+    await page.getByTestId("directory-file-alpha.md").click();
+
+    const editor = richTextEditor(page);
+    await expect(editor).toContainText("See the beta doc for more.");
+
+    // The link is clickable and navigates to the sibling document.
+    await editor.getByRole("link", { name: "the beta doc" }).click();
+    await expect(editor).toContainText("Beta body text.");
+
+    // Navigation stays in directory mode (sidebar preserved) and points at beta.
+    await expect(page).toHaveURL(/[?&]dir=/);
+    await expect(page).toHaveURL(/[?&]path=.*beta\.md/);
+    await expect(page.getByTestId("directory-file-beta.md")).toBeVisible();
+  });
+
+  test("a sibling link inside a table cell is clickable @smoke", async ({
+    page,
+  }) => {
+    writeProjectFile(
+      projectDir,
+      "index.md",
+      [
+        "# Index",
+        "",
+        "| ID | Ref |",
+        "|----|-----|",
+        "| R1 | see [the beta doc](beta.md) |",
+        "",
+      ].join("\n"),
+    );
+    writeProjectFile(projectDir, "beta.md", "# Beta\n\nBeta body text.\n");
+
+    await page.goto(`/?${new URLSearchParams({ dir: projectDir }).toString()}`);
+    await page.getByTestId("directory-file-index.md").click();
+
+    const editor = richTextEditor(page);
+    await expect(editor.locator("table")).toBeVisible();
+
+    await editor.getByRole("link", { name: "the beta doc" }).click();
+    await expect(editor).toContainText("Beta body text.");
+    await expect(page).toHaveURL(/[?&]path=.*beta\.md/);
+  });
+
+  test("full-width toggle persists across reloads @smoke", async ({ page }) => {
+    writeProjectFile(projectDir, "alpha.md", "# Alpha\n\nAlpha body.\n");
+
+    await page.goto(`/?${new URLSearchParams({ dir: projectDir }).toString()}`);
+    await page.getByTestId("directory-file-alpha.md").click();
+
+    const toggle = page.getByTestId("document-full-width-toggle");
+    await expect(toggle).toHaveAttribute("aria-pressed", "false");
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-pressed", "true");
+
+    // The preference survives a full reload (persisted in localStorage).
+    await page.reload();
+    await page.getByTestId("directory-file-alpha.md").click();
+    await expect(
+      page.getByTestId("document-full-width-toggle"),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+});

--- a/packages/app/e2e/mermaid.spec.ts
+++ b/packages/app/e2e/mermaid.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "@playwright/test";
+import {
+  codeEditor,
+  createMarkdownProject,
+  logE2eEvent,
+  openMarkdownFile,
+  removeMarkdownProject,
+  writeProjectFile,
+} from "./helpers";
+
+const MERMAID_DOC = [
+  "# Flow",
+  "",
+  "```mermaid",
+  "graph TD;",
+  "  A-->B;",
+  "  A-->C;",
+  "```",
+  "",
+].join("\n");
+
+test.describe("mermaid diagrams", () => {
+  let projectDir: string;
+
+  test.beforeEach(() => {
+    projectDir = createMarkdownProject("mermaid");
+  });
+
+  test.afterEach(() => {
+    removeMarkdownProject(projectDir);
+  });
+
+  test("renders a mermaid code block as an SVG diagram @smoke", async ({
+    page,
+  }) => {
+    const filePath = writeProjectFile(projectDir, "diagram.md", MERMAID_DOC);
+
+    await openMarkdownFile(page, filePath);
+
+    const diagram = page.getByTestId("mermaid-diagram");
+    await expect(diagram).toBeVisible();
+    // The rendered-SVG container only appears once mermaid finishes drawing.
+    await expect(page.getByTestId("mermaid-diagram-rendered")).toBeVisible();
+    // The raw fence text must not be shown verbatim in the rendered diagram.
+    await expect(diagram).not.toContainText("graph TD;");
+
+    logE2eEvent("mermaid.rendered", { projectDir, file: "diagram.md" });
+  });
+
+  test("keeps the mermaid source editable in code mode @smoke", async ({
+    page,
+  }) => {
+    const filePath = writeProjectFile(projectDir, "source.md", MERMAID_DOC);
+
+    await openMarkdownFile(page, filePath, "code");
+
+    await expect(codeEditor(page)).toContainText("```mermaid");
+    await expect(codeEditor(page)).toContainText("graph TD;");
+
+    logE2eEvent("mermaid.source-preserved", { projectDir, file: "source.md" });
+  });
+});

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -37,6 +37,7 @@
     "codemirror": "^6.0.2",
     "lucide-react": "^1.8.0",
     "marked": "^15.0.0",
+    "mermaid": "^11.15.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "shadcn": "^4.4.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -37,6 +37,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "codemirror": "^6.0.2",
+    "katex": "^0.16.11",
     "lucide-react": "^1.8.0",
     "marked": "^15.0.0",
     "mermaid": "^11.15.0",
@@ -50,6 +51,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.4",
+    "@types/katex": "^0.16.7",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@types/turndown": "^5.0.5",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,6 +13,8 @@
     "@base-ui/react": "^1.4.1",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/lang-yaml": "^6.1.3",
+    "@codemirror/language": "^6.10.0",
+    "@codemirror/language-data": "^6.5.1",
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.41.1",
     "@fontsource-variable/inter": "^5.2.8",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -22,12 +22,13 @@ import {
   useState,
 } from "react";
 import {
+  buildLocationForDirectorySelection,
   buildLocationForDocumentEditorViewMode,
   type DocumentEditorViewMode,
   formatWorkspacePathForDisplay,
   getDocumentEditorViewModeFromLocation,
   getPathLeaf,
-  getRequestedPathState,
+  getWorkspaceState,
   joinPath,
   PREVIEW_PATH,
   ROUGHDRAFT_FLAVORED_MARKDOWN_PATH,
@@ -43,6 +44,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "./components/ui/dialog";
+import { DirectoryEmptyState, DirectorySidebar } from "./DirectoryWorkspace";
 import { DocumentWorkspace } from "./DocumentWorkspace";
 import { detectBackend } from "./detect-backend";
 import {
@@ -1471,8 +1473,10 @@ export function PreviewPage() {
 }
 
 export function App() {
-  const initialRequestedPathState = getRequestedPathState();
+  const initialRequestedPathState = getWorkspaceState();
   const [requestedPathState] = useState(initialRequestedPathState);
+  const isDirectoryMode = requestedPathState.mode === "directory";
+  const [fileTreePaths, setFileTreePaths] = useState<string[]>([]);
   const isRoughdraftFlavoredMarkdownRoute =
     window.location.pathname === ROUGHDRAFT_FLAVORED_MARKDOWN_PATH;
   const isPreviewRoute = window.location.pathname === PREVIEW_PATH;
@@ -1594,6 +1598,39 @@ export function App() {
           return;
         }
 
+        if (requestedPathState.mode === "directory") {
+          if (!requestedPathState.directoryPath) {
+            setActiveDocumentPath(null);
+            setLoadError("Could not open that directory.");
+            setLoading(false);
+            return;
+          }
+
+          if (detectedBackend.canManageProjects) {
+            await detectedBackend.openProject(requestedPathState.directoryPath);
+          }
+          if (cancelled) return;
+
+          if (detectedBackend.listFileTree) {
+            const tree = await detectedBackend.listFileTree();
+            if (cancelled) return;
+            setFileTreePaths(tree.paths);
+          }
+
+          if (requestedPathState.documentPath) {
+            await loadDocument(
+              detectedBackend,
+              requestedPathState.documentPath,
+            );
+          } else {
+            setActiveDocumentPath(null);
+          }
+          if (cancelled) return;
+
+          setLoading(false);
+          return;
+        }
+
         if (!requestedPathState.rawPath) {
           setActiveDocumentPath(null);
           setLoading(false);
@@ -1639,7 +1676,9 @@ export function App() {
     };
   }, [
     loadDocument,
+    requestedPathState.directoryPath,
     requestedPathState.documentPath,
+    requestedPathState.mode,
     requestedPathState.projectPath,
     requestedPathState.rawPath,
   ]);
@@ -1894,6 +1933,73 @@ export function App() {
     [],
   );
 
+  const directoryPath = requestedPathState.directoryPath;
+
+  const handleSelectDirectoryFile = useCallback(
+    async (relativePath: string) => {
+      const currentBackend = backendRef.current;
+      if (!currentBackend || !directoryPath) return;
+      if (relativePath === activeDocumentPathRef.current) return;
+
+      if (
+        shouldWarnBeforeUnload({
+          activeDocumentPath: activeDocumentPathRef.current,
+          isDirty: documentDirtyRef.current,
+          saveState: documentSaveStateRef.current,
+          diskChangeState: documentDiskChangeState,
+        }) &&
+        !window.confirm(
+          "You have unsaved changes. Switch files and discard them?",
+        )
+      ) {
+        return;
+      }
+
+      window.history.pushState(
+        null,
+        "",
+        buildLocationForDirectorySelection(
+          directoryPath,
+          joinPath(directoryPath, relativePath),
+        ),
+      );
+
+      try {
+        await loadDocument(currentBackend, relativePath);
+      } catch (error) {
+        console.error("Failed to open markdown file:", error);
+        setLoadError("Could not open that markdown file.");
+      }
+    },
+    [directoryPath, documentDiskChangeState, loadDocument],
+  );
+
+  useEffect(() => {
+    if (!isDirectoryMode) return;
+
+    const handlePopState = () => {
+      const currentBackend = backendRef.current;
+      if (!currentBackend) return;
+
+      const nextState = getWorkspaceState();
+      if (nextState.documentPath) {
+        void loadDocument(currentBackend, nextState.documentPath).catch(
+          (error) => {
+            console.error("Failed to open markdown file:", error);
+          },
+        );
+      } else {
+        setDocumentPage(null);
+        setActiveDocumentPath(null);
+        documentDirtyRef.current = false;
+        setDocumentDiskChangeState("clean");
+      }
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, [isDirectoryMode, loadDocument]);
+
   if (loading) {
     return (
       <div
@@ -1911,7 +2017,7 @@ export function App() {
     return <PreviewPage />;
   }
 
-  if (!requestedPathState.rawPath || loadError) {
+  if ((!requestedPathState.rawPath && !isDirectoryMode) || loadError) {
     return (
       <Homepage
         message={loadError ?? <HomepageSubtitle />}
@@ -1927,33 +2033,59 @@ export function App() {
   const documentFilenameLabel =
     getPathLeaf(documentAbsolutePath ?? activeDocumentPath) ?? "Untitled.md";
 
+  const updateNotice = updateStatus ? (
+    <div className="pointer-events-none absolute top-4 right-4 z-40 max-w-sm">
+      <div className="pointer-events-auto">
+        <UpdateNotice updateStatus={updateStatus} />
+      </div>
+    </div>
+  ) : null;
+
+  const hasOpenDocument = Boolean(documentPage && activeDocumentPath);
+  const documentWorkspace = hasOpenDocument ? (
+    <DocumentWorkspace
+      documentPage={documentPage}
+      activeDocumentPath={activeDocumentPath}
+      documentFilenameLabel={documentFilenameLabel}
+      documentEditorViewMode={documentEditorViewMode}
+      onDocumentEditorViewModeChange={handleDocumentEditorViewModeChange}
+      onSaveDocument={handleSaveDocument}
+      onDocumentSaveStateChange={handleDocumentSaveStateChange}
+      onDocumentDirtyStateChange={handleDocumentDirtyStateChange}
+      onDocumentLocalContentChange={handleDocumentLocalContentChange}
+      documentDiskChangeState={documentDiskChangeState}
+      documentForceResetKey={documentForceResetKey}
+      onReloadDocumentFromDisk={handleReloadDocumentFromDisk}
+      onKeepEditingWithoutAutosave={handleKeepEditingWithoutAutosave}
+      onOverwriteDocumentOnDisk={handleOverwriteDocumentOnDisk}
+      onCompleteReview={handleCompleteReview}
+      backend={backend}
+    />
+  ) : null;
+
+  if (isDirectoryMode && directoryPath) {
+    return (
+      <main className="relative flex h-screen min-w-0 overflow-hidden bg-[#FCFCFC] dark:bg-background text-slate-950 dark:text-slate-50">
+        <DirectorySidebar
+          directoryLabel={
+            formatWorkspacePathForDisplay(directoryPath) ?? directoryPath
+          }
+          paths={fileTreePaths}
+          activePath={activeDocumentPath}
+          onSelect={handleSelectDirectoryFile}
+        />
+        <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
+          {updateNotice}
+          {documentWorkspace ?? <DirectoryEmptyState />}
+        </div>
+      </main>
+    );
+  }
+
   return (
     <main className="relative flex h-screen min-w-0 flex-col overflow-hidden bg-[#FCFCFC] dark:bg-background text-slate-950 dark:text-slate-50">
-      {updateStatus ? (
-        <div className="pointer-events-none absolute top-4 right-4 z-40 max-w-sm">
-          <div className="pointer-events-auto">
-            <UpdateNotice updateStatus={updateStatus} />
-          </div>
-        </div>
-      ) : null}
-      <DocumentWorkspace
-        documentPage={documentPage}
-        activeDocumentPath={activeDocumentPath}
-        documentFilenameLabel={documentFilenameLabel}
-        documentEditorViewMode={documentEditorViewMode}
-        onDocumentEditorViewModeChange={handleDocumentEditorViewModeChange}
-        onSaveDocument={handleSaveDocument}
-        onDocumentSaveStateChange={handleDocumentSaveStateChange}
-        onDocumentDirtyStateChange={handleDocumentDirtyStateChange}
-        onDocumentLocalContentChange={handleDocumentLocalContentChange}
-        documentDiskChangeState={documentDiskChangeState}
-        documentForceResetKey={documentForceResetKey}
-        onReloadDocumentFromDisk={handleReloadDocumentFromDisk}
-        onKeepEditingWithoutAutosave={handleKeepEditingWithoutAutosave}
-        onOverwriteDocumentOnDisk={handleOverwriteDocumentOnDisk}
-        onCompleteReview={handleCompleteReview}
-        backend={backend}
-      />
+      {updateNotice}
+      {documentWorkspace}
     </main>
   );
 }

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1553,8 +1553,14 @@ export function App() {
 
   useEffect(() => {
     const sourceUrl = new URL("/api/open-requests", window.location.origin);
-    if (requestedPathState.rawPath) {
-      sourceUrl.searchParams.set("path", requestedPathState.rawPath);
+    // In directory mode the CLI sends an open request keyed on the directory,
+    // so register this window under the directory path; otherwise use the file.
+    const registrationPath =
+      requestedPathState.mode === "directory"
+        ? requestedPathState.directoryPath
+        : requestedPathState.rawPath;
+    if (registrationPath) {
+      sourceUrl.searchParams.set("path", registrationPath);
     }
 
     const source = new EventSource(`${sourceUrl.pathname}${sourceUrl.search}`);
@@ -1567,6 +1573,20 @@ export function App() {
 
         const nextUrl = new URL(payload.url, window.location.origin);
         window.focus();
+
+        // If we are already browsing the requested directory, keep the
+        // currently open file instead of resetting to the directory root.
+        const currentUrl = new URL(window.location.href);
+        const nextDir = nextUrl.searchParams.get("dir");
+        const currentDir = currentUrl.searchParams.get("dir");
+        if (
+          nextDir &&
+          nextDir === currentDir &&
+          !nextUrl.searchParams.get("path")
+        ) {
+          return;
+        }
+
         if (nextUrl.href !== window.location.href) {
           window.location.assign(nextUrl.href);
         }
@@ -1581,7 +1601,11 @@ export function App() {
       source.removeEventListener("open-request", handleOpenRequest);
       source.close();
     };
-  }, [requestedPathState.rawPath]);
+  }, [
+    requestedPathState.directoryPath,
+    requestedPathState.mode,
+    requestedPathState.rawPath,
+  ]);
 
   useEffect(() => {
     let cancelled = false;

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -96,6 +96,13 @@ export function shouldWarnBeforeUnload({
 const AGENT_SETUP_PROMPT =
   "Install Roughdraft for me using `npm i -g roughdraft`, then read https://roughdraft.md/setup.md and set yourself up to use it.";
 const PREVIEW_DOCUMENT_PATH = "preview.md";
+const DIRECTORY_TREE_REFRESH_MS = 2000;
+
+function arraysShallowEqual(left: string[], right: string[]): boolean {
+  if (left === right) return true;
+  if (left.length !== right.length) return false;
+  return left.every((value, index) => value === right[index]);
+}
 const PREVIEW_INITIAL_MARKDOWN = [
   "# Live Preview",
   "",
@@ -1999,6 +2006,39 @@ export function App() {
     window.addEventListener("popstate", handlePopState);
     return () => window.removeEventListener("popstate", handlePopState);
   }, [isDirectoryMode, loadDocument]);
+
+  useEffect(() => {
+    if (!isDirectoryMode || !backend?.listFileTree) return;
+    const listFileTree = backend.listFileTree.bind(backend);
+
+    let cancelled = false;
+    let inFlight = false;
+
+    const refreshTree = async () => {
+      if (inFlight) return;
+      inFlight = true;
+      try {
+        const tree = await listFileTree();
+        if (cancelled) return;
+        setFileTreePaths((current) =>
+          arraysShallowEqual(current, tree.paths) ? current : tree.paths,
+        );
+      } catch (error) {
+        console.error("Failed to refresh directory tree:", error);
+      } finally {
+        inFlight = false;
+      }
+    };
+
+    const intervalId = window.setInterval(() => {
+      void refreshTree();
+    }, DIRECTORY_TREE_REFRESH_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [isDirectoryMode, backend]);
 
   if (loading) {
     return (

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1948,20 +1948,6 @@ export function App() {
       if (!currentBackend || !directoryPath) return;
       if (relativePath === activeDocumentPathRef.current) return;
 
-      if (
-        shouldWarnBeforeUnload({
-          activeDocumentPath: activeDocumentPathRef.current,
-          isDirty: documentDirtyRef.current,
-          saveState: documentSaveStateRef.current,
-          diskChangeState: documentDiskChangeState,
-        }) &&
-        !window.confirm(
-          "You have unsaved changes. Switch files and discard them?",
-        )
-      ) {
-        return;
-      }
-
       window.history.pushState(
         null,
         "",
@@ -1978,7 +1964,7 @@ export function App() {
         setLoadError("Could not open that markdown file.");
       }
     },
-    [directoryPath, documentDiskChangeState, loadDocument],
+    [directoryPath, loadDocument],
   );
 
   useEffect(() => {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -46,6 +46,8 @@ import {
 } from "./components/ui/dialog";
 import { DirectoryEmptyState, DirectorySidebar } from "./DirectoryWorkspace";
 import { DocumentWorkspace } from "./DocumentWorkspace";
+import { classifyFile, type FileKind } from "./file-types";
+import { FileViewerWorkspace } from "./FileViewerWorkspace";
 import { detectBackend } from "./detect-backend";
 import {
   getCommentAnchorMeasurements,
@@ -1489,6 +1491,13 @@ export function App() {
   const isPreviewRoute = window.location.pathname === PREVIEW_PATH;
   const [backend, setBackend] = useState<StorageBackend | null>(null);
   const [documentPage, setDocumentPage] = useState<Page | null>(null);
+  // A non-markdown file opened read-only from the directory tree. Mutually
+  // exclusive with `documentPage`: markdown uses the full review workspace,
+  // everything else uses the read-only viewer (ADR 0005).
+  const [activeViewerFile, setActiveViewerFile] = useState<{
+    path: string;
+    kind: Exclude<FileKind, "markdown">;
+  } | null>(null);
   const [activeDocumentPath, setActiveDocumentPath] = useState<string | null>(
     initialRequestedPathState.documentPath,
   );
@@ -1511,11 +1520,13 @@ export function App() {
   const documentDirtyRef = useRef(false);
   const documentSaveStateRef = useRef<DocumentSaveState>("saved");
   const documentDraftContentRef = useRef<string | null>(null);
+  const activeViewerFileRef = useRef<string | null>(null);
 
   backendRef.current = backend;
   documentPageRef.current = documentPage;
   activeDocumentPathRef.current = activeDocumentPath;
   documentSaveStateRef.current = documentSaveState;
+  activeViewerFileRef.current = activeViewerFile?.path ?? null;
 
   const applyDocumentPage = useCallback((nextDocument: Page) => {
     setDocumentPage(nextDocument);
@@ -1525,6 +1536,7 @@ export function App() {
   const loadDocument = useCallback(
     async (nextBackend: StorageBackend, relativePath: string) => {
       const nextDocument = await nextBackend.getMarkdownFile(relativePath);
+      setActiveViewerFile(null);
       applyDocumentPage(nextDocument);
       setActiveDocumentPath(relativePath);
       documentDirtyRef.current = false;
@@ -1532,6 +1544,26 @@ export function App() {
       return nextDocument;
     },
     [applyDocumentPage],
+  );
+
+  // Open a file selected in the directory tree. Markdown goes through the full
+  // review workspace; any other file opens in the read-only viewer instead of
+  // hitting the `.md`-only markdown endpoint.
+  const openDirectoryFile = useCallback(
+    async (nextBackend: StorageBackend, relativePath: string) => {
+      const { kind } = classifyFile(relativePath);
+      if (kind === "markdown") {
+        await loadDocument(nextBackend, relativePath);
+        return;
+      }
+
+      setDocumentPage(null);
+      setActiveDocumentPath(null);
+      documentDirtyRef.current = false;
+      setDocumentDiskChangeState("clean");
+      setActiveViewerFile({ path: relativePath, kind });
+    },
+    [loadDocument],
   );
 
   useEffect(() => {
@@ -1614,6 +1646,7 @@ export function App() {
       setLoading(true);
       setLoadError(null);
       setDocumentPage(null);
+      setActiveViewerFile(null);
 
       try {
         const detectedBackend = await detectBackend();
@@ -1649,7 +1682,7 @@ export function App() {
           }
 
           if (requestedPathState.documentPath) {
-            await loadDocument(
+            await openDirectoryFile(
               detectedBackend,
               requestedPathState.documentPath,
             );
@@ -1707,6 +1740,7 @@ export function App() {
     };
   }, [
     loadDocument,
+    openDirectoryFile,
     requestedPathState.directoryPath,
     requestedPathState.documentPath,
     requestedPathState.mode,
@@ -1970,7 +2004,9 @@ export function App() {
     async (relativePath: string) => {
       const currentBackend = backendRef.current;
       if (!currentBackend || !directoryPath) return;
-      if (relativePath === activeDocumentPathRef.current) return;
+      const currentPath =
+        activeDocumentPathRef.current ?? activeViewerFileRef.current;
+      if (relativePath === currentPath) return;
 
       window.history.pushState(
         null,
@@ -1982,13 +2018,13 @@ export function App() {
       );
 
       try {
-        await loadDocument(currentBackend, relativePath);
+        await openDirectoryFile(currentBackend, relativePath);
       } catch (error) {
-        console.error("Failed to open markdown file:", error);
-        setLoadError("Could not open that markdown file.");
+        console.error("Failed to open file:", error);
+        setLoadError("Could not open that file.");
       }
     },
-    [directoryPath, loadDocument],
+    [directoryPath, openDirectoryFile],
   );
 
   useEffect(() => {
@@ -2000,14 +2036,15 @@ export function App() {
 
       const nextState = getWorkspaceState();
       if (nextState.documentPath) {
-        void loadDocument(currentBackend, nextState.documentPath).catch(
+        void openDirectoryFile(currentBackend, nextState.documentPath).catch(
           (error) => {
-            console.error("Failed to open markdown file:", error);
+            console.error("Failed to open file:", error);
           },
         );
       } else {
         setDocumentPage(null);
         setActiveDocumentPath(null);
+        setActiveViewerFile(null);
         documentDirtyRef.current = false;
         setDocumentDiskChangeState("clean");
       }
@@ -2015,7 +2052,7 @@ export function App() {
 
     window.addEventListener("popstate", handlePopState);
     return () => window.removeEventListener("popstate", handlePopState);
-  }, [isDirectoryMode, loadDocument]);
+  }, [isDirectoryMode, openDirectoryFile]);
 
   useEffect(() => {
     if (!isDirectoryMode || !backend?.listFileTree) return;
@@ -2114,6 +2151,19 @@ export function App() {
   ) : null;
 
   if (isDirectoryMode && directoryPath) {
+    const fileViewer =
+      backend && activeViewerFile ? (
+        <FileViewerWorkspace
+          key={activeViewerFile.path}
+          backend={backend}
+          relativePath={activeViewerFile.path}
+          fileLabel={
+            getPathLeaf(activeViewerFile.path) ?? activeViewerFile.path
+          }
+          kind={activeViewerFile.kind}
+        />
+      ) : null;
+
     return (
       <main className="relative flex h-screen min-w-0 overflow-hidden bg-[#FCFCFC] dark:bg-background text-slate-950 dark:text-slate-50">
         <DirectorySidebar
@@ -2121,12 +2171,12 @@ export function App() {
             formatWorkspacePathForDisplay(directoryPath) ?? directoryPath
           }
           paths={fileTreePaths}
-          activePath={activeDocumentPath}
+          activePath={activeDocumentPath ?? activeViewerFile?.path ?? null}
           onSelect={handleSelectDirectoryFile}
         />
         <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
           {updateNotice}
-          {documentWorkspace ?? <DirectoryEmptyState />}
+          {documentWorkspace ?? fileViewer ?? <DirectoryEmptyState />}
         </div>
       </main>
     );

--- a/packages/app/src/CodeFileViewer.tsx
+++ b/packages/app/src/CodeFileViewer.tsx
@@ -1,0 +1,113 @@
+import { LanguageDescription } from "@codemirror/language";
+import { languages } from "@codemirror/language-data";
+import { Compartment, EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { basicSetup } from "codemirror";
+import { useEffect, useRef } from "react";
+import { cn } from "./lib/utils";
+
+interface CodeFileViewerProps {
+  value: string;
+  /** Filename used to pick a syntax-highlighting language (lazily loaded). */
+  filename: string;
+  className?: string;
+  testId?: string;
+}
+
+const codeViewerTheme = EditorView.theme({
+  "&": {
+    backgroundColor: "transparent",
+    color: "inherit",
+    fontFamily:
+      'ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, "Liberation Mono", monospace',
+    fontSize: "0.95rem",
+  },
+  ".cm-scroller": {
+    fontFamily: "inherit",
+    lineHeight: "1.75",
+    overflow: "auto",
+  },
+  ".cm-content": {
+    minHeight: "70vh",
+    padding: "0",
+  },
+  ".cm-line": { padding: "0" },
+  ".cm-gutters": {
+    backgroundColor: "transparent",
+    border: "none",
+    color: "rgb(148 163 184)",
+    marginRight: "0.75rem",
+  },
+  ".cm-gutterElement": { padding: "0 0.5rem 0 0" },
+  ".cm-foldGutter": { display: "none" },
+  ".cm-activeLine": { backgroundColor: "transparent" },
+  ".cm-activeLineGutter": {
+    backgroundColor: "transparent",
+    color: "rgb(100 116 139)",
+  },
+  "&.cm-focused": { outline: "none" },
+});
+
+/**
+ * Read-only source viewer. Syntax highlighting is loaded on demand for the
+ * matched language so the base bundle stays small; files with no matching
+ * language render as plain monospaced text.
+ */
+export function CodeFileViewer({
+  value,
+  filename,
+  className,
+  testId,
+}: CodeFileViewerProps) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const hostElement = hostRef.current;
+    if (!hostElement) return;
+
+    const languageCompartment = new Compartment();
+    const view = new EditorView({
+      parent: hostElement,
+      state: EditorState.create({
+        doc: value,
+        extensions: [
+          basicSetup,
+          EditorView.lineWrapping,
+          EditorState.readOnly.of(true),
+          EditorView.editable.of(false),
+          languageCompartment.of([]),
+          codeViewerTheme,
+        ],
+      }),
+    });
+
+    let disposed = false;
+    const description = LanguageDescription.matchFilename(languages, filename);
+    if (description) {
+      void description
+        .load()
+        .then((support) => {
+          if (disposed) return;
+          view.dispatch({
+            effects: languageCompartment.reconfigure(support),
+          });
+        })
+        .catch(() => {
+          // Highlighting is best-effort; plain text is an acceptable fallback.
+        });
+    }
+
+    return () => {
+      disposed = true;
+      view.destroy();
+    };
+  }, [value, filename]);
+
+  return (
+    <div
+      ref={hostRef}
+      className={cn("markdown-code-editor", className)}
+      data-testid={testId}
+    />
+  );
+}

--- a/packages/app/src/DirectoryWorkspace.test.ts
+++ b/packages/app/src/DirectoryWorkspace.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildMarkdownFileTree } from "./DirectoryWorkspace";
+import { buildFileTree } from "./DirectoryWorkspace";
 
-describe("buildMarkdownFileTree", () => {
-  it("nests markdown files under their directories", () => {
-    const tree = buildMarkdownFileTree(["notes/", "notes/alpha.md", "zeta.md"]);
+describe("buildFileTree", () => {
+  it("nests files under their directories", () => {
+    const tree = buildFileTree(["notes/", "notes/alpha.md", "zeta.md"]);
 
     expect(tree).toEqual([
       {
@@ -28,29 +28,29 @@ describe("buildMarkdownFileTree", () => {
     ]);
   });
 
-  it("drops non-markdown files and directories without markdown", () => {
-    const tree = buildMarkdownFileTree([
+  it("keeps non-markdown files and prunes only empty directories", () => {
+    const tree = buildFileTree([
       "empty/",
       "empty/nested/",
       "assets/",
       "assets/diagram.png",
+      "src/app.ts",
       "draft.md",
     ]);
 
-    expect(tree).toEqual([
-      {
-        name: "draft.md",
-        relativePath: "draft.md",
-        kind: "file",
-        children: [],
-      },
+    expect(tree.map((node) => node.name)).toEqual([
+      "assets",
+      "src",
+      "draft.md",
     ]);
+    expect(tree[0]?.children.map((node) => node.name)).toEqual(["diagram.png"]);
+    expect(tree[1]?.children.map((node) => node.name)).toEqual(["app.ts"]);
   });
 
   it("orders directories before files and sorts numerically", () => {
-    const tree = buildMarkdownFileTree([
+    const tree = buildFileTree([
       "b.md",
-      "a.md",
+      "a.txt",
       "10-late.md",
       "2-early.md",
       "docs/z.md",
@@ -60,16 +60,16 @@ describe("buildMarkdownFileTree", () => {
       "docs",
       "2-early.md",
       "10-late.md",
-      "a.md",
+      "a.txt",
       "b.md",
     ]);
   });
 
   it("uses the canonical relative path as the file identifier", () => {
-    const tree = buildMarkdownFileTree(["a/b/c/deep.md"]);
+    const tree = buildFileTree(["a/b/c/deep.rs"]);
 
     const deep = tree[0]?.children[0]?.children[0]?.children[0];
-    expect(deep?.relativePath).toBe("a/b/c/deep.md");
+    expect(deep?.relativePath).toBe("a/b/c/deep.rs");
     expect(deep?.kind).toBe("file");
   });
 });

--- a/packages/app/src/DirectoryWorkspace.test.ts
+++ b/packages/app/src/DirectoryWorkspace.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { buildMarkdownFileTree } from "./DirectoryWorkspace";
+
+describe("buildMarkdownFileTree", () => {
+  it("nests markdown files under their directories", () => {
+    const tree = buildMarkdownFileTree(["notes/", "notes/alpha.md", "zeta.md"]);
+
+    expect(tree).toEqual([
+      {
+        name: "notes",
+        relativePath: "notes",
+        kind: "directory",
+        children: [
+          {
+            name: "alpha.md",
+            relativePath: "notes/alpha.md",
+            kind: "file",
+            children: [],
+          },
+        ],
+      },
+      {
+        name: "zeta.md",
+        relativePath: "zeta.md",
+        kind: "file",
+        children: [],
+      },
+    ]);
+  });
+
+  it("drops non-markdown files and directories without markdown", () => {
+    const tree = buildMarkdownFileTree([
+      "empty/",
+      "empty/nested/",
+      "assets/",
+      "assets/diagram.png",
+      "draft.md",
+    ]);
+
+    expect(tree).toEqual([
+      {
+        name: "draft.md",
+        relativePath: "draft.md",
+        kind: "file",
+        children: [],
+      },
+    ]);
+  });
+
+  it("orders directories before files and sorts numerically", () => {
+    const tree = buildMarkdownFileTree([
+      "b.md",
+      "a.md",
+      "10-late.md",
+      "2-early.md",
+      "docs/z.md",
+    ]);
+
+    expect(tree.map((node) => node.name)).toEqual([
+      "docs",
+      "2-early.md",
+      "10-late.md",
+      "a.md",
+      "b.md",
+    ]);
+  });
+
+  it("uses the canonical relative path as the file identifier", () => {
+    const tree = buildMarkdownFileTree(["a/b/c/deep.md"]);
+
+    const deep = tree[0]?.children[0]?.children[0]?.children[0];
+    expect(deep?.relativePath).toBe("a/b/c/deep.md");
+    expect(deep?.kind).toBe("file");
+  });
+});

--- a/packages/app/src/DirectoryWorkspace.tsx
+++ b/packages/app/src/DirectoryWorkspace.tsx
@@ -1,36 +1,40 @@
 import {
   ChevronDown,
   ChevronRight,
+  File as FileIcon,
+  FileCode,
   FileText,
   Folder,
   FolderOpen,
+  Image as ImageIcon,
 } from "lucide-react";
 import { useMemo, useState } from "react";
+import { classifyFile, type FileKind } from "./file-types";
 import { cn } from "./lib/utils";
 
-export interface MarkdownTreeNode {
+export interface FileTreeNode {
   name: string;
   relativePath: string;
   kind: "file" | "directory";
-  children: MarkdownTreeNode[];
+  children: FileTreeNode[];
 }
 
 /**
  * Build a nested tree from the flat `paths` returned by `/api/file-tree`.
  *
- * Only `.md` files are kept; directories are inferred from file path segments,
- * so empty directories and non-markdown files are pruned automatically.
- * Directories sort before files, then by numeric-aware name order.
+ * Every file is kept so the directory can be browsed in full; directories are
+ * inferred from file path segments, so empty directories are pruned
+ * automatically. Directories sort before files, then by numeric-aware name
+ * order. Markdown opens as the interactive unit of work; other files open
+ * read-only (see ADR 0005).
  */
-export function buildMarkdownFileTree(paths: string[]): MarkdownTreeNode[] {
-  const root: MarkdownTreeNode[] = [];
-  const directoryIndex = new Map<string, MarkdownTreeNode>();
+export function buildFileTree(paths: string[]): FileTreeNode[] {
+  const root: FileTreeNode[] = [];
+  const directoryIndex = new Map<string, FileTreeNode>();
 
-  const markdownPaths = paths.filter(
-    (entry) => !entry.endsWith("/") && entry.toLowerCase().endsWith(".md"),
-  );
+  const filePaths = paths.filter((entry) => !entry.endsWith("/"));
 
-  for (const filePath of markdownPaths) {
+  for (const filePath of filePaths) {
     const segments = filePath.split("/").filter(Boolean);
     let currentChildren = root;
     let currentPrefix = "";
@@ -64,7 +68,7 @@ export function buildMarkdownFileTree(paths: string[]): MarkdownTreeNode[] {
     });
   }
 
-  const sortNodes = (nodes: MarkdownTreeNode[]) => {
+  const sortNodes = (nodes: FileTreeNode[]) => {
     nodes.sort((left, right) => {
       if (left.kind !== right.kind) {
         return left.kind === "directory" ? -1 : 1;
@@ -81,7 +85,7 @@ export function buildMarkdownFileTree(paths: string[]): MarkdownTreeNode[] {
 }
 
 interface DirectoryTreeProps {
-  nodes: MarkdownTreeNode[];
+  nodes: FileTreeNode[];
   activePath: string | null;
   onSelect: (relativePath: string) => void;
   depth?: number;
@@ -119,13 +123,21 @@ function DirectoryTree({
 }
 
 interface DirectoryTreeNodeProps {
-  node: MarkdownTreeNode;
+  node: FileTreeNode;
   activePath: string | null;
   onSelect: (relativePath: string) => void;
   depth: number;
 }
 
 const INDENT_STEP_REM = 0.75;
+
+const fileIconByKind: Record<FileKind, typeof FileText> = {
+  markdown: FileText,
+  text: FileText,
+  code: FileCode,
+  image: ImageIcon,
+  binary: FileIcon,
+};
 
 function DirectoryTreeFolder({
   node,
@@ -176,6 +188,7 @@ function DirectoryTreeFile({
   depth,
 }: DirectoryTreeNodeProps) {
   const isActive = activePath === node.relativePath;
+  const FileKindIcon = fileIconByKind[classifyFile(node.relativePath).kind];
 
   return (
     <li>
@@ -192,7 +205,7 @@ function DirectoryTreeFile({
         )}
         style={{ paddingLeft: `${0.5 + depth * INDENT_STEP_REM + 1.25}rem` }}
       >
-        <FileText className="size-4 shrink-0 opacity-70" />
+        <FileKindIcon className="size-4 shrink-0 opacity-70" />
         <span className="truncate">{node.name}</span>
       </button>
     </li>
@@ -212,7 +225,7 @@ export function DirectorySidebar({
   activePath,
   onSelect,
 }: DirectorySidebarProps) {
-  const nodes = useMemo(() => buildMarkdownFileTree(paths), [paths]);
+  const nodes = useMemo(() => buildFileTree(paths), [paths]);
 
   return (
     <nav
@@ -239,9 +252,7 @@ export function DirectorySidebar({
             onSelect={onSelect}
           />
         ) : (
-          <p className="px-3 py-2 text-sm text-slate-400">
-            No Markdown files here.
-          </p>
+          <p className="px-3 py-2 text-sm text-slate-400">No files here.</p>
         )}
       </div>
     </nav>
@@ -255,7 +266,8 @@ export function DirectoryEmptyState() {
       className="flex h-full flex-1 items-center justify-center p-8 text-center"
     >
       <p className="max-w-sm text-sm text-slate-400">
-        Select a Markdown file from the sidebar to review it.
+        Select a file from the sidebar. Markdown opens for review; other files
+        open read-only.
       </p>
     </div>
   );

--- a/packages/app/src/DirectoryWorkspace.tsx
+++ b/packages/app/src/DirectoryWorkspace.tsx
@@ -1,0 +1,262 @@
+import {
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  Folder,
+  FolderOpen,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import { cn } from "./lib/utils";
+
+export interface MarkdownTreeNode {
+  name: string;
+  relativePath: string;
+  kind: "file" | "directory";
+  children: MarkdownTreeNode[];
+}
+
+/**
+ * Build a nested tree from the flat `paths` returned by `/api/file-tree`.
+ *
+ * Only `.md` files are kept; directories are inferred from file path segments,
+ * so empty directories and non-markdown files are pruned automatically.
+ * Directories sort before files, then by numeric-aware name order.
+ */
+export function buildMarkdownFileTree(paths: string[]): MarkdownTreeNode[] {
+  const root: MarkdownTreeNode[] = [];
+  const directoryIndex = new Map<string, MarkdownTreeNode>();
+
+  const markdownPaths = paths.filter(
+    (entry) => !entry.endsWith("/") && entry.toLowerCase().endsWith(".md"),
+  );
+
+  for (const filePath of markdownPaths) {
+    const segments = filePath.split("/").filter(Boolean);
+    let currentChildren = root;
+    let currentPrefix = "";
+
+    segments.forEach((segment, index) => {
+      currentPrefix = currentPrefix ? `${currentPrefix}/${segment}` : segment;
+      const isFile = index === segments.length - 1;
+
+      if (isFile) {
+        currentChildren.push({
+          name: segment,
+          relativePath: currentPrefix,
+          kind: "file",
+          children: [],
+        });
+        return;
+      }
+
+      let directoryNode = directoryIndex.get(currentPrefix);
+      if (!directoryNode) {
+        directoryNode = {
+          name: segment,
+          relativePath: currentPrefix,
+          kind: "directory",
+          children: [],
+        };
+        directoryIndex.set(currentPrefix, directoryNode);
+        currentChildren.push(directoryNode);
+      }
+      currentChildren = directoryNode.children;
+    });
+  }
+
+  const sortNodes = (nodes: MarkdownTreeNode[]) => {
+    nodes.sort((left, right) => {
+      if (left.kind !== right.kind) {
+        return left.kind === "directory" ? -1 : 1;
+      }
+      return left.name.localeCompare(right.name, undefined, { numeric: true });
+    });
+    for (const node of nodes) {
+      if (node.kind === "directory") sortNodes(node.children);
+    }
+  };
+
+  sortNodes(root);
+  return root;
+}
+
+interface DirectoryTreeProps {
+  nodes: MarkdownTreeNode[];
+  activePath: string | null;
+  onSelect: (relativePath: string) => void;
+  depth?: number;
+}
+
+function DirectoryTree({
+  nodes,
+  activePath,
+  onSelect,
+  depth = 0,
+}: DirectoryTreeProps) {
+  return (
+    <ul className="m-0 list-none p-0">
+      {nodes.map((node) =>
+        node.kind === "directory" ? (
+          <DirectoryTreeFolder
+            key={node.relativePath}
+            node={node}
+            activePath={activePath}
+            onSelect={onSelect}
+            depth={depth}
+          />
+        ) : (
+          <DirectoryTreeFile
+            key={node.relativePath}
+            node={node}
+            activePath={activePath}
+            onSelect={onSelect}
+            depth={depth}
+          />
+        ),
+      )}
+    </ul>
+  );
+}
+
+interface DirectoryTreeNodeProps {
+  node: MarkdownTreeNode;
+  activePath: string | null;
+  onSelect: (relativePath: string) => void;
+  depth: number;
+}
+
+const INDENT_STEP_REM = 0.75;
+
+function DirectoryTreeFolder({
+  node,
+  activePath,
+  onSelect,
+  depth,
+}: DirectoryTreeNodeProps) {
+  const [expanded, setExpanded] = useState(true);
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => setExpanded((current) => !current)}
+        aria-expanded={expanded}
+        data-testid={`directory-folder-${node.relativePath}`}
+        className="flex w-full items-center gap-1 rounded-md px-2 py-1 text-left text-sm text-slate-600 hover:bg-slate-200/60 dark:text-slate-300 dark:hover:bg-slate-700/50"
+        style={{ paddingLeft: `${0.5 + depth * INDENT_STEP_REM}rem` }}
+      >
+        {expanded ? (
+          <ChevronDown className="size-3.5 shrink-0 opacity-70" />
+        ) : (
+          <ChevronRight className="size-3.5 shrink-0 opacity-70" />
+        )}
+        {expanded ? (
+          <FolderOpen className="size-4 shrink-0 opacity-80" />
+        ) : (
+          <Folder className="size-4 shrink-0 opacity-80" />
+        )}
+        <span className="truncate">{node.name}</span>
+      </button>
+      {expanded ? (
+        <DirectoryTree
+          nodes={node.children}
+          activePath={activePath}
+          onSelect={onSelect}
+          depth={depth + 1}
+        />
+      ) : null}
+    </li>
+  );
+}
+
+function DirectoryTreeFile({
+  node,
+  activePath,
+  onSelect,
+  depth,
+}: DirectoryTreeNodeProps) {
+  const isActive = activePath === node.relativePath;
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onSelect(node.relativePath)}
+        aria-current={isActive ? "true" : undefined}
+        data-testid={`directory-file-${node.relativePath}`}
+        className={cn(
+          "flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-left text-sm",
+          isActive
+            ? "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900"
+            : "text-slate-700 hover:bg-slate-200/60 dark:text-slate-200 dark:hover:bg-slate-700/50",
+        )}
+        style={{ paddingLeft: `${0.5 + depth * INDENT_STEP_REM + 1.25}rem` }}
+      >
+        <FileText className="size-4 shrink-0 opacity-70" />
+        <span className="truncate">{node.name}</span>
+      </button>
+    </li>
+  );
+}
+
+interface DirectorySidebarProps {
+  directoryLabel: string;
+  paths: string[];
+  activePath: string | null;
+  onSelect: (relativePath: string) => void;
+}
+
+export function DirectorySidebar({
+  directoryLabel,
+  paths,
+  activePath,
+  onSelect,
+}: DirectorySidebarProps) {
+  const nodes = useMemo(() => buildMarkdownFileTree(paths), [paths]);
+
+  return (
+    <nav
+      aria-label="Directory files"
+      data-testid="directory-sidebar"
+      className="flex h-screen w-64 shrink-0 flex-col border-r border-slate-200 bg-slate-50 dark:border-slate-800 dark:bg-slate-900/40"
+    >
+      <div className="border-b border-slate-200 px-3 py-3 dark:border-slate-800">
+        <p className="text-xs font-medium uppercase tracking-wide text-slate-400">
+          Directory
+        </p>
+        <p
+          className="truncate text-sm font-medium text-slate-700 dark:text-slate-200"
+          title={directoryLabel}
+        >
+          {directoryLabel}
+        </p>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto px-1 py-2">
+        {nodes.length > 0 ? (
+          <DirectoryTree
+            nodes={nodes}
+            activePath={activePath}
+            onSelect={onSelect}
+          />
+        ) : (
+          <p className="px-3 py-2 text-sm text-slate-400">
+            No Markdown files here.
+          </p>
+        )}
+      </div>
+    </nav>
+  );
+}
+
+export function DirectoryEmptyState() {
+  return (
+    <div
+      data-testid="directory-empty-state"
+      className="flex h-full flex-1 items-center justify-center p-8 text-center"
+    >
+      <p className="max-w-sm text-sm text-slate-400">
+        Select a Markdown file from the sidebar to review it.
+      </p>
+    </div>
+  );
+}

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -7,7 +7,9 @@ import {
   Copy,
   Eye,
   Loader2,
+  Maximize2,
   MessageSquarePlus,
+  Minimize2,
   PencilLine,
   RefreshCcw,
   Upload,
@@ -48,6 +50,10 @@ import {
 import { RobotsHighFiveToy } from "./RobotsHighFiveToy";
 import type { CompleteReviewOptions, Page, StorageBackend } from "./storage";
 import { useReviewLayoutShiftAnimation } from "./useReviewLayoutShiftAnimation";
+import {
+  readFullWidthPreference,
+  writeFullWidthPreference,
+} from "./view-preferences";
 
 type DiskChangeState = "clean" | "changed" | "conflict" | "paused";
 type ReviewHandoffState =
@@ -420,6 +426,14 @@ export function DocumentWorkspace({
 }: DocumentWorkspaceProps) {
   const [documentInteractionMode, setDocumentInteractionMode] =
     useState<DocumentInteractionMode>("suggesting");
+  const [fullWidth, setFullWidth] = useState(readFullWidthPreference);
+  const toggleFullWidth = useCallback(() => {
+    setFullWidth((current) => {
+      const next = !current;
+      writeFullWidthPreference(next);
+      return next;
+    });
+  }, []);
   const [saveState, setSaveState] = useState<DocumentSaveState>("saved");
   const [reviewHandoffState, setReviewHandoffState] =
     useState<ReviewHandoffState>("idle");
@@ -976,18 +990,29 @@ export function DocumentWorkspace({
           </div>
         </div>
       ) : null}
-      <div className="mx-auto min-h-full max-w-[1080px]">
+      <div
+        className={cn(
+          "mx-auto min-h-full",
+          fullWidth ? "max-w-none" : "max-w-[1080px]",
+        )}
+      >
         {documentPage ? (
           <div
             ref={documentHeaderRef}
             data-testid="document-page-header"
             className={cn(
               "review-layout-grid document-page-shell mb-2 text-[0.62rem] font-medium tracking-[0.01em] text-stone-400",
+              fullWidth && "review-layout-grid--full-width",
               !documentHasComments &&
                 "review-layout-grid--centered document-page-shell-no-comments",
             )}
           >
-            <div className="review-layout-main document-page-main w-full max-w-[46.5rem] min-w-0">
+            <div
+              className={cn(
+                "review-layout-main document-page-main w-full min-w-0",
+                fullWidth ? "max-w-none" : "max-w-[46.5rem]",
+              )}
+            >
               <div className="flex w-full flex-wrap items-center gap-1.5 px-1">
                 <Tooltip>
                   <TooltipTrigger
@@ -1027,6 +1052,40 @@ export function DocumentWorkspace({
                     }
                   />
                   <TooltipContent>{editorViewModeToggleLabel}</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        type="button"
+                        data-testid="document-full-width-toggle"
+                        aria-pressed={fullWidth}
+                        className={cn(
+                          "inline-flex size-7 shrink-0 items-center justify-center rounded-full outline-none transition focus-visible:ring-2 focus-visible:ring-stone-300/70 dark:focus-visible:ring-slate-600/70",
+                          fullWidth
+                            ? "bg-[#E8E3DB] text-stone-700 dark:bg-slate-700 dark:text-white"
+                            : "text-stone-400 hover:bg-[#EEE9E1] hover:text-stone-600 dark:text-stone-500 dark:hover:bg-slate-800 dark:hover:text-stone-300",
+                        )}
+                      >
+                        {fullWidth ? (
+                          <Minimize2
+                            className="size-[0.8rem]"
+                            aria-hidden="true"
+                          />
+                        ) : (
+                          <Maximize2
+                            className="size-[0.8rem]"
+                            aria-hidden="true"
+                          />
+                        )}
+                      </button>
+                    }
+                    aria-label={fullWidth ? "Fit width" : "Full width"}
+                    onClick={toggleFullWidth}
+                  />
+                  <TooltipContent>
+                    {fullWidth ? "Fit width" : "Full width"}
+                  </TooltipContent>
                 </Tooltip>
                 <Popover
                   open={fileCopyMenuOpen}

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -991,6 +991,7 @@ export function DocumentWorkspace({
         </div>
       ) : null}
       <div
+        data-full-width={fullWidth ? "true" : undefined}
         className={cn(
           "mx-auto min-h-full",
           fullWidth ? "max-w-none" : "max-w-[1080px]",
@@ -1002,17 +1003,11 @@ export function DocumentWorkspace({
             data-testid="document-page-header"
             className={cn(
               "review-layout-grid document-page-shell mb-2 text-[0.62rem] font-medium tracking-[0.01em] text-stone-400",
-              fullWidth && "review-layout-grid--full-width",
               !documentHasComments &&
                 "review-layout-grid--centered document-page-shell-no-comments",
             )}
           >
-            <div
-              className={cn(
-                "review-layout-main document-page-main w-full min-w-0",
-                fullWidth ? "max-w-none" : "max-w-[46.5rem]",
-              )}
-            >
+            <div className="review-layout-main document-page-main w-full max-w-[46.5rem] min-w-0">
               <div className="flex w-full flex-wrap items-center gap-1.5 px-1">
                 <Tooltip>
                   <TooltipTrigger

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -805,6 +805,25 @@ export function DocumentWorkspace({
                   saveState={saveState}
                   diskChangeState={documentDiskChangeState}
                 />
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        type="button"
+                        data-testid="document-reload-button"
+                        className="inline-flex size-7 shrink-0 items-center justify-center rounded-full text-stone-400 outline-none transition hover:bg-[#EEE9E1] hover:text-stone-600 focus-visible:ring-2 focus-visible:ring-stone-300/70 dark:text-stone-500 dark:hover:bg-slate-800 dark:hover:text-stone-300 dark:focus-visible:ring-slate-600/70"
+                      >
+                        <RefreshCcw
+                          className="size-[0.8rem]"
+                          aria-hidden="true"
+                        />
+                      </button>
+                    }
+                    aria-label="Reload from disk"
+                    onClick={() => void onReloadDocumentFromDisk()}
+                  />
+                  <TooltipContent>Reload from disk</TooltipContent>
+                </Tooltip>
                 <div className="ml-auto inline-flex h-[1.25rem] shrink-0 items-center">
                   <Select<DocumentInteractionMode>
                     value={documentInteractionMode}

--- a/packages/app/src/FileViewerWorkspace.tsx
+++ b/packages/app/src/FileViewerWorkspace.tsx
@@ -1,8 +1,13 @@
-import { Eye, FileWarning, Loader2 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { Eye, FileWarning, Loader2, Maximize2, Minimize2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 import { CodeFileViewer } from "./CodeFileViewer";
 import type { FileKind } from "./file-types";
+import { cn } from "./lib/utils";
 import type { StorageBackend } from "./storage";
+import {
+  readFullWidthPreference,
+  writeFullWidthPreference,
+} from "./view-preferences";
 
 interface FileViewerWorkspaceProps {
   backend: StorageBackend;
@@ -145,13 +150,26 @@ export function FileViewerWorkspace({
 }: FileViewerWorkspaceProps) {
   const imageUrl =
     kind === "image" ? backend.resolveFileUrl(relativePath) : null;
+  const [fullWidth, setFullWidth] = useState(readFullWidthPreference);
+  const toggleFullWidth = useCallback(() => {
+    setFullWidth((current) => {
+      const next = !current;
+      writeFullWidthPreference(next);
+      return next;
+    });
+  }, []);
 
   return (
     <div
       data-testid="file-viewer-workspace"
       className="min-h-0 flex-1 overflow-y-auto px-8 pt-10 pb-8 sm:px-12"
     >
-      <div className="mx-auto min-h-full max-w-[1080px]">
+      <div
+        className={cn(
+          "mx-auto min-h-full",
+          fullWidth ? "max-w-none" : "max-w-[1080px]",
+        )}
+      >
         <div className="mb-4 flex items-center gap-1.5 px-1 text-[0.62rem] font-medium tracking-[0.01em] text-stone-400">
           <span
             className="min-w-0 truncate font-mono text-[0.7rem] text-stone-400 dark:text-stone-500"
@@ -159,9 +177,29 @@ export function FileViewerWorkspace({
           >
             {fileLabel}
           </span>
+          <button
+            type="button"
+            data-testid="file-viewer-full-width-toggle"
+            aria-pressed={fullWidth}
+            aria-label={fullWidth ? "Fit width" : "Full width"}
+            title={fullWidth ? "Fit width" : "Full width"}
+            onClick={toggleFullWidth}
+            className={cn(
+              "ml-auto inline-flex size-7 shrink-0 items-center justify-center rounded-full outline-none transition focus-visible:ring-2 focus-visible:ring-stone-300/70 dark:focus-visible:ring-slate-600/70",
+              fullWidth
+                ? "bg-[#E8E3DB] text-stone-700 dark:bg-slate-700 dark:text-white"
+                : "text-stone-400 hover:bg-[#EEE9E1] hover:text-stone-600 dark:text-stone-500 dark:hover:bg-slate-800 dark:hover:text-stone-300",
+            )}
+          >
+            {fullWidth ? (
+              <Minimize2 className="size-[0.68rem]" aria-hidden="true" />
+            ) : (
+              <Maximize2 className="size-[0.68rem]" aria-hidden="true" />
+            )}
+          </button>
           <span
             data-testid="file-viewer-readonly-badge"
-            className="ml-auto inline-flex items-center gap-1 font-mono text-[0.7rem] text-stone-400 dark:text-stone-500"
+            className="inline-flex items-center gap-1 font-mono text-[0.7rem] text-stone-400 dark:text-stone-500"
           >
             <Eye className="size-[0.68rem]" aria-hidden="true" />
             Read-only

--- a/packages/app/src/FileViewerWorkspace.tsx
+++ b/packages/app/src/FileViewerWorkspace.tsx
@@ -1,0 +1,204 @@
+import { Eye, FileWarning, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { CodeFileViewer } from "./CodeFileViewer";
+import type { FileKind } from "./file-types";
+import type { StorageBackend } from "./storage";
+
+interface FileViewerWorkspaceProps {
+  backend: StorageBackend;
+  relativePath: string;
+  fileLabel: string;
+  kind: Exclude<FileKind, "markdown">;
+}
+
+type TextLoadState =
+  | { status: "loading" }
+  | { status: "ready"; content: string }
+  | { status: "binary" }
+  | { status: "error"; message: string };
+
+// Text decoded from a binary file is full of replacement/NUL characters; a NUL
+// byte is the cheapest reliable signal that we should fall back to the stub
+// instead of rendering garbage.
+function looksBinary(content: string): boolean {
+  return content.includes("\u0000");
+}
+
+function FileViewerStub({
+  icon: Icon,
+  title,
+  body,
+}: {
+  icon: typeof FileWarning;
+  title: string;
+  body: string;
+}) {
+  return (
+    <div
+      data-testid="file-viewer-stub"
+      className="flex min-h-[50vh] flex-col items-center justify-center gap-2 text-center"
+    >
+      <Icon className="size-7 text-slate-400" aria-hidden="true" />
+      <p className="text-sm font-medium text-slate-600 dark:text-slate-300">
+        {title}
+      </p>
+      <p className="max-w-sm text-sm text-slate-400">{body}</p>
+    </div>
+  );
+}
+
+function TextOrCodeView({
+  backend,
+  relativePath,
+  fileLabel,
+}: {
+  backend: StorageBackend;
+  relativePath: string;
+  fileLabel: string;
+}) {
+  const [state, setState] = useState<TextLoadState>({ status: "loading" });
+
+  useEffect(() => {
+    if (!backend.readTextFile) {
+      setState({ status: "error", message: "This file cannot be opened." });
+      return;
+    }
+
+    let cancelled = false;
+    setState({ status: "loading" });
+    backend
+      .readTextFile(relativePath)
+      .then((content) => {
+        if (cancelled) return;
+        setState(
+          looksBinary(content)
+            ? { status: "binary" }
+            : { status: "ready", content },
+        );
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setState({
+          status: "error",
+          message:
+            error instanceof Error ? error.message : "Could not read the file.",
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [backend, relativePath]);
+
+  if (state.status === "loading") {
+    return (
+      <div
+        data-testid="file-viewer-loading"
+        className="flex min-h-[50vh] items-center justify-center gap-2 text-sm text-slate-400"
+      >
+        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+        Loading…
+      </div>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <FileViewerStub
+        icon={FileWarning}
+        title="Could not open this file"
+        body={state.message}
+      />
+    );
+  }
+
+  if (state.status === "binary") {
+    return (
+      <FileViewerStub
+        icon={FileWarning}
+        title="Preview unavailable"
+        body="This looks like a binary file, so Roughdraft can't show it as text."
+      />
+    );
+  }
+
+  return (
+    <CodeFileViewer
+      value={state.content}
+      filename={fileLabel}
+      testId="file-viewer-code"
+    />
+  );
+}
+
+/**
+ * Read-only workspace for non-markdown files reached from the directory tree.
+ * Images render as a preview, code and text render with highlighting, and
+ * other binaries fall back to a stub. None of these support commenting,
+ * editing, or saving (ADR 0005).
+ */
+export function FileViewerWorkspace({
+  backend,
+  relativePath,
+  fileLabel,
+  kind,
+}: FileViewerWorkspaceProps) {
+  const imageUrl =
+    kind === "image" ? backend.resolveFileUrl(relativePath) : null;
+
+  return (
+    <div
+      data-testid="file-viewer-workspace"
+      className="min-h-0 flex-1 overflow-y-auto px-8 pt-10 pb-8 sm:px-12"
+    >
+      <div className="mx-auto min-h-full max-w-[1080px]">
+        <div className="mb-4 flex items-center gap-1.5 px-1 text-[0.62rem] font-medium tracking-[0.01em] text-stone-400">
+          <span
+            className="min-w-0 truncate font-mono text-[0.7rem] text-stone-400 dark:text-stone-500"
+            title={fileLabel}
+          >
+            {fileLabel}
+          </span>
+          <span
+            data-testid="file-viewer-readonly-badge"
+            className="ml-auto inline-flex items-center gap-1 font-mono text-[0.7rem] text-stone-400 dark:text-stone-500"
+          >
+            <Eye className="size-[0.68rem]" aria-hidden="true" />
+            Read-only
+          </span>
+        </div>
+
+        {kind === "image" ? (
+          imageUrl ? (
+            <div className="flex justify-center py-4">
+              <img
+                data-testid="file-viewer-image"
+                src={imageUrl}
+                alt={fileLabel}
+                className="max-h-[80vh] max-w-full rounded-md border border-slate-200 object-contain dark:border-slate-800"
+              />
+            </div>
+          ) : (
+            <FileViewerStub
+              icon={FileWarning}
+              title="Preview unavailable"
+              body="This image can't be loaded in the current workspace."
+            />
+          )
+        ) : kind === "binary" ? (
+          <FileViewerStub
+            icon={FileWarning}
+            title="Preview unavailable"
+            body="This file type can't be shown in Roughdraft. Open it with another app."
+          />
+        ) : (
+          <TextOrCodeView
+            backend={backend}
+            relativePath={relativePath}
+            fileLabel={fileLabel}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/MathView.tsx
+++ b/packages/app/src/MathView.tsx
@@ -1,0 +1,30 @@
+import { type NodeViewProps, NodeViewWrapper } from "@tiptap/react";
+import { renderKatex } from "./markdown";
+
+/**
+ * Renders a `mathInline` / `mathBlock` node as KaTeX. The node is an opaque
+ * atom in the editor: the LaTeX source lives in `node.attrs.latex` and is what
+ * serializes back to `$…$` / `$$…$$`, while this view only paints the rendered
+ * formula.
+ */
+export function MathView(props: NodeViewProps) {
+  const latex = (props.node.attrs.latex as string) ?? "";
+  const display = props.node.type.name === "mathBlock";
+  const html = renderKatex(latex, display);
+
+  return (
+    <NodeViewWrapper
+      as={display ? "div" : "span"}
+      className={display ? "math-block" : "math-inline"}
+      data-testid={display ? "math-block" : "math-inline"}
+      contentEditable={false}
+    >
+      <span
+        // KaTeX output is generated locally from the document's own LaTeX and
+        // never contains untrusted scripts.
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: trusted KaTeX HTML
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </NodeViewWrapper>
+  );
+}

--- a/packages/app/src/MermaidCodeBlockView.tsx
+++ b/packages/app/src/MermaidCodeBlockView.tsx
@@ -1,0 +1,140 @@
+import {
+  NodeViewContent,
+  type NodeViewProps,
+  NodeViewWrapper,
+} from "@tiptap/react";
+import { useEffect, useState } from "react";
+
+type MermaidApi = {
+  initialize: (config: Record<string, unknown>) => void;
+  render: (id: string, code: string) => Promise<{ svg: string }>;
+};
+
+let mermaidPromise: Promise<MermaidApi> | null = null;
+
+// Lazy-load mermaid so its weight only lands when a diagram is actually shown.
+async function loadMermaid(): Promise<MermaidApi> {
+  if (!mermaidPromise) {
+    mermaidPromise = import("mermaid").then((module) => {
+      const mermaid = module.default as unknown as MermaidApi;
+      return mermaid;
+    });
+  }
+  return mermaidPromise;
+}
+
+function isDarkTheme(): boolean {
+  return (
+    typeof document !== "undefined" &&
+    document.documentElement.classList.contains("dark")
+  );
+}
+
+let renderCounter = 0;
+
+async function renderDiagram(code: string, dark: boolean): Promise<string> {
+  const mermaid = await loadMermaid();
+  mermaid.initialize({
+    startOnLoad: false,
+    securityLevel: "strict",
+    theme: dark ? "dark" : "default",
+  });
+  renderCounter += 1;
+  const { svg } = await mermaid.render(`mermaid-${renderCounter}`, code);
+  return svg;
+}
+
+function MermaidDiagram({ code }: { code: string }) {
+  const [svg, setSvg] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+  const dark = isDarkTheme();
+
+  useEffect(() => {
+    let active = true;
+    const trimmed = code.trim();
+    if (!trimmed) {
+      setSvg("");
+      setError(null);
+      return;
+    }
+
+    renderDiagram(trimmed, dark)
+      .then((nextSvg) => {
+        if (!active) return;
+        setSvg(nextSvg);
+        setError(null);
+      })
+      .catch((renderError: unknown) => {
+        if (!active) return;
+        setSvg("");
+        setError(
+          renderError instanceof Error
+            ? renderError.message
+            : String(renderError),
+        );
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [code, dark]);
+
+  if (error) {
+    return (
+      <div className="mermaid-diagram mermaid-diagram--error" role="img">
+        <p className="mermaid-diagram__error-title">Could not render diagram</p>
+        <pre className="mermaid-diagram__source">
+          <code>{code}</code>
+        </pre>
+        <p className="mermaid-diagram__error-detail">{error}</p>
+      </div>
+    );
+  }
+
+  if (!svg) {
+    return (
+      <div
+        className="mermaid-diagram mermaid-diagram--loading"
+        aria-busy="true"
+      >
+        Rendering diagram…
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="mermaid-diagram"
+      data-testid="mermaid-diagram-rendered"
+      // mermaid output is sanitized via securityLevel: "strict"
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: trusted mermaid SVG
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+}
+
+export function MermaidCodeBlockView(props: NodeViewProps) {
+  const language = (props.node.attrs.language as string | null) ?? "";
+
+  if (language === "mermaid") {
+    return (
+      <NodeViewWrapper
+        as="div"
+        className="mermaid-block"
+        data-testid="mermaid-diagram"
+        contentEditable={false}
+        // ProseMirror should treat the rendered diagram as an opaque leaf in
+        // the editor; the markdown source still lives in the node and is what
+        // serializes back to a ```mermaid fence.
+      >
+        <MermaidDiagram code={props.node.textContent} />
+      </NodeViewWrapper>
+    );
+  }
+
+  return (
+    <NodeViewWrapper as="pre">
+      <NodeViewContent<"code"> as="code" />
+    </NodeViewWrapper>
+  );
+}

--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -1448,6 +1448,36 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
     };
   }, [editor]);
 
+  const scrollToAnchor = useCallback((dom: HTMLElement, rawId: string) => {
+    if (!rawId) return;
+    let id = rawId;
+    try {
+      id = decodeURIComponent(rawId);
+    } catch {
+      // Use the raw value if it is not valid percent-encoding.
+    }
+    const escaped =
+      typeof CSS !== "undefined" && CSS.escape ? CSS.escape(id) : id;
+    const target =
+      dom.querySelector(`#${escaped}`) ??
+      dom.querySelector(`[name="${escaped}"]`);
+    target?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
+
+  // Scroll to the URL hash once a document renders, so following a
+  // `doc.md#REQ-11` link to another file lands on the matching anchor (the
+  // anchorTarget node preserves those ids). Same-document anchor clicks are
+  // handled directly in the click handler below.
+  useEffect(() => {
+    if (!editor) return;
+    const hash = window.location.hash.slice(1);
+    if (!hash) return;
+
+    const dom = editor.view.dom;
+    const frame = requestAnimationFrame(() => scrollToAnchor(dom, hash));
+    return () => cancelAnimationFrame(frame);
+  }, [editor, scrollToAnchor]);
+
   // Make rendered links clickable. Links to sibling markdown files navigate
   // in-app (staying in directory mode when active); same-document anchors
   // scroll; external links and raw files open in a new tab. The Link extension
@@ -1461,17 +1491,6 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
       backend.info.projectPath && activeDocumentPath
         ? joinPath(backend.info.projectPath, activeDocumentPath)
         : null;
-
-    const scrollToAnchor = (rawId: string) => {
-      if (!rawId) return;
-      const id = decodeURIComponent(rawId);
-      const escaped =
-        typeof CSS !== "undefined" && CSS.escape ? CSS.escape(id) : id;
-      const target =
-        dom.querySelector(`#${escaped}`) ??
-        dom.querySelector(`[name="${escaped}"]`);
-      target?.scrollIntoView({ behavior: "smooth", block: "start" });
-    };
 
     const handleClick = (event: MouseEvent) => {
       if (event.defaultPrevented || event.button !== 0) return;
@@ -1489,7 +1508,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
 
       if (href.startsWith("#")) {
         event.preventDefault();
-        scrollToAnchor(href.slice(1));
+        scrollToAnchor(dom, href.slice(1));
         return;
       }
 
@@ -1518,7 +1537,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
       // Same-document anchor: scroll instead of reloading the document.
       const targetPath = url.searchParams.get("path");
       if (url.hash && targetPath && targetPath === currentAbsolutePath) {
-        scrollToAnchor(url.hash.slice(1));
+        scrollToAnchor(dom, url.hash.slice(1));
         return;
       }
 
@@ -1536,7 +1555,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
     return () => {
       dom.removeEventListener("click", handleClick);
     };
-  }, [editor, backend, activeDocumentPath]);
+  }, [editor, backend, activeDocumentPath, scrollToAnchor]);
 
   useEffect(() => {
     const handleDocumentPointerDown = (event: PointerEvent) => {

--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -30,7 +30,10 @@ import {
 } from "./editor-extensions";
 import { cn } from "./lib/utils";
 import { MarkdownCodeEditor } from "./MarkdownCodeEditor";
-import { buildLocationForLinkedMarkdownDocument } from "./app-navigation";
+import {
+  buildLocationForLinkedMarkdownDocument,
+  joinPath,
+} from "./app-navigation";
 import { toHtml } from "./markdown";
 import type { Page, StorageBackend } from "./storage";
 import { useCommentAnchorLayout } from "./useCommentAnchorLayout";
@@ -1444,6 +1447,96 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
       }
     };
   }, [editor]);
+
+  // Make rendered links clickable. Links to sibling markdown files navigate
+  // in-app (staying in directory mode when active); same-document anchors
+  // scroll; external links and raw files open in a new tab. The Link extension
+  // keeps `openOnClick: false` so this handler stays the single source of
+  // truth for link behavior.
+  useEffect(() => {
+    if (!editor) return;
+
+    const dom = editor.view.dom;
+    const currentAbsolutePath =
+      backend.info.projectPath && activeDocumentPath
+        ? joinPath(backend.info.projectPath, activeDocumentPath)
+        : null;
+
+    const scrollToAnchor = (rawId: string) => {
+      if (!rawId) return;
+      const id = decodeURIComponent(rawId);
+      const escaped =
+        typeof CSS !== "undefined" && CSS.escape ? CSS.escape(id) : id;
+      const target =
+        dom.querySelector(`#${escaped}`) ??
+        dom.querySelector(`[name="${escaped}"]`);
+      target?.scrollIntoView({ behavior: "smooth", block: "start" });
+    };
+
+    const handleClick = (event: MouseEvent) => {
+      if (event.defaultPrevented || event.button !== 0) return;
+      // Let modified clicks fall through so the browser can open a new tab.
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+        return;
+      }
+
+      const target = event.target as HTMLElement | null;
+      const anchor = target?.closest("a[href]") as HTMLAnchorElement | null;
+      if (!anchor || !dom.contains(anchor)) return;
+
+      const href = anchor.getAttribute("href");
+      if (!href) return;
+
+      if (href.startsWith("#")) {
+        event.preventDefault();
+        scrollToAnchor(href.slice(1));
+        return;
+      }
+
+      let url: URL;
+      try {
+        url = new URL(href, window.location.origin);
+      } catch {
+        return;
+      }
+
+      if (url.origin !== window.location.origin) {
+        event.preventDefault();
+        window.open(href, "_blank", "noopener,noreferrer");
+        return;
+      }
+
+      // Raw files/assets served by the backend (e.g. images, attachments).
+      if (url.pathname.startsWith("/api/")) {
+        event.preventDefault();
+        window.open(href, "_blank", "noopener,noreferrer");
+        return;
+      }
+
+      event.preventDefault();
+
+      // Same-document anchor: scroll instead of reloading the document.
+      const targetPath = url.searchParams.get("path");
+      if (url.hash && targetPath && targetPath === currentAbsolutePath) {
+        scrollToAnchor(url.hash.slice(1));
+        return;
+      }
+
+      if (url.searchParams.get("dir")) {
+        // SPA navigation that keeps the directory sidebar mounted.
+        window.history.pushState(null, "", href);
+        window.dispatchEvent(new PopStateEvent("popstate"));
+        return;
+      }
+
+      window.location.assign(href);
+    };
+
+    dom.addEventListener("click", handleClick);
+    return () => {
+      dom.removeEventListener("click", handleClick);
+    };
+  }, [editor, backend, activeDocumentPath]);
 
   useEffect(() => {
     const handleDocumentPointerDown = (event: PointerEvent) => {

--- a/packages/app/src/anchor-id-check.test.ts
+++ b/packages/app/src/anchor-id-check.test.ts
@@ -1,0 +1,24 @@
+import { generateHTML } from "@tiptap/core";
+import { describe, expect, it } from "vitest";
+import {
+  criticMarkdownToEditorState,
+  editorStateToCriticMarkdown,
+} from "./critic-markup";
+import { createEditorExtensions } from "./editor-extensions";
+
+const extensions = createEditorExtensions("");
+const SOURCE = '# Heading\n\n**<a id="REQ-11"></a>REQ-11** is a requirement.\n';
+
+describe("in-document anchor targets", () => {
+  it("keeps an empty <a id> in the rendered editor doc", () => {
+    const { doc } = criticMarkdownToEditorState(SOURCE);
+    expect(generateHTML(doc, extensions)).toContain('id="REQ-11"');
+  });
+
+  it("round-trips the anchor back to markdown", () => {
+    const { doc, comments } = criticMarkdownToEditorState(SOURCE);
+    expect(editorStateToCriticMarkdown(doc, comments)).toContain(
+      '<a id="REQ-11"></a>',
+    );
+  });
+});

--- a/packages/app/src/api-backend.ts
+++ b/packages/app/src/api-backend.ts
@@ -43,10 +43,13 @@ export class ApiBackend implements StorageBackend {
   }
 
   async getMarkdownFile(relativePath: string): Promise<Page> {
+    // `no-store` so a manual reload or watcher-triggered refresh always reads
+    // the current file from disk rather than a cached HTTP response.
     const res = await fetch(
       this.buildUrl("/api/markdown-file", {
         path: relativePath,
       }),
+      { cache: "no-store" },
     );
     if (!res.ok) {
       throw new Error(
@@ -58,7 +61,9 @@ export class ApiBackend implements StorageBackend {
 
   async readTextFile(relativePath: string): Promise<string> {
     const normalized = relativePath.replace(/^\.?\//, "");
-    const res = await fetch(this.buildUrl("/api/files", { path: normalized }));
+    const res = await fetch(this.buildUrl("/api/files", { path: normalized }), {
+      cache: "no-store",
+    });
     if (!res.ok) {
       throw new Error(`Failed to read file ${relativePath}: ${res.status}`);
     }

--- a/packages/app/src/api-backend.ts
+++ b/packages/app/src/api-backend.ts
@@ -56,6 +56,15 @@ export class ApiBackend implements StorageBackend {
     return res.json();
   }
 
+  async readTextFile(relativePath: string): Promise<string> {
+    const normalized = relativePath.replace(/^\.?\//, "");
+    const res = await fetch(this.buildUrl("/api/files", { path: normalized }));
+    if (!res.ok) {
+      throw new Error(`Failed to read file ${relativePath}: ${res.status}`);
+    }
+    return res.text();
+  }
+
   async listFileTree(): Promise<FileTreeListing> {
     const res = await fetch(this.buildUrl("/api/file-tree"));
     if (!res.ok) {

--- a/packages/app/src/api-backend.ts
+++ b/packages/app/src/api-backend.ts
@@ -2,6 +2,7 @@ import {
   type BackendInfo,
   type CompleteReviewOptions,
   type CompleteReviewResult,
+  type FileTreeListing,
   type MarkdownFileChangeEvent,
   MarkdownFileConflictError,
   type Page,
@@ -51,6 +52,14 @@ export class ApiBackend implements StorageBackend {
       throw new Error(
         `Failed to get markdown file ${relativePath}: ${res.status}`,
       );
+    }
+    return res.json();
+  }
+
+  async listFileTree(): Promise<FileTreeListing> {
+    const res = await fetch(this.buildUrl("/api/file-tree"));
+    if (!res.ok) {
+      throw new Error(`Failed to list file tree: ${res.status}`);
     }
     return res.json();
   }

--- a/packages/app/src/app-navigation.test.ts
+++ b/packages/app/src/app-navigation.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
-  PREVIEW_PATH,
-  ROUGHDRAFT_FLAVORED_MARKDOWN_PATH,
+  buildLocationForDirectorySelection,
   buildLocationForLinkedMarkdownDocument,
   getRequestedPathState,
+  getWorkspaceState,
+  PREVIEW_PATH,
+  ROUGHDRAFT_FLAVORED_MARKDOWN_PATH,
   syncRequestedPathInUrl,
 } from "./app-navigation";
 
@@ -91,5 +93,89 @@ describe("app navigation", () => {
         href: "diagram.png",
       }),
     ).toBeNull();
+  });
+
+  it("reports single-file workspace state for a path query parameter", () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/?path=%2FUsers%2Fme%2Fproject%2Fdraft.md",
+    );
+
+    expect(getWorkspaceState()).toEqual({
+      mode: "single",
+      rawPath: "/Users/me/project/draft.md",
+      directoryPath: null,
+      projectPath: "/Users/me/project",
+      documentPath: "draft.md",
+    });
+  });
+
+  it("reports directory workspace state with no file selected", () => {
+    window.history.replaceState(null, "", "/?dir=%2FUsers%2Fme%2Fproject");
+
+    expect(getWorkspaceState()).toEqual({
+      mode: "directory",
+      rawPath: null,
+      directoryPath: "/Users/me/project",
+      projectPath: "/Users/me/project",
+      documentPath: null,
+    });
+  });
+
+  it("resolves a selected file relative to the directory root", () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/?dir=%2FUsers%2Fme%2Fproject&path=%2FUsers%2Fme%2Fproject%2Fnotes%2Falpha.md",
+    );
+
+    expect(getWorkspaceState()).toEqual({
+      mode: "directory",
+      rawPath: "/Users/me/project/notes/alpha.md",
+      directoryPath: "/Users/me/project",
+      projectPath: "/Users/me/project",
+      documentPath: "notes/alpha.md",
+    });
+  });
+
+  it("ignores a path outside the directory root", () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/?dir=%2FUsers%2Fme%2Fproject&path=%2FUsers%2Fme%2Fother%2Falpha.md",
+    );
+
+    expect(getWorkspaceState().documentPath).toBeNull();
+  });
+
+  it("builds directory selection locations preserving the directory root", () => {
+    window.history.replaceState(null, "", "/?dir=%2FUsers%2Fme%2Fproject");
+
+    const location = buildLocationForDirectorySelection(
+      "/Users/me/project",
+      "/Users/me/project/notes/alpha.md",
+    );
+    const params = new URLSearchParams(location.split("?")[1]);
+
+    expect(params.get("dir")).toBe("/Users/me/project");
+    expect(params.get("path")).toBe("/Users/me/project/notes/alpha.md");
+  });
+
+  it("clears the selected file when building a directory-only location", () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/?dir=%2FUsers%2Fme%2Fproject&path=%2FUsers%2Fme%2Fproject%2Fdraft.md",
+    );
+
+    const location = buildLocationForDirectorySelection(
+      "/Users/me/project",
+      null,
+    );
+    const params = new URLSearchParams(location.split("?")[1]);
+
+    expect(params.get("dir")).toBe("/Users/me/project");
+    expect(params.has("path")).toBe(false);
   });
 });

--- a/packages/app/src/app-navigation.test.ts
+++ b/packages/app/src/app-navigation.test.ts
@@ -85,6 +85,24 @@ describe("app navigation", () => {
     ).toBe("/?path=%2FUsers%2Fme%2Fproject%2Findex.md#summary");
   });
 
+  it("keeps directory mode when linking to a sibling document", () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/?dir=%2FUsers%2Fme%2Fproject&path=%2FUsers%2Fme%2Fproject%2Fnotes%2Fsource.md",
+    );
+
+    expect(
+      buildLocationForLinkedMarkdownDocument({
+        projectPath: "/Users/me/project",
+        currentDocumentPath: "notes/source.md",
+        href: "../index.md#summary",
+      }),
+    ).toBe(
+      "/?dir=%2FUsers%2Fme%2Fproject&path=%2FUsers%2Fme%2Fproject%2Findex.md#summary",
+    );
+  });
+
   it("leaves non-markdown links for the file resolver", () => {
     expect(
       buildLocationForLinkedMarkdownDocument({

--- a/packages/app/src/app-navigation.ts
+++ b/packages/app/src/app-navigation.ts
@@ -228,8 +228,15 @@ export function buildLocationForLinkedMarkdownDocument({
   const targetPath = decodeURI(targetUrl.pathname);
   const url = new URL(window.location.href);
 
+  // Preserve directory-review mode so following a sibling link keeps the
+  // sidebar tree and the directory's path boundary instead of dropping into
+  // single-file mode.
+  const currentDir = url.searchParams.get("dir");
   url.pathname = "/";
   url.search = "";
+  if (currentDir) {
+    url.searchParams.set("dir", currentDir);
+  }
   url.searchParams.set("path", targetPath);
   url.hash = linkedPath.hash;
 

--- a/packages/app/src/app-navigation.ts
+++ b/packages/app/src/app-navigation.ts
@@ -71,6 +71,75 @@ export function getRequestedPathState(): RequestedPathState {
   return { rawPath, projectPath, documentPath };
 }
 
+export type WorkspaceMode = "single" | "directory";
+
+export interface WorkspaceState {
+  mode: WorkspaceMode;
+  rawPath: string | null;
+  directoryPath: string | null;
+  projectPath: string | null;
+  documentPath: string | null;
+}
+
+function getDirectoryPathFromLocation(): string | null {
+  const searchParams = new URLSearchParams(window.location.search);
+  const directoryPath = searchParams.get("dir")?.trim();
+  return directoryPath || null;
+}
+
+function relativePathWithin(
+  basePath: string,
+  targetPath: string,
+): string | null {
+  const base = normalizePathSeparators(basePath).replace(/\/+$/, "");
+  const target = normalizePathSeparators(targetPath);
+  if (target === base) return null;
+
+  const prefix = `${base}/`;
+  if (!target.startsWith(prefix)) return null;
+
+  return target.slice(prefix.length) || null;
+}
+
+export function getWorkspaceState(): WorkspaceState {
+  const directoryPath = getDirectoryPathFromLocation();
+  if (directoryPath) {
+    const rawPath =
+      new URLSearchParams(window.location.search).get("path")?.trim() || null;
+    return {
+      mode: "directory",
+      rawPath,
+      directoryPath,
+      projectPath: directoryPath,
+      documentPath: rawPath ? relativePathWithin(directoryPath, rawPath) : null,
+    };
+  }
+
+  const single = getRequestedPathState();
+  return {
+    mode: "single",
+    rawPath: single.rawPath,
+    directoryPath: null,
+    projectPath: single.projectPath,
+    documentPath: single.documentPath,
+  };
+}
+
+export function buildLocationForDirectorySelection(
+  directoryPath: string,
+  fileAbsolutePath: string | null,
+): string {
+  const url = new URL(window.location.href);
+  url.pathname = "/";
+  url.searchParams.set("dir", directoryPath);
+  if (fileAbsolutePath) {
+    url.searchParams.set("path", fileAbsolutePath);
+  } else {
+    url.searchParams.delete("path");
+  }
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
 export function formatWorkspacePathForDisplay(path?: string | null) {
   const value = path?.trim();
   if (!value) return null;

--- a/packages/app/src/critic-markup/index.ts
+++ b/packages/app/src/critic-markup/index.ts
@@ -16,6 +16,7 @@ import {
 } from "../editor-extensions";
 import {
   createMarkedRenderer,
+  createMathExtensions,
   createTurndownService,
   normalizeBlockSpacing,
   appendYamlEndmatter,
@@ -1263,6 +1264,7 @@ function createCriticMarked(
 
   parser.use({
     extensions: [
+      ...createMathExtensions(),
       {
         name: "criticCommentAnchor",
         level: "inline",

--- a/packages/app/src/editor-extensions.ts
+++ b/packages/app/src/editor-extensions.ts
@@ -712,7 +712,10 @@ const MarkdownLink = Link.extend({
 });
 
 const MarkdownCode = Code.extend({
-  excludes: "bold italic strike link",
+  // Keep `link` out of the exclusion list so an inline-code link such as
+  // [`AC-E`](doc.md#AC-E) keeps its link mark (and stays clickable) instead of
+  // collapsing to a bare <code> span. Bold/italic/strike stay excluded.
+  excludes: "bold italic strike",
 });
 
 const MarkdownCodeBlock = CodeBlock.extend({

--- a/packages/app/src/editor-extensions.ts
+++ b/packages/app/src/editor-extensions.ts
@@ -16,8 +16,10 @@ import type {
 } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import { ReactNodeViewRenderer } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { rawMarkdownBlockAttribute } from "./markdown";
+import { MermaidCodeBlockView } from "./MermaidCodeBlockView";
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
@@ -715,6 +717,10 @@ const MarkdownCode = Code.extend({
 
 const MarkdownCodeBlock = CodeBlock.extend({
   marks: "commentRef criticChange",
+
+  addNodeView() {
+    return ReactNodeViewRenderer(MermaidCodeBlockView);
+  },
 });
 
 const MarkdownImage = Image.extend({

--- a/packages/app/src/editor-extensions.ts
+++ b/packages/app/src/editor-extensions.ts
@@ -18,7 +18,13 @@ import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import { rawMarkdownBlockAttribute } from "./markdown";
+import {
+  mathBlockAttribute,
+  mathInlineAttribute,
+  mathLatexAttribute,
+  rawMarkdownBlockAttribute,
+} from "./markdown";
+import { MathView } from "./MathView";
 import { MermaidCodeBlockView } from "./MermaidCodeBlockView";
 
 declare module "@tiptap/core" {
@@ -776,6 +782,85 @@ const RawMarkdownBlock = Node.create({
   },
 });
 
+// Inline LaTeX math (`$…$`). The KaTeX render is an opaque atom; the LaTeX
+// source lives in `latex` and round-trips back to `$…$`.
+const MathInline = Node.create({
+  name: "mathInline",
+  group: "inline",
+  inline: true,
+  atom: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      latex: {
+        default: "",
+        parseHTML: (element) => element.getAttribute(mathLatexAttribute) ?? "",
+        renderHTML: (attributes) => ({
+          [mathLatexAttribute]: attributes.latex ?? "",
+        }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: `span[${mathInlineAttribute}]`, priority: 1000 }];
+  },
+
+  // The LaTeX source is emitted as text content (not just an attribute) so the
+  // serialized element is not "blank" — otherwise Turndown collapses it before
+  // the math rule can turn it back into `$…$`.
+  renderHTML({ node, HTMLAttributes }) {
+    return [
+      "span",
+      mergeAttributes(HTMLAttributes, { [mathInlineAttribute]: "" }),
+      (node.attrs.latex as string) ?? "",
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(MathView);
+  },
+});
+
+// Block LaTeX math (`$$…$$`).
+const MathBlock = Node.create({
+  name: "mathBlock",
+  group: "block",
+  atom: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      latex: {
+        default: "",
+        parseHTML: (element) => element.getAttribute(mathLatexAttribute) ?? "",
+        renderHTML: (attributes) => ({
+          [mathLatexAttribute]: attributes.latex ?? "",
+        }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: `div[${mathBlockAttribute}]`, priority: 1000 }];
+  },
+
+  // See MathInline: emit the LaTeX as text so Turndown does not treat the node
+  // as blank and drop it before the math rule runs.
+  renderHTML({ node, HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, { [mathBlockAttribute]: "" }),
+      (node.attrs.latex as string) ?? "",
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(MathView);
+  },
+});
+
 // Preserve empty in-document anchors like `<a id="REQ-11"></a>` so they survive
 // the round-trip and exist in the rendered DOM as scroll targets for `#REQ-11`
 // links. Real links (`a[href]`) stay with the link mark.
@@ -847,6 +932,8 @@ export function createEditorExtensions(placeholder: string) {
     }),
     CommentRef,
     CriticChange,
+    MathInline,
+    MathBlock,
     RawMarkdownBlock,
     MarkdownCodeBlock,
     CommentHighlight,

--- a/packages/app/src/editor-extensions.ts
+++ b/packages/app/src/editor-extensions.ts
@@ -776,6 +776,45 @@ const RawMarkdownBlock = Node.create({
   },
 });
 
+// Preserve empty in-document anchors like `<a id="REQ-11"></a>` so they survive
+// the round-trip and exist in the rendered DOM as scroll targets for `#REQ-11`
+// links. Real links (`a[href]`) stay with the link mark.
+const AnchorTarget = Node.create({
+  name: "anchorTarget",
+  group: "inline",
+  inline: true,
+  atom: true,
+  selectable: false,
+
+  addAttributes() {
+    return {
+      anchorId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("id"),
+        renderHTML: (attributes) =>
+          attributes.anchorId ? { id: attributes.anchorId } : {},
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: "a[id]",
+        priority: 1100,
+        getAttrs: (element) =>
+          element.getAttribute("href")
+            ? false
+            : { anchorId: element.getAttribute("id") },
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["a", mergeAttributes(HTMLAttributes, { class: "anchor-target" })];
+  },
+});
+
 export function createEditorExtensions(placeholder: string) {
   return [
     StarterKit.configure({
@@ -795,6 +834,7 @@ export function createEditorExtensions(placeholder: string) {
       linkOnPaste: true,
     }),
     MarkdownCode,
+    AnchorTarget,
     Table.configure({
       resizable: true,
     }),

--- a/packages/app/src/file-types.test.ts
+++ b/packages/app/src/file-types.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { classifyFile, isMarkdownPath, isOpenableFile } from "./file-types";
+
+describe("classifyFile", () => {
+  it("treats only .md as the interactive markdown unit of work", () => {
+    expect(classifyFile("notes/plan.md").kind).toBe("markdown");
+    expect(classifyFile("PLAN.MD").kind).toBe("markdown");
+    // `.markdown`/`.mdx` are read-only text because the server only serves .md.
+    expect(classifyFile("readme.markdown").kind).toBe("text");
+    expect(classifyFile("doc.mdx").kind).toBe("text");
+  });
+
+  it("classifies source files as code", () => {
+    for (const path of [
+      "src/app.ts",
+      "src/App.tsx",
+      "main.py",
+      "lib.rs",
+      "styles.css",
+      "config.yaml",
+      "Dockerfile",
+      "Makefile",
+    ]) {
+      expect(classifyFile(path).kind, path).toBe("code");
+    }
+  });
+
+  it("classifies images so they can be previewed", () => {
+    expect(classifyFile("assets/diagram.png").kind).toBe("image");
+    expect(classifyFile("logo.SVG").kind).toBe("image");
+  });
+
+  it("classifies known non-text files as binary", () => {
+    expect(classifyFile("report.pdf").kind).toBe("binary");
+    expect(classifyFile("archive.zip").kind).toBe("binary");
+    expect(classifyFile("font.woff2").kind).toBe("binary");
+  });
+
+  it("falls back to readable text for plain and extensionless files", () => {
+    expect(classifyFile("notes.txt").kind).toBe("text");
+    expect(classifyFile("server.log").kind).toBe("text");
+    expect(classifyFile("LICENSE").kind).toBe("text");
+    expect(classifyFile("data.csv").kind).toBe("text");
+  });
+});
+
+describe("isMarkdownPath", () => {
+  it("matches the server's .md gate", () => {
+    expect(isMarkdownPath("a.md")).toBe(true);
+    expect(isMarkdownPath("a.markdown")).toBe(false);
+    expect(isMarkdownPath("a.txt")).toBe(false);
+  });
+});
+
+describe("isOpenableFile", () => {
+  it("opens everything except non-previewable binaries", () => {
+    expect(isOpenableFile("a.md")).toBe(true);
+    expect(isOpenableFile("a.ts")).toBe(true);
+    expect(isOpenableFile("a.png")).toBe(true);
+    expect(isOpenableFile("a.zip")).toBe(false);
+  });
+});

--- a/packages/app/src/file-types.ts
+++ b/packages/app/src/file-types.ts
@@ -1,0 +1,237 @@
+/**
+ * Classify a file in the directory tree so the workspace knows how to present
+ * it. Markdown is the only fully interactive unit of work (review, comment,
+ * edit, save per ADR 0001/0005); every other file is opened read-only — code
+ * with syntax highlighting, plain text as-is, images as a preview, and
+ * anything else as a non-previewable stub.
+ */
+export type FileKind = "markdown" | "code" | "text" | "image" | "binary";
+
+export interface FileTypeInfo {
+  kind: FileKind;
+}
+
+/**
+ * Markdown is detected exactly the way the server gates `/api/markdown-file`
+ * (`endsWith(".md")`), so `.markdown` and `.mdx` are intentionally treated as
+ * read-only text rather than routed into the comment/edit workspace where the
+ * server would reject them.
+ */
+export function isMarkdownPath(path: string): boolean {
+  return path.toLowerCase().endsWith(".md");
+}
+
+const IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "svg",
+  "webp",
+  "avif",
+  "bmp",
+  "ico",
+]);
+
+// Files that are not text we can usefully render in a code viewer. Images are
+// handled separately above; everything here falls back to a "no preview" stub.
+const BINARY_EXTENSIONS = new Set([
+  "pdf",
+  "zip",
+  "gz",
+  "tgz",
+  "tar",
+  "rar",
+  "7z",
+  "bz2",
+  "xz",
+  "exe",
+  "dll",
+  "so",
+  "dylib",
+  "bin",
+  "dat",
+  "wasm",
+  "class",
+  "jar",
+  "node",
+  "pyc",
+  "o",
+  "a",
+  "lib",
+  "woff",
+  "woff2",
+  "ttf",
+  "otf",
+  "eot",
+  "mp3",
+  "wav",
+  "flac",
+  "ogg",
+  "m4a",
+  "aac",
+  "mp4",
+  "mov",
+  "avi",
+  "mkv",
+  "webm",
+  "wmv",
+  "doc",
+  "docx",
+  "xls",
+  "xlsx",
+  "ppt",
+  "pptx",
+  "odt",
+  "ods",
+  "odp",
+  "pages",
+  "numbers",
+  "key",
+  "psd",
+  "ai",
+  "sketch",
+  "fig",
+  "db",
+  "sqlite",
+  "sqlite3",
+]);
+
+// Extensions that read as source code; used to pick the code icon. The viewer
+// itself attempts syntax highlighting for any matched language, so this set
+// only needs to be good enough to distinguish code from prose at a glance.
+const CODE_EXTENSIONS = new Set([
+  "js",
+  "jsx",
+  "mjs",
+  "cjs",
+  "ts",
+  "tsx",
+  "mts",
+  "cts",
+  "json",
+  "json5",
+  "jsonc",
+  "py",
+  "pyi",
+  "rb",
+  "go",
+  "rs",
+  "java",
+  "kt",
+  "kts",
+  "swift",
+  "c",
+  "h",
+  "cc",
+  "cpp",
+  "cxx",
+  "hpp",
+  "hh",
+  "cs",
+  "php",
+  "sh",
+  "bash",
+  "zsh",
+  "fish",
+  "ps1",
+  "sql",
+  "html",
+  "htm",
+  "xhtml",
+  "css",
+  "scss",
+  "sass",
+  "less",
+  "vue",
+  "svelte",
+  "astro",
+  "yaml",
+  "yml",
+  "toml",
+  "ini",
+  "cfg",
+  "conf",
+  "xml",
+  "gradle",
+  "cmake",
+  "lua",
+  "r",
+  "dart",
+  "scala",
+  "clj",
+  "cljs",
+  "cljc",
+  "edn",
+  "ex",
+  "exs",
+  "erl",
+  "hrl",
+  "hs",
+  "ml",
+  "mli",
+  "fs",
+  "fsx",
+  "pl",
+  "pm",
+  "proto",
+  "graphql",
+  "gql",
+  "tf",
+  "tfvars",
+  "hcl",
+  "bat",
+  "cmd",
+  "zig",
+  "nim",
+  "jl",
+  "groovy",
+  "tcl",
+  "vim",
+]);
+
+// Well-known filenames without a useful extension that are still source code.
+const CODE_FILENAMES = new Set([
+  "dockerfile",
+  "makefile",
+  "rakefile",
+  "gemfile",
+  "brewfile",
+  "procfile",
+  "vagrantfile",
+  "jenkinsfile",
+  "cmakelists.txt",
+]);
+
+function fileName(path: string): string {
+  const segments = path.split("/");
+  return segments[segments.length - 1] ?? path;
+}
+
+function extensionOf(name: string): string {
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0) return "";
+  return name.slice(dot + 1).toLowerCase();
+}
+
+export function classifyFile(path: string): FileTypeInfo {
+  if (isMarkdownPath(path)) return { kind: "markdown" };
+
+  const name = fileName(path).toLowerCase();
+  const extension = extensionOf(name);
+
+  if (extension && IMAGE_EXTENSIONS.has(extension)) return { kind: "image" };
+  if (extension && BINARY_EXTENSIONS.has(extension)) return { kind: "binary" };
+
+  if (CODE_FILENAMES.has(name)) return { kind: "code" };
+  if (extension && CODE_EXTENSIONS.has(extension)) return { kind: "code" };
+
+  // Anything else that is not known-binary — including extensionless files like
+  // LICENSE or README and plain `.txt`/`.log` — is treated as readable text.
+  return { kind: "text" };
+}
+
+/** Files we can open read-only (everything except non-previewable binaries). */
+export function isOpenableFile(path: string): boolean {
+  return classifyFile(path).kind !== "binary";
+}

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import "katex/dist/katex.min.css";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { App } from "./App";
 import "./style.css";

--- a/packages/app/src/markdown.ts
+++ b/packages/app/src/markdown.ts
@@ -1,7 +1,13 @@
 import { tables, taskListItems } from "@joplin/turndown-plugin-gfm";
+import katex from "katex";
 import { marked } from "marked";
+import type { TokenizerAndRendererExtension, Tokens } from "marked";
 import TurndownService from "turndown";
 import { parse as parseYaml } from "yaml";
+
+export const mathInlineAttribute = "data-math-inline";
+export const mathBlockAttribute = "data-math-block";
+export const mathLatexAttribute = "data-latex";
 
 export const rawMarkdownBlockAttribute = "data-markdown-raw-block";
 
@@ -314,6 +320,98 @@ export function appendYamlEndmatter(
     : markdown;
 }
 
+interface MathToken extends Tokens.Generic {
+  latex: string;
+  display: boolean;
+}
+
+/**
+ * Render LaTeX to self-contained HTML+MathML. `throwOnError: false` makes KaTeX
+ * emit an inline error node instead of throwing, so a malformed formula never
+ * breaks the whole document render.
+ */
+export function renderKatex(latex: string, displayMode: boolean): string {
+  try {
+    return katex.renderToString(latex, {
+      displayMode,
+      throwOnError: false,
+      output: "htmlAndMathml",
+    });
+  } catch {
+    return escapeHtml(latex);
+  }
+}
+
+/**
+ * `marked` extensions that recognise TeX math: `$$…$$` as a standalone block
+ * and `$…$` inline. The rendered output keeps the raw LaTeX in a data
+ * attribute so the Tiptap editor can re-render it and round-trip back to
+ * markdown without depending on the KaTeX HTML.
+ */
+export function createMathExtensions(): TokenizerAndRendererExtension[] {
+  return [
+    {
+      name: "mathBlock",
+      level: "block",
+      start(src: string) {
+        const index = src.indexOf("$$");
+        return index < 0 ? undefined : index;
+      },
+      tokenizer(src: string) {
+        const match = /^\$\$[ \t]*\n?([\s\S]+?)\n?[ \t]*\$\$(?:\n|$)/.exec(src);
+        if (!match) return undefined;
+        const latex = match[1].trim();
+        if (!latex) return undefined;
+        return {
+          type: "mathBlock",
+          raw: match[0],
+          latex,
+          display: true,
+        } satisfies MathToken;
+      },
+      renderer(token) {
+        const math = token as MathToken;
+        return `<div ${mathBlockAttribute} ${mathLatexAttribute}="${escapeHtml(
+          math.latex,
+        )}">${renderKatex(math.latex, true)}</div>\n`;
+      },
+    },
+    {
+      name: "mathInline",
+      level: "inline",
+      start(src: string) {
+        const index = src.indexOf("$");
+        return index < 0 ? undefined : index;
+      },
+      tokenizer(src: string) {
+        // A single `$…$` with no `$$`, no surrounding whitespace just inside the
+        // delimiters, and support for escaped characters such as `\$` and `\{`.
+        const match = /^\$(?!\$)((?:\\.|[^$\\])+?)\$(?!\$)/.exec(src);
+        if (!match) return undefined;
+        const latex = match[1];
+        if (/^\s|\s$/.test(latex)) return undefined;
+        return {
+          type: "mathInline",
+          raw: match[0],
+          latex,
+          display: false,
+        } satisfies MathToken;
+      },
+      renderer(token) {
+        const math = token as MathToken;
+        return `<span ${mathInlineAttribute} ${mathLatexAttribute}="${escapeHtml(
+          math.latex,
+        )}">${renderKatex(math.latex, false)}</span>`;
+      },
+    },
+  ];
+}
+
+// Register math support on the shared `marked` singleton used by `toHtml`.
+// `createCriticMarked` builds its own `Marked` instance and registers the same
+// extensions there.
+marked.use({ extensions: createMathExtensions() });
+
 export function createMarkedRenderer(options?: MarkdownOptions) {
   const renderer = new marked.Renderer();
   const baseRenderer = new marked.Renderer();
@@ -526,6 +624,28 @@ export function createTurndownService(): TurndownService {
       node.nodeName === "STRIKE",
     replacement(content) {
       return `~~${content}~~`;
+    },
+  });
+
+  service.addRule("mathInline", {
+    filter: (node) =>
+      node.nodeType === 1 &&
+      (node as HTMLElement).hasAttribute(mathInlineAttribute),
+    replacement(_content, node) {
+      const latex =
+        (node as HTMLElement).getAttribute(mathLatexAttribute) ?? "";
+      return `$${latex}$`;
+    },
+  });
+
+  service.addRule("mathBlock", {
+    filter: (node) =>
+      node.nodeType === 1 &&
+      (node as HTMLElement).hasAttribute(mathBlockAttribute),
+    replacement(_content, node) {
+      const latex =
+        (node as HTMLElement).getAttribute(mathLatexAttribute) ?? "";
+      return `\n\n$$\n${latex}\n$$\n\n`;
     },
   });
 

--- a/packages/app/src/markdown.ts
+++ b/packages/app/src/markdown.ts
@@ -464,6 +464,15 @@ export function createTurndownService(): TurndownService {
     filter: "a",
     replacement(content, node) {
       const element = node as HTMLAnchorElement;
+
+      // Empty in-document anchors (`<a id="REQ-11"></a>`, no href) are scroll
+      // targets, not links — preserve them as raw HTML instead of turning them
+      // into an empty `[](./)` link.
+      const anchorId = element.getAttribute("id");
+      if (anchorId && !element.getAttribute("href")) {
+        return `<a id="${anchorId}"></a>`;
+      }
+
       const href =
         element.getAttribute("data-markdown-src") ||
         element.getAttribute("href") ||

--- a/packages/app/src/markdown.ts
+++ b/packages/app/src/markdown.ts
@@ -74,7 +74,14 @@ function protectIndentedCodeAfterLists(markdown: string): string {
 }
 
 function codeSpanContainsPipe(value: string): boolean {
-  return /`[^`\n]*\|[^`\n]*`/.test(value);
+  // Match each real code span and check whether its contents hold a pipe. A
+  // naive `/`[^`\n]*\|[^`\n]*`/` regex false-positives across two separate code
+  // spans: it pairs the closing backtick of one span with the opening backtick
+  // of the next and treats the cell-separator `|` between them as "inside" a
+  // code span, which wrongly protected (and dropped) any table row with two or
+  // more code-span links.
+  const codeSpans = value.match(/`[^`\n]+`/g) ?? [];
+  return codeSpans.some((span) => span.includes("|"));
 }
 
 function protectPipeSensitiveTables(markdown: string): string {

--- a/packages/app/src/storage.ts
+++ b/packages/app/src/storage.ts
@@ -57,6 +57,12 @@ export interface StorageBackend {
   info: BackendInfo;
   canManageProjects: boolean;
   getMarkdownFile(relativePath: string): Promise<Page>;
+  /**
+   * Read any file in the project as text, for the read-only viewer used on
+   * non-markdown files in directory mode. Unlike `getMarkdownFile` this is not
+   * gated to `.md` and never returns review/edit state.
+   */
+  readTextFile?(relativePath: string): Promise<string>;
   listFileTree?(): Promise<FileTreeListing>;
   saveMarkdownFile(
     relativePath: string,

--- a/packages/app/src/storage.ts
+++ b/packages/app/src/storage.ts
@@ -49,10 +49,15 @@ export interface BackendInfo {
   originPath?: string;
 }
 
+export interface FileTreeListing {
+  paths: string[];
+}
+
 export interface StorageBackend {
   info: BackendInfo;
   canManageProjects: boolean;
   getMarkdownFile(relativePath: string): Promise<Page>;
+  listFileTree?(): Promise<FileTreeListing>;
   saveMarkdownFile(
     relativePath: string,
     content: string,

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -367,6 +367,43 @@
     @apply bg-transparent p-0 text-inherit;
   }
 
+  .tiptap .mermaid-block {
+    margin: 1.35em 0;
+  }
+
+  .mermaid-diagram {
+    @apply flex justify-center overflow-x-auto rounded-2xl border p-4;
+    background-color: var(--code-block-background);
+    border-color: var(--code-block-border);
+  }
+
+  .mermaid-diagram svg {
+    max-width: 100%;
+    height: auto;
+  }
+
+  .mermaid-diagram--loading {
+    @apply justify-start text-sm text-slate-400;
+  }
+
+  .mermaid-diagram--error {
+    @apply flex-col items-stretch gap-2 text-sm;
+  }
+
+  .mermaid-diagram__error-title {
+    @apply font-medium text-red-600 dark:text-red-400;
+  }
+
+  .mermaid-diagram__error-detail {
+    @apply text-xs text-red-600/80 dark:text-red-400/80;
+  }
+
+  .mermaid-diagram__source {
+    @apply overflow-x-auto rounded-lg p-2 text-xs;
+    background-color: var(--code-block-background);
+    color: var(--code-block-foreground);
+  }
+
   .tiptap blockquote {
     @apply border-l-4 border-slate-300 dark:border-slate-600 pl-4 text-slate-600 dark:text-slate-400;
     margin: 1.3em 0;

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -846,6 +846,13 @@
     column-gap: 0rem;
   }
 
+  /* full-width: let the document column fill the available space instead of
+     capping at the readable 46.5rem measure */
+  .review-layout-grid.review-layout-grid--full-width {
+    grid-template-columns: minmax(0, 1fr) var(--review-rail-width);
+    justify-content: stretch;
+  }
+
   .review-layout-grid > .review-layout-main {
     grid-column: 1;
   }

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -418,6 +418,14 @@
     color: var(--code-block-foreground);
   }
 
+  .math-block {
+    @apply my-5 overflow-x-auto text-center;
+  }
+
+  .math-inline {
+    @apply inline-block;
+  }
+
   .tiptap blockquote {
     @apply border-l-4 border-slate-300 dark:border-slate-600 pl-4 text-slate-600 dark:text-slate-400;
     margin: 1.3em 0;

--- a/packages/app/src/style.css
+++ b/packages/app/src/style.css
@@ -829,6 +829,12 @@
   transform: translateX(var(--review-layout-shift-x));
 }
 
+/* Full-width mode drops the readable-measure cap on the document column at all
+   widths (the grid-template override below handles the >=1100px grid). */
+[data-full-width="true"] .review-layout-main {
+  max-width: none;
+}
+
 @media (min-width: 1100px) {
   .review-layout-grid {
     display: grid;
@@ -847,8 +853,10 @@
   }
 
   /* full-width: let the document column fill the available space instead of
-     capping at the readable 46.5rem measure */
-  .review-layout-grid.review-layout-grid--full-width {
+     capping at the readable 46.5rem measure. Scoped to a `data-full-width`
+     ancestor so it covers both the header row and the PageCard body, which
+     share the review-layout-grid / review-layout-main classes. */
+  [data-full-width="true"] .review-layout-grid {
     grid-template-columns: minmax(0, 1fr) var(--review-rail-width);
     justify-content: stretch;
   }

--- a/packages/app/src/table-link-protection.test.ts
+++ b/packages/app/src/table-link-protection.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { criticMarkdownToEditorState } from "./critic-markup";
+import {
+  protectRichTextRoundTripMarkdown,
+  rawMarkdownBlockAttribute,
+} from "./markdown";
+
+const HEADER = `| ID | Metric | Notes |
+|----|--------|-------|`;
+
+function tableCount(markdown: string): number {
+  const { doc } = criticMarkdownToEditorState(markdown);
+  let count = 0;
+  const visit = (node: { type?: string; content?: unknown[] }) => {
+    if (node.type === "table") count += 1;
+    for (const child of (node.content ?? []) as (typeof node)[]) visit(child);
+  };
+  visit(doc as never);
+  return count;
+}
+
+describe("table rows with multiple code-span links", () => {
+  it("renders a table when a row has two links (regression)", () => {
+    // Two code-span links in one row used to false-trigger pipe protection,
+    // wrapping the whole table in a raw block so it vanished from rich text.
+    const markdown = `${HEADER}
+| M-1 | x | see ([\`M-16\`](06-metrics.md#M-16)) and ([\`ADR-6\`](decisions/0006.md)) |
+`;
+    expect(tableCount(markdown)).toBe(1);
+  });
+
+  it("does not protect a table whose code spans merely sit on either side of a cell pipe", () => {
+    const markdown = `${HEADER}
+| M-1 | x | a (\`one\`) | b (\`two\`) |
+`;
+    expect(protectRichTextRoundTripMarkdown(markdown)).not.toContain(
+      rawMarkdownBlockAttribute,
+    );
+  });
+
+  it("still protects a table whose code span genuinely contains a pipe", () => {
+    // A literal `|` inside a code span would confuse the GFM table parser, so
+    // the table must stay protected as a raw block.
+    const markdown = `${HEADER}
+| M-1 | x | run \`a | b\` here |
+`;
+    expect(protectRichTextRoundTripMarkdown(markdown)).toContain(
+      rawMarkdownBlockAttribute,
+    );
+  });
+});

--- a/packages/app/src/view-preferences.test.ts
+++ b/packages/app/src/view-preferences.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  readFullWidthPreference,
+  writeFullWidthPreference,
+} from "./view-preferences";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("full-width view preference", () => {
+  it("defaults to false when nothing is stored", () => {
+    expect(readFullWidthPreference()).toBe(false);
+  });
+
+  it("round-trips an enabled preference", () => {
+    writeFullWidthPreference(true);
+    expect(readFullWidthPreference()).toBe(true);
+  });
+
+  it("round-trips a disabled preference", () => {
+    writeFullWidthPreference(true);
+    writeFullWidthPreference(false);
+    expect(readFullWidthPreference()).toBe(false);
+  });
+});

--- a/packages/app/src/view-preferences.ts
+++ b/packages/app/src/view-preferences.ts
@@ -1,0 +1,21 @@
+// Persisted, machine-local view preferences (survive across runs via
+// localStorage). These are UI-only toggles, never document content.
+
+const FULL_WIDTH_KEY = "roughdraft:full-width";
+
+export function readFullWidthPreference(): boolean {
+  try {
+    return localStorage.getItem(FULL_WIDTH_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function writeFullWidthPreference(value: boolean): void {
+  try {
+    localStorage.setItem(FULL_WIDTH_KEY, value ? "true" : "false");
+  } catch {
+    // Ignore storage failures (private mode, disabled storage); the toggle
+    // still works for the current session.
+  }
+}

--- a/packages/app/test/critic-markup.test.ts
+++ b/packages/app/test/critic-markup.test.ts
@@ -46,6 +46,21 @@ describe("CriticMarkup comments", () => {
     expect(editorStateToCriticMarkdown(doc, comments)).toBe(input);
   });
 
+  it("round-trips a mermaid fenced code block without rewriting it", () => {
+    const input = [
+      "```mermaid",
+      "graph TD;",
+      "  A-->B;",
+      "  A-->C;",
+      "```",
+      "",
+    ].join("\n");
+
+    const { doc, comments } = criticMarkdownToEditorState(input);
+
+    expect(editorStateToCriticMarkdown(doc, comments)).toBe(input);
+  });
+
   it("detects review rail content without counting fenced examples", () => {
     expect(
       criticMarkdownHasReviewRail(

--- a/packages/app/test/math.test.ts
+++ b/packages/app/test/math.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  criticMarkdownToEditorState,
+  editorStateToCriticMarkdown,
+} from "../src/critic-markup";
+import { toHtml } from "../src/markdown";
+
+function roundTrip(input: string): string {
+  const { doc, comments } = criticMarkdownToEditorState(input);
+  return editorStateToCriticMarkdown(doc, comments);
+}
+
+describe("LaTeX math rendering", () => {
+  it("renders inline $...$ as KaTeX with the source preserved", () => {
+    const html = toHtml("Score is $x^2$ here.");
+    expect(html).toContain("data-math-inline");
+    expect(html).toContain('data-latex="x^2"');
+    // KaTeX emits a `.katex` wrapper around the rendered formula.
+    expect(html).toContain('class="katex"');
+  });
+
+  it("renders block $$...$$ as KaTeX", () => {
+    const html = toHtml("$$\n\\sum_{n=1}^{N} w_n\n$$");
+    expect(html).toContain("data-math-block");
+    expect(html).toContain('class="katex');
+  });
+
+  it("does not treat a lone dollar sign as math", () => {
+    const html = toHtml("It costs $5 today.");
+    expect(html).not.toContain("data-math-inline");
+    expect(html).toContain("$5");
+  });
+});
+
+describe("LaTeX math round-trip", () => {
+  it("round-trips an inline formula", () => {
+    const input =
+      "BLEU is $BP \\cdot \\exp(\\sum_{n=1}^{N} w_n \\ln p_n)$ overall.\n";
+    expect(roundTrip(input)).toBe(input);
+  });
+
+  it("round-trips a standalone block formula", () => {
+    const input = ["$$", "F = \\frac{2 P R}{P + R}", "$$", ""].join("\n");
+    expect(roundTrip(input)).toBe(input);
+  });
+});

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -260,7 +260,7 @@ describe("cli", () => {
     fs.writeFileSync(documentPath, "# Draft\n");
 
     const exitCode = await runCli(
-      ["open", documentPath, "--no-watch"],
+      ["open", "--open", documentPath, "--no-watch"],
       test.deps,
     );
     const persisted = JSON.parse(
@@ -275,12 +275,35 @@ describe("cli", () => {
     expect(fs.existsSync(getServerStateFilePath(test.deps.env))).toBeTruthy();
   });
 
+  it("prints the URL without launching a browser by default", async () => {
+    const test = createTestDependencies();
+    const documentPath = path.join(projectDir, "draft.md");
+    fs.writeFileSync(documentPath, "# Draft\n");
+
+    const exitCode = await runCli(
+      ["open", documentPath, "--no-watch"],
+      test.deps,
+    );
+    const persisted = JSON.parse(
+      fs.readFileSync(getServerStateFilePath(test.deps.env), "utf8"),
+    ) as { port: number };
+
+    expect(exitCode).toBe(0);
+    expect(test.getLastOpenedUrl()).toBeNull();
+    expect(test.logs).toContain(
+      `Roughdraft is running at ${expectedOpenUrl(
+        `http://localhost:${persisted.port}`,
+        documentPath,
+      )}`,
+    );
+  });
+
   it("opens a directory with a dir-scoped URL", async () => {
     const test = createTestDependencies();
     fs.mkdirSync(path.join(projectDir, "sub"), { recursive: true });
     fs.writeFileSync(path.join(projectDir, "draft.md"), "# Draft\n");
 
-    const exitCode = await runCli(["open", projectDir], test.deps);
+    const exitCode = await runCli(["open", "--open", projectDir], test.deps);
     const persisted = JSON.parse(
       fs.readFileSync(getServerStateFilePath(test.deps.env), "utf8"),
     ) as { port: number };
@@ -424,7 +447,10 @@ describe("cli", () => {
       error: () => {},
     });
 
-    const exitCode = await runCli(["open", documentPath, "--no-watch"], deps);
+    const exitCode = await runCli(
+      ["open", "--open", documentPath, "--no-watch"],
+      deps,
+    );
 
     expect(exitCode).toBe(0);
     expect(postedOpenRequest).toEqual({
@@ -702,7 +728,10 @@ describe("cli", () => {
       error: () => {},
     });
 
-    const exitCode = await runCli(["open", documentPath, "--no-watch"], deps);
+    const exitCode = await runCli(
+      ["open", "--open", documentPath, "--no-watch"],
+      deps,
+    );
 
     expect(exitCode).toBe(0);
     expect(spawnCount).toBe(0);
@@ -798,7 +827,7 @@ describe("cli", () => {
     });
 
     const exitCode = await runCli(
-      ["open", documentPath, "--json", "--batch-window", "0"],
+      ["open", "--open", documentPath, "--json", "--batch-window", "0"],
       deps,
     );
 
@@ -831,7 +860,7 @@ describe("cli", () => {
 
     const test = createTestDependencies();
     const exitCode = await runCli(
-      ["open", documentPath, "--no-watch"],
+      ["open", "--open", documentPath, "--no-watch"],
       test.deps,
     );
     const persisted = JSON.parse(
@@ -906,7 +935,10 @@ describe("cli", () => {
       error: () => {},
     });
 
-    const exitCode = await runCli(["open", documentPath, "--no-watch"], deps);
+    const exitCode = await runCli(
+      ["open", "--open", documentPath, "--no-watch"],
+      deps,
+    );
 
     expect(exitCode).toBe(0);
     expect(spawnCount).toBe(0);
@@ -1088,7 +1120,7 @@ describe("cli", () => {
     };
 
     const watchPromise = runCli(
-      ["open", documentPath, "--json", "--batch-window", "0"],
+      ["open", "--open", documentPath, "--json", "--batch-window", "0"],
       deps,
     );
 
@@ -1224,7 +1256,7 @@ describe("cli", () => {
 
     const statusExitCode = await runCli(["status"], deps);
     const openExitCode = await runCli(
-      ["open", documentPath, "--no-watch"],
+      ["open", "--open", documentPath, "--no-watch"],
       deps,
     );
 
@@ -1508,7 +1540,7 @@ describe("cli", () => {
 
     expect(exitCode).toBe(0);
     expect(test.logs).toContain(
-      "  roughdraft open <path> [--no-open] [--no-watch] [--print-url] [--port <port>]",
+      "  roughdraft open <path> [--open] [--no-watch] [--print-url] [--port <port>]",
     );
     expect(test.logs).toContain(
       "  --no-watch           Open the file without waiting",
@@ -1825,7 +1857,7 @@ describe("runCli open in remote mode", () => {
     const logs: string[] = [];
     const errors: string[] = [];
 
-    const exitCode = await runCli(["open", filePath], {
+    const exitCode = await runCli(["open", "--open", filePath], {
       env: { ROUGHDRAFT_HOST: "http://127.0.0.1:1" },
       cwd: projectDir,
       log: (m) => logs.push(m),
@@ -1851,7 +1883,7 @@ describe("runCli open in remote mode", () => {
     const errors: string[] = [];
     let fetchCalls = 0;
 
-    const exitCode = await runCli(["open", filePath], {
+    const exitCode = await runCli(["open", "--open", filePath], {
       env: { ROUGHDRAFT_HOST: "http://127.0.0.1:1" },
       cwd: projectDir,
       log: () => {},
@@ -1887,7 +1919,7 @@ describe("runCli open in remote mode", () => {
       const errors: string[] = [];
       let openedUrl: string | null = null;
 
-      const cliPromise = runCli(["open", filePath], {
+      const cliPromise = runCli(["open", "--open", filePath], {
         env: { ROUGHDRAFT_HOST: remote.url },
         cwd: projectDir,
         log: (m) => logs.push(m),
@@ -1964,7 +1996,7 @@ describe("runCli open in remote mode", () => {
       const errors: string[] = [];
       let openedUrl: string | null = null;
 
-      const cliPromise = runCli(["open", filePath], {
+      const cliPromise = runCli(["open", "--open", filePath], {
         env: {
           ROUGHDRAFT_HOST: remote.url,
           ROUGHDRAFT_TOKEN: "secret-token",
@@ -2075,7 +2107,7 @@ describe("runCli open in remote mode", () => {
       const errors: string[] = [];
       let openedUrl: string | null = null;
 
-      const cliPromise = runCli(["open", filePath], {
+      const cliPromise = runCli(["open", "--open", filePath], {
         env: { ROUGHDRAFT_HOST: remote.url },
         cwd: projectDir,
         log: (m) => logs.push(m),
@@ -2161,7 +2193,7 @@ describe("runCli open in remote mode", () => {
       let openedUrl: string | null = null;
       let cliSettled = false;
 
-      const cliPromise = runCli(["open", filePath], {
+      const cliPromise = runCli(["open", "--open", filePath], {
         env: { ROUGHDRAFT_HOST: remote.url },
         cwd: projectDir,
         log: (m) => logs.push(m),

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -102,6 +102,16 @@ describe("cli", () => {
     return url.toString();
   }
 
+  function expectedDirectoryUrl(
+    baseUrl: string,
+    directoryPath: string,
+  ): string {
+    const url = new URL(baseUrl);
+    url.pathname = "/";
+    url.searchParams.set("dir", directoryPath);
+    return url.toString();
+  }
+
   function parseOnlyJsonLog<T>(logs: string[]): T {
     expect(logs).toHaveLength(1);
     return JSON.parse(logs[0] ?? "{}") as T;
@@ -263,6 +273,31 @@ describe("cli", () => {
       expectedOpenUrl(`http://localhost:${persisted.port}`, documentPath),
     );
     expect(fs.existsSync(getServerStateFilePath(test.deps.env))).toBeTruthy();
+  });
+
+  it("opens a directory with a dir-scoped URL", async () => {
+    const test = createTestDependencies();
+    fs.mkdirSync(path.join(projectDir, "sub"), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, "draft.md"), "# Draft\n");
+
+    const exitCode = await runCli(["open", projectDir], test.deps);
+    const persisted = JSON.parse(
+      fs.readFileSync(getServerStateFilePath(test.deps.env), "utf8"),
+    ) as { port: number };
+
+    expect(exitCode).toBe(0);
+    expect(test.getLastOpenedUrl()).toBe(
+      expectedDirectoryUrl(`http://localhost:${persisted.port}`, projectDir),
+    );
+  });
+
+  it("rejects --watch when opening a directory", async () => {
+    const test = createTestDependencies();
+
+    const exitCode = await runCli(["open", projectDir, "--watch"], test.deps);
+
+    expect(exitCode).not.toBe(0);
+    expect(test.errors.join("\n")).toMatch(/director/i);
   });
 
   it("prints an update notice after a successful human-readable command", async () => {
@@ -1204,15 +1239,17 @@ describe("cli", () => {
     expect(fs.existsSync(stateFilePath)).toBeFalsy();
   });
 
-  it("rejects directories before opening", async () => {
+  it("rejects non-markdown files before opening", async () => {
     const test = createTestDependencies();
+    const notMarkdown = path.join(projectDir, "notes.txt");
+    fs.writeFileSync(notMarkdown, "plain text\n");
 
-    const exitCode = await runCli(["open", projectDir], test.deps);
+    const exitCode = await runCli(["open", notMarkdown], test.deps);
 
     expect(exitCode).toBe(1);
     expect(test.getSpawnCount()).toBe(0);
     expect(test.errors).toContain(
-      `Roughdraft can only open .md files: ${projectDir}`,
+      `Roughdraft can only open .md files: ${notMarkdown}`,
     );
     expect(test.getLastOpenedUrl()).toBeNull();
   });

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,10 +1,10 @@
+import { spawn, spawnSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { spawn, spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
 import { setTimeout as sleep } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
 import {
   type RfmDiagnostic,
   validateRoughdraftMarkdown,
@@ -115,6 +115,7 @@ interface EnsureRunningResult {
 interface ResolvedTargetPath {
   projectDir: string;
   openPath: string;
+  isDirectory: boolean;
 }
 
 interface ReusableServer {
@@ -846,7 +847,9 @@ function printHelp(log: (message: string) => void) {
   log("  roughdraft <path>");
   log("");
   log("Commands:");
-  log("  open <path>        Open a Markdown file and wait for Done Reviewing");
+  log(
+    "  open <path>        Open a Markdown file (waits for Done Reviewing) or a directory to browse",
+  );
   log("  start              Start or reuse the background server");
   log("  status             Show server status");
   log("  stop               Stop the managed background server");
@@ -869,6 +872,7 @@ function printHelp(log: (message: string) => void) {
   log("  roughdraft open ./draft.md --print-url");
   log("  roughdraft open ./draft.md --json");
   log("  roughdraft open ./draft.md --no-watch");
+  log("  roughdraft open ./docs");
   log("  roughdraft watch ./draft.md --json");
   log("  roughdraft status --json");
   log("");
@@ -888,6 +892,9 @@ function printCommandHelp(
     log("");
     log(
       "Opens one Markdown file and waits for Done Reviewing. Starts Roughdraft if needed.",
+    );
+    log(
+      "If <path> is a directory, opens a browsable tree of its Markdown files instead.",
     );
     log("");
     log("Flags:");
@@ -1136,11 +1143,15 @@ function buildLoopbackUrl(host: string, port: number, pathname = "/"): URL {
   return new URL(`http://${baseHost}:${port}${pathname}`);
 }
 
-function buildTargetUrl(baseUrl: string, openPath: string): string {
+function buildTargetUrl(
+  baseUrl: string,
+  openPath: string,
+  isDirectory = false,
+): string {
   const url = new URL(baseUrl);
 
   url.pathname = "/";
-  url.searchParams.set("path", openPath);
+  url.searchParams.set(isDirectory ? "dir" : "path", openPath);
   return url.toString();
 }
 
@@ -1429,7 +1440,11 @@ function resolveTargetPath(inputPath: string): ResolvedTargetPath {
   try {
     const stat = fs.statSync(resolvedPath);
     if (stat.isDirectory()) {
-      throw new Error(`Roughdraft can only open .md files: ${resolvedPath}`);
+      return {
+        projectDir: resolvedPath,
+        openPath: resolvedPath,
+        isDirectory: true,
+      };
     }
 
     if (stat.isFile()) {
@@ -1440,6 +1455,7 @@ function resolveTargetPath(inputPath: string): ResolvedTargetPath {
       return {
         projectDir: path.dirname(resolvedPath),
         openPath: resolvedPath,
+        isDirectory: false,
       };
     }
   } catch (error) {
@@ -2706,13 +2722,22 @@ export async function runCli(
         return 1;
       }
 
-      const { projectDir, openPath } = resolvedTarget;
+      const { projectDir, openPath, isDirectory } = resolvedTarget;
+
+      if (isDirectory && options.watch) {
+        deps.error("Cannot watch a directory; --watch works on a single file.");
+        return USAGE_ERROR;
+      }
 
       const remoteHost =
         typeof deps.env.ROUGHDRAFT_HOST === "string"
           ? deps.env.ROUGHDRAFT_HOST.trim()
           : "";
       if (remoteHost.length > 0) {
+        if (isDirectory) {
+          deps.error("Remote mode can only open a single .md file.");
+          return USAGE_ERROR;
+        }
         return runRemoteOpen(deps, {
           host: remoteHost,
           openPath,
@@ -2733,7 +2758,7 @@ export async function runCli(
         baseUrl = buildPublicBaseUrl(result.server.port);
       }
 
-      const targetUrl = buildTargetUrl(baseUrl, openPath);
+      const targetUrl = buildTargetUrl(baseUrl, openPath, isDirectory);
       let openMode: OpenMode = "disabled";
       if (!options.noOpen && deps.env.ROUGHDRAFT_NO_OPEN !== "1") {
         openMode = (await sendOpenRequestToExistingWindow(
@@ -2760,7 +2785,7 @@ export async function runCli(
         return 0;
       }
 
-      const shouldWatch = !options.noWatch && !options.printUrl;
+      const shouldWatch = !isDirectory && !options.noWatch && !options.printUrl;
 
       if (shouldWatch) {
         if (!json) {

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -274,7 +274,9 @@ function parseCommandOptions(
     batchWindowSeconds: 0.25,
     help: false,
     json: false,
-    noOpen: false,
+    // Default to NOT launching a browser: `open` prints the URL and the user
+    // opens it themselves. Pass `--open` to launch a browser.
+    noOpen: true,
     noWatch: false,
     positionals: [],
     printUrl: false,
@@ -309,6 +311,12 @@ function parseCommandOptions(
     if (arg === "--no-open") {
       if (!options.allowOpen) throw new Error(`Unknown flag: ${arg}`);
       parsed.noOpen = true;
+      continue;
+    }
+
+    if (arg === "--open") {
+      if (!options.allowOpen) throw new Error(`Unknown flag: ${arg}`);
+      parsed.noOpen = false;
       continue;
     }
 
@@ -848,7 +856,7 @@ function printHelp(log: (message: string) => void) {
   log("");
   log("Commands:");
   log(
-    "  open <path>        Open a Markdown file (waits for Done Reviewing) or a directory to browse",
+    "  open <path>        Print the URL for a Markdown file (waits for Done Reviewing) or directory; pass --open to launch a browser",
   );
   log("  start              Start or reuse the background server");
   log("  status             Show server status");
@@ -869,6 +877,7 @@ function printHelp(log: (message: string) => void) {
   log("");
   log("Examples:");
   log("  roughdraft open ./draft.md");
+  log("  roughdraft open ./draft.md --open");
   log("  roughdraft open ./draft.md --print-url");
   log("  roughdraft open ./draft.md --json");
   log("  roughdraft open ./draft.md --no-watch");
@@ -887,11 +896,14 @@ function printCommandHelp(
   if (command === "open") {
     log("Usage:");
     log(
-      "  roughdraft open <path> [--no-open] [--no-watch] [--print-url] [--port <port>]",
+      "  roughdraft open <path> [--open] [--no-watch] [--print-url] [--port <port>]",
     );
     log("");
     log(
-      "Opens one Markdown file and waits for Done Reviewing. Starts Roughdraft if needed.",
+      "Prints the document URL and waits for Done Reviewing. Starts Roughdraft if needed.",
+    );
+    log(
+      "Does NOT launch a browser by default — open the printed URL yourself, or pass --open.",
     );
     log(
       "If <path> is a directory, opens a browsable tree of its Markdown files instead.",
@@ -899,10 +911,11 @@ function printCommandHelp(
     log("");
     log("Flags:");
     log(
-      "  --no-open            Start/reuse the server without opening a browser",
+      "  --open               Also launch a browser (default: just print the URL)",
     );
+    log("  --no-open            Do not launch a browser (already the default)");
     log(
-      "  --print-url          Print only the document URL and do not open it",
+      "  --print-url          Print only the document URL and exit (no watch)",
     );
     log("  --no-watch           Open the file without waiting");
     log("  --timeout <seconds>  Maximum watch time; omitted means no timeout");
@@ -925,7 +938,10 @@ function printCommandHelp(
     log("                        Required when the hosted server binds to a");
     log("                        non-loopback host. Must match the value the");
     log("                        hosted server was started with.");
-    log("  ROUGHDRAFT_NO_OPEN    Set to 1 to suppress browser launch.");
+    log(
+      "  ROUGHDRAFT_NO_OPEN    Set to 1 to force-suppress browser launch even",
+    );
+    log("                        when --open is passed.");
     log("  ROUGHDRAFT_BIND_HOST  Comma-separated bind hosts for the hosted");
     log(
       "                        server (default: loopback). Set to 0.0.0.0 or",

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -659,6 +659,33 @@ describe("createApp", () => {
     });
   });
 
+  it("omits .git, node_modules, and hidden directories from the project tree", async () => {
+    fs.mkdirSync(path.join(projectDir, ".git"), { recursive: true });
+    fs.mkdirSync(path.join(projectDir, "node_modules", "pkg"), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(projectDir, ".hidden"), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, ".git", "config.md"), "# Git\n");
+    fs.writeFileSync(
+      path.join(projectDir, "node_modules", "pkg", "readme.md"),
+      "# Pkg\n",
+    );
+    fs.writeFileSync(path.join(projectDir, ".hidden", "secret.md"), "# H\n");
+    fs.writeFileSync(path.join(projectDir, "draft.md"), "# Draft\n");
+
+    const { app } = createApp({
+      homeDir,
+      staticDirPath: projectDir,
+    });
+
+    const response = await request(app).get("/api/file-tree").query({
+      projectPath: projectDir,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ paths: ["draft.md"] });
+  });
+
   it("opens and creates project directories", async () => {
     const createdDir = path.join(projectDir, "created", "workspace");
 

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -70,6 +70,35 @@ describe("createApp", () => {
     expect(response.body.version).toEqual(expect.any(String));
   });
 
+  it("serves non-markdown files whose project path includes a dot-directory", async () => {
+    // Projects opened under a dotfile dir (e.g. ~/.claude/skills/...) must still
+    // serve their files. `res.sendFile` defaults to `dotfiles: "ignore"`, which
+    // 404s any path that traverses a dot-directory, so this reproduces the
+    // read-only viewer failing on every file under such a project.
+    const dottedProjectDir = path.join(projectDir, ".vault", "project");
+    fs.mkdirSync(path.join(dottedProjectDir, "templates"), { recursive: true });
+    fs.writeFileSync(
+      path.join(dottedProjectDir, "templates", "Dockerfile.tmpl"),
+      "FROM python:3.12\n",
+    );
+
+    const { app } = createApp({
+      homeDir,
+      staticDirPath: projectDir,
+    });
+
+    const response = await request(app).get("/api/files").query({
+      projectPath: dottedProjectDir,
+      path: "templates/Dockerfile.tmpl",
+    });
+
+    expect(response.status).toBe(200);
+    // supertest puts non-text bodies in `body` as a Buffer.
+    const body =
+      response.text ?? (response.body as Buffer | undefined)?.toString("utf-8");
+    expect(body).toContain("FROM python:3.12");
+  });
+
   it("lists, updates, and deletes page-backed markdown files", async () => {
     fs.writeFileSync(path.join(projectDir, "alpha.md"), "# Alpha\n");
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1202,7 +1202,11 @@ export function createApp(options: CreateAppOptions = {}): CreateAppResult {
       return;
     }
 
-    res.sendFile(absolutePath);
+    // `ensureProjectPath` already confined the path to the project boundary, so
+    // serve it even when the project lives under a dot-directory (e.g.
+    // ~/.claude/skills/...). Without this, sendFile's default `dotfiles:
+    // "ignore"` 404s every file whose path traverses a dot-directory.
+    res.sendFile(absolutePath, { dotfiles: "allow" });
   });
 
   app.post("/api/assets", (req, res) => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -356,6 +356,10 @@ function toCanonicalRelativePath(
   return isDirectory ? `${canonicalPath}/` : canonicalPath;
 }
 
+function isIgnoredTreeDirectory(name: string): boolean {
+  return name === "node_modules" || name.startsWith(".");
+}
+
 function listProjectTree(projectDir: string): ProjectTreeListing {
   const paths: string[] = [];
 
@@ -376,6 +380,9 @@ function listProjectTree(projectDir: string): ProjectTreeListing {
       const absolutePath = path.join(dir, entry.name);
 
       if (entry.isDirectory()) {
+        if (isIgnoredTreeDirectory(entry.name)) {
+          continue;
+        }
         paths.push(toCanonicalRelativePath(projectDir, absolutePath, true));
         visitDirectory(absolutePath);
         continue;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       codemirror:
         specifier: ^6.0.2
         version: 6.0.2
+      katex:
+        specifier: ^0.16.11
+        version: 0.16.47
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.5)
@@ -151,6 +154,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@types/katex':
+        specifier: ^0.16.7
+        version: 0.16.8
       '@types/react':
         specifier: ^19.1.0
         version: 19.2.14
@@ -1972,6 +1978,9 @@ packages:
 
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
+  '@types/katex@0.16.8':
+    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
@@ -5754,6 +5763,8 @@ snapshots:
   '@types/geojson@7946.0.16': {}
 
   '@types/http-errors@2.0.5': {}
+
+  '@types/katex@0.16.8': {}
 
   '@types/methods@1.1.4': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       marked:
         specifier: ^15.0.0
         version: 15.0.12
+      mermaid:
+        specifier: ^11.15.0
+        version: 11.15.0
       react:
         specifier: ^19.1.0
         version: 19.2.5
@@ -214,6 +217,9 @@ importers:
   packages/skill: {}
 
 packages:
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -463,9 +469,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@codemirror/autocomplete@6.20.1':
     resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
@@ -903,6 +915,12 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.3':
+    resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
+
   '@inquirer/ansi@2.0.5':
     resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
@@ -983,6 +1001,9 @@ packages:
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
+
+  '@mermaid-js/parser@1.1.1':
+    resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
@@ -1754,6 +1775,99 @@ packages:
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1765,6 +1879,9 @@ packages:
 
   '@types/express@5.0.6':
     resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
@@ -1807,6 +1924,9 @@ packages:
   '@types/supertest@7.2.0':
     resolution: {integrity: sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/turndown@5.0.6':
     resolution: {integrity: sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==}
 
@@ -1815,6 +1935,9 @@ packages:
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -2019,6 +2142,14 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
 
@@ -2052,6 +2183,12 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   cosmiconfig@9.0.1:
     resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
     engines: {node: '>=14'}
@@ -2080,6 +2217,162 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -2087,6 +2380,9 @@ packages:
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -2124,6 +2420,9 @@ packages:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
 
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -2142,6 +2441,9 @@ packages:
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  dompurify@3.4.9:
+    resolution: {integrity: sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -2204,6 +2506,9 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.47.0:
+    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -2416,6 +2721,9 @@ packages:
     resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -2462,6 +2770,10 @@ packages:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -2474,8 +2786,18 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -2630,6 +2952,13 @@ packages:
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
@@ -2642,6 +2971,12 @@ packages:
     resolution: {integrity: sha512-ckL51NDH1YJxnv1kNB0iUdDngB4f/e9Igz8uIqYfmNDoyOFmmk1V0WFv3LQ7/hzC63b2Z9X41gGUE9eOWrZpaA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -2723,6 +3058,9 @@ packages:
   linkifyjs@4.3.2:
     resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
@@ -2754,6 +3092,11 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2775,6 +3118,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mermaid@11.15.0:
+    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -2917,6 +3263,9 @@ packages:
   oxc-resolver@11.19.1:
     resolution: {integrity: sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2938,6 +3287,9 @@ packages:
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -2980,6 +3332,12 @@ packages:
     resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -3106,6 +3464,9 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -3113,6 +3474,9 @@ packages:
 
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
@@ -3124,6 +3488,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -3267,6 +3634,9 @@ packages:
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   superagent@10.3.0:
     resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
     engines: {node: '>=14.18.0'}
@@ -3336,6 +3706,10 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
 
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
@@ -3411,6 +3785,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
 
   validate-npm-package-name@7.0.2:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
@@ -3601,6 +3979,11 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.1.1
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -3880,9 +4263,13 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.12':
     optional: true
 
+  '@braintree/sanitize-url@7.1.2': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
+
+  '@chevrotain/types@11.1.2': {}
 
   '@codemirror/autocomplete@6.20.1':
     dependencies:
@@ -4220,6 +4607,14 @@ snapshots:
     dependencies:
       hono: 4.12.14
 
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.3':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@inquirer/ansi@2.0.5': {}
 
   '@inquirer/confirm@6.0.12(@types/node@22.19.17)':
@@ -4308,6 +4703,10 @@ snapshots:
       '@lezer/lr': 1.4.10
 
   '@marijn/find-cluster-break@1.0.2': {}
+
+  '@mermaid-js/parser@1.1.1':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@mixmark-io/domino@2.2.0': {}
 
@@ -4922,6 +5321,123 @@ snapshots:
 
   '@types/cookiejar@2.1.5': {}
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -4938,6 +5454,8 @@ snapshots:
       '@types/body-parser': 1.19.6
       '@types/express-serve-static-core': 5.1.1
       '@types/serve-static': 2.2.0
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/http-errors@2.0.5': {}
 
@@ -4986,11 +5504,19 @@ snapshots:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/turndown@5.0.6': {}
 
   '@types/use-sync-external-store@0.0.6': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -5212,6 +5738,10 @@ snapshots:
 
   commander@14.0.3: {}
 
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   component-emitter@1.3.1: {}
 
   content-disposition@1.1.0: {}
@@ -5232,6 +5762,14 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
 
   cosmiconfig@9.0.1(typescript@5.9.3):
     dependencies:
@@ -5259,6 +5797,190 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
   data-uri-to-buffer@4.0.1: {}
 
   data-urls@7.0.0(@noble/hashes@1.8.0):
@@ -5267,6 +5989,8 @@ snapshots:
       whatwg-url: 16.0.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  dayjs@1.11.21: {}
 
   debug@4.4.3:
     dependencies:
@@ -5287,6 +6011,10 @@ snapshots:
 
   define-lazy-prop@3.0.0: {}
 
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
+
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
@@ -5299,6 +6027,10 @@ snapshots:
       wrappy: 1.0.2
 
   diff@8.0.4: {}
+
+  dompurify@3.4.9:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv@17.4.2: {}
 
@@ -5354,6 +6086,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.3
+
+  es-toolkit@1.47.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -5649,6 +6383,8 @@ snapshots:
 
   graphql@16.13.2: {}
 
+  hachure-fill@0.5.2: {}
+
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
@@ -5695,6 +6431,10 @@ snapshots:
 
   human-signals@8.0.1: {}
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -5706,7 +6446,13 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-meta-resolve@4.2.0: {}
+
   inherits@2.0.4: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   ip-address@10.1.0: {}
 
@@ -5829,6 +6575,12 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
+  khroma@2.1.0: {}
+
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
@@ -5852,6 +6604,10 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -5906,6 +6662,8 @@ snapshots:
 
   linkifyjs@4.3.2: {}
 
+  lodash-es@4.18.1: {}
+
   log-symbols@6.0.0:
     dependencies:
       chalk: 5.6.2
@@ -5937,6 +6695,8 @@ snapshots:
 
   marked@15.0.12: {}
 
+  marked@16.4.2: {}
+
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.27.1: {}
@@ -5948,6 +6708,30 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  mermaid@11.15.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.3
+      '@mermaid-js/parser': 1.1.1
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.21
+      dompurify: 3.4.9
+      es-toolkit: 1.47.0
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 14.0.0
 
   methods@1.1.2: {}
 
@@ -6132,6 +6916,8 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  package-manager-detector@1.6.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -6152,6 +6938,8 @@ snapshots:
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
+
+  path-data-parser@0.1.0: {}
 
   path-key@3.1.1: {}
 
@@ -6178,6 +6966,13 @@ snapshots:
       playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -6328,6 +7123,8 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  robust-predicates@3.0.3: {}
+
   rollup@4.60.2:
     dependencies:
       '@types/estree': 1.0.8
@@ -6361,6 +7158,13 @@ snapshots:
 
   rope-sequence@1.3.4: {}
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -6376,6 +7180,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   safer-buffer@2.1.2: {}
 
@@ -6555,6 +7361,8 @@ snapshots:
 
   style-mod@4.1.3: {}
 
+  stylis@4.4.0: {}
+
   superagent@10.3.0:
     dependencies:
       component-emitter: 1.3.1
@@ -6624,6 +7432,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  ts-dedent@2.3.0: {}
+
   ts-morph@26.0.0:
     dependencies:
       '@ts-morph/common': 0.27.0
@@ -6687,6 +7497,8 @@ snapshots:
       react: 19.2.5
 
   util-deprecate@1.0.2: {}
+
+  uuid@14.0.0: {}
 
   validate-npm-package-name@7.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,12 @@ importers:
       '@codemirror/lang-yaml':
         specifier: ^6.1.3
         version: 6.1.3
+      '@codemirror/language':
+        specifier: ^6.10.0
+        version: 6.12.3
+      '@codemirror/language-data':
+        specifier: ^6.5.1
+        version: 6.5.2
       '@codemirror/state':
         specifier: ^6.6.0
         version: 6.6.0
@@ -485,23 +491,77 @@ packages:
   '@codemirror/commands@6.10.3':
     resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
 
+  '@codemirror/lang-angular@0.1.4':
+    resolution: {integrity: sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g==}
+
+  '@codemirror/lang-cpp@6.0.3':
+    resolution: {integrity: sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA==}
+
   '@codemirror/lang-css@6.3.1':
     resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-go@6.0.1':
+    resolution: {integrity: sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==}
 
   '@codemirror/lang-html@6.4.11':
     resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
 
+  '@codemirror/lang-java@6.0.2':
+    resolution: {integrity: sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==}
+
   '@codemirror/lang-javascript@6.2.5':
     resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-jinja@6.0.1':
+    resolution: {integrity: sha512-P5kyHLObzjtbGj16h+hyvZTxJhSjBEeSx4wMjbnAf3b0uwTy2+F0zGjMZL4PQOm/mh2eGZ5xUDVZXgwP783Nsw==}
+
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/lang-less@6.0.2':
+    resolution: {integrity: sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ==}
+
+  '@codemirror/lang-liquid@6.3.2':
+    resolution: {integrity: sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw==}
 
   '@codemirror/lang-markdown@6.5.0':
     resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
 
+  '@codemirror/lang-php@6.0.2':
+    resolution: {integrity: sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==}
+
+  '@codemirror/lang-python@6.2.1':
+    resolution: {integrity: sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==}
+
+  '@codemirror/lang-rust@6.0.2':
+    resolution: {integrity: sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA==}
+
+  '@codemirror/lang-sass@6.0.2':
+    resolution: {integrity: sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==}
+
+  '@codemirror/lang-sql@6.10.0':
+    resolution: {integrity: sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==}
+
+  '@codemirror/lang-vue@0.1.3':
+    resolution: {integrity: sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==}
+
+  '@codemirror/lang-wast@6.0.2':
+    resolution: {integrity: sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==}
+
+  '@codemirror/lang-xml@6.1.0':
+    resolution: {integrity: sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==}
+
   '@codemirror/lang-yaml@6.1.3':
     resolution: {integrity: sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==}
 
+  '@codemirror/language-data@6.5.2':
+    resolution: {integrity: sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg==}
+
   '@codemirror/language@6.12.3':
     resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/legacy-modes@6.5.3':
+    resolution: {integrity: sha512-xCsmIzH78MyWkib9jlPaaun57XNkfbMIhagfaZVd0iLTqlpw3jXaIcbZm72MTmmn64eTZpBVNjbyYh+QXnxRsg==}
 
   '@codemirror/lint@6.9.5':
     resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
@@ -978,8 +1038,14 @@ packages:
   '@lezer/common@1.5.2':
     resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
 
+  '@lezer/cpp@1.1.6':
+    resolution: {integrity: sha512-vh9gWWJOXFVY8HBHK3Twzq8MgwG2iN4GSyzBP9sCGTe37P15x2R14VaBQk0VA0ezTRN1KHYBBsHhvpGZ2Xy/pA==}
+
   '@lezer/css@1.3.3':
     resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
+
+  '@lezer/go@1.0.1':
+    resolution: {integrity: sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==}
 
   '@lezer/highlight@1.2.3':
     resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
@@ -987,14 +1053,35 @@ packages:
   '@lezer/html@1.3.13':
     resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
 
+  '@lezer/java@1.1.3':
+    resolution: {integrity: sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==}
+
   '@lezer/javascript@1.5.4':
     resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
 
   '@lezer/lr@1.4.10':
     resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
 
   '@lezer/markdown@1.6.3':
     resolution: {integrity: sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==}
+
+  '@lezer/php@1.0.5':
+    resolution: {integrity: sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==}
+
+  '@lezer/python@1.1.19':
+    resolution: {integrity: sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ==}
+
+  '@lezer/rust@1.0.2':
+    resolution: {integrity: sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==}
+
+  '@lezer/sass@1.1.0':
+    resolution: {integrity: sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==}
+
+  '@lezer/xml@1.0.6':
+    resolution: {integrity: sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==}
 
   '@lezer/yaml@1.0.4':
     resolution: {integrity: sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==}
@@ -4285,6 +4372,20 @@ snapshots:
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
 
+  '@codemirror/lang-angular@0.1.4':
+    dependencies:
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-cpp@6.0.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/cpp': 1.1.6
+
   '@codemirror/lang-css@6.3.1':
     dependencies:
       '@codemirror/autocomplete': 6.20.1
@@ -4292,6 +4393,14 @@ snapshots:
       '@codemirror/state': 6.6.0
       '@lezer/common': 1.5.2
       '@lezer/css': 1.3.3
+
+  '@codemirror/lang-go@6.0.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/go': 1.0.1
 
   '@codemirror/lang-html@6.4.11':
     dependencies:
@@ -4305,6 +4414,11 @@ snapshots:
       '@lezer/css': 1.3.3
       '@lezer/html': 1.3.13
 
+  '@codemirror/lang-java@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/java': 1.1.3
+
   '@codemirror/lang-javascript@6.2.5':
     dependencies:
       '@codemirror/autocomplete': 6.20.1
@@ -4314,6 +4428,41 @@ snapshots:
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
       '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-jinja@6.0.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/json': 1.0.3
+
+  '@codemirror/lang-less@6.0.2':
+    dependencies:
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/language': 6.12.3
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-liquid@6.3.2':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@codemirror/lang-markdown@6.5.0':
     dependencies:
@@ -4325,6 +4474,69 @@ snapshots:
       '@lezer/common': 1.5.2
       '@lezer/markdown': 1.6.3
 
+  '@codemirror/lang-php@6.0.2':
+    dependencies:
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/php': 1.0.5
+
+  '@codemirror/lang-python@6.2.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/python': 1.1.19
+
+  '@codemirror/lang-rust@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/rust': 1.0.2
+
+  '@codemirror/lang-sass@6.0.2':
+    dependencies:
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/sass': 1.1.0
+
+  '@codemirror/lang-sql@6.10.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-vue@0.1.3':
+    dependencies:
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-wast@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-xml@6.1.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/xml': 1.0.6
+
   '@codemirror/lang-yaml@6.1.3':
     dependencies:
       '@codemirror/autocomplete': 6.20.1
@@ -4335,6 +4547,32 @@ snapshots:
       '@lezer/lr': 1.4.10
       '@lezer/yaml': 1.0.4
 
+  '@codemirror/language-data@6.5.2':
+    dependencies:
+      '@codemirror/lang-angular': 0.1.4
+      '@codemirror/lang-cpp': 6.0.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-go': 6.0.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-java': 6.0.2
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/lang-jinja': 6.0.1
+      '@codemirror/lang-json': 6.0.2
+      '@codemirror/lang-less': 6.0.2
+      '@codemirror/lang-liquid': 6.3.2
+      '@codemirror/lang-markdown': 6.5.0
+      '@codemirror/lang-php': 6.0.2
+      '@codemirror/lang-python': 6.2.1
+      '@codemirror/lang-rust': 6.0.2
+      '@codemirror/lang-sass': 6.0.2
+      '@codemirror/lang-sql': 6.10.0
+      '@codemirror/lang-vue': 0.1.3
+      '@codemirror/lang-wast': 6.0.2
+      '@codemirror/lang-xml': 6.1.0
+      '@codemirror/lang-yaml': 6.1.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/legacy-modes': 6.5.3
+
   '@codemirror/language@6.12.3':
     dependencies:
       '@codemirror/state': 6.6.0
@@ -4343,6 +4581,10 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
       style-mod: 4.1.3
+
+  '@codemirror/legacy-modes@6.5.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
 
   '@codemirror/lint@6.9.5':
     dependencies:
@@ -4665,7 +4907,19 @@ snapshots:
 
   '@lezer/common@1.5.2': {}
 
+  '@lezer/cpp@1.1.6':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@lezer/css@1.3.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/go@1.0.1':
     dependencies:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
@@ -4681,7 +4935,19 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
 
+  '@lezer/java@1.1.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/json@1.0.3':
     dependencies:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
@@ -4695,6 +4961,36 @@ snapshots:
     dependencies:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
+
+  '@lezer/php@1.0.5':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/python@1.1.19':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/rust@1.0.2':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/sass@1.1.0':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/xml@1.0.6':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@lezer/yaml@1.0.4':
     dependencies:

--- a/scripts/dev/verify-ui.mjs
+++ b/scripts/dev/verify-ui.mjs
@@ -1,0 +1,42 @@
+// Headless browser smoke check used by `make verify-ui`.
+//
+// Trusted surface: this file is write-denied in .claude/settings.json so the
+// agent can run it (via `make verify-ui`) but cannot widen it. It only opens a
+// URL and reports — it never takes free-form code.
+//
+//   make verify-ui URL=http://localhost:7373/?dir=...&path=...  [TESTIDS=a,b]
+import { chromium } from "@playwright/test";
+
+const url = process.argv[2] || process.env.URL;
+if (!url) {
+  console.error(
+    "usage: node scripts/dev/verify-ui.mjs <url> [testid,testid,...]",
+  );
+  process.exit(2);
+}
+
+const testids = (process.argv[3] || process.env.TESTIDS || "")
+  .split(",")
+  .map((value) => value.trim())
+  .filter(Boolean);
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+const errors = [];
+page.on("pageerror", (error) => errors.push(error.message));
+
+await page.goto(url, { waitUntil: "load" });
+await page.waitForTimeout(1800);
+
+console.log("URL:", url);
+console.log("table count:", await page.locator("table").count());
+for (const testid of testids) {
+  console.log(`testid ${testid}:`, await page.getByTestId(testid).count());
+}
+const body = (await page.locator("body").innerText())
+  .replace(/\s+/g, " ")
+  .slice(0, 400);
+console.log("body:", body);
+console.log("pageerrors:", errors.length ? errors : "none");
+
+await browser.close();


### PR DESCRIPTION
## Summary
Roughdraft had no math support, so TeX written in documents rendered as literal text. This adds KaTeX rendering for inline `$…$` and block `$$…$$` across the full pipeline — read view, the Tiptap editor, and the markdown round-trip.

- **`markdown.ts`** — `marked` extensions tokenize `$…$` / `$$…$$` and render via KaTeX (`throwOnError: false`), keeping the raw LaTeX in a `data-latex` attribute. Registered on both the global `marked` (used by `toHtml`) and — separately — the editor's `createCriticMarked` parser, since a `new Marked()` does not inherit global extensions. Two Turndown rules serialize back to `$…$` / `$$…$$`.
- **`editor-extensions.ts` + `MathView.tsx`** — `MathInline` / `MathBlock` Tiptap atom nodes with a KaTeX NodeView that re-renders from the stored LaTeX.
- **`main.tsx` / `style.css` / `package.json`** — KaTeX CSS import, block/inline styles, `katex` dependency.

### The one subtle bit
Atom nodes serialize to empty elements, and Turndown classifies empty elements as *blank* — routing them to `blankReplacement` **before** custom rules, silently dropping the math. Fix: `renderHTML` emits the LaTeX as the element's text content so it isn't blank and the math rule fires.

## Test fix (2nd commit)
`pnpm test:selectors` was already red on `main` (recent clickable-links / anchor-scroll commits). Two locators in `links-and-layout.spec.ts` assert on rendered-markdown DOM with no `data-testid` by design (a `<table>`, the `#REQ-11` anchor whose id *is* the behavior under test). Marked both with the script's sanctioned `selector-check-ignore` exception rather than weakening the convention globally.

## Verification
- New `packages/app/test/math.test.ts`: inline/block render, lone-`$` ignored, inline + block round-trip.
- Real browser (`make verify-ui`) on a research doc: 54 inline formulas render, 0 page errors.
- KaTeX validity: rendered the converted docs, asserted **0** `katex-error` spans.
- Save round-trip on the real doc: all 54 `$…$` survive parse → editor → serialize unchanged.
- `pnpm lint`, `pnpm test:selectors`, app typecheck, `make test-app` (256), `make build-app`, and `pnpm test:smoke` (24 @smoke) — all green.

## Residual gaps
- `markdownToPlainText` reads KaTeX's `textContent`, which duplicates glyphs — cosmetic, affects only plain-text copy/search of a math span, not display or round-trip.
- No live input rule (typing `$x$` doesn't auto-convert); math is created on load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
