### PR TITLE
fix: preserve single tilde text in markdown

### DIFF
--- a/packages/app/src/critic-markup/index.ts
+++ b/packages/app/src/critic-markup/index.ts
@@ -17,6 +17,7 @@ import {
 import {
   createMarkedRenderer,
   createTurndownService,
+  markedTokenizer,
   normalizeBlockSpacing,
   appendYamlEndmatter,
   prependYamlFrontmatter,
@@ -1262,6 +1263,7 @@ function createCriticMarked(
   });
 
   parser.use({
+    tokenizer: markedTokenizer,
     extensions: [
       {
         name: "criticCommentAnchor",

--- a/packages/app/src/markdown.test.ts
+++ b/packages/app/src/markdown.test.ts
@@ -97,6 +97,17 @@ describe("toHtml", () => {
     );
   });
 
+  it("does not treat single tildes as strikethrough", () => {
+    const html = toHtml(
+      "Tracked ~57% of work time (~100h), with ~16 posts.\n\nKeep ~~removed~~ text.",
+    );
+
+    expect(html).toContain(
+      "<p>Tracked ~57% of work time (~100h), with ~16 posts.</p>",
+    );
+    expect(html).toContain("<p>Keep <del>removed</del> text.</p>");
+  });
+
   it("round-trips headerless HTML tables to valid GFM table markdown", () => {
     expect(toMarkdown(toHtml(readMarkdownFixture("headerless-table.md")))).toBe(
       [

--- a/packages/app/src/markdown.ts
+++ b/packages/app/src/markdown.ts
@@ -1,5 +1,5 @@
 import { tables, taskListItems } from "@joplin/turndown-plugin-gfm";
-import { marked } from "marked";
+import { Marked, marked, type TokenizerObject } from "marked";
 import TurndownService from "turndown";
 import { parse as parseYaml } from "yaml";
 
@@ -376,6 +376,24 @@ export function createMarkedRenderer(options?: MarkdownOptions) {
   return renderer;
 }
 
+const doubleTildeDelPattern =
+  /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
+
+export const markedTokenizer: TokenizerObject = {
+  del(src) {
+    const match = doubleTildeDelPattern.exec(src);
+    if (!match) return undefined;
+
+    const text = match[2] ?? "";
+    return {
+      type: "del",
+      raw: match[0],
+      text,
+      tokens: this.lexer.inlineTokens(text),
+    };
+  },
+};
+
 export function createTurndownService(): TurndownService {
   const service = new TurndownService({
     headingStyle: "atx",
@@ -550,9 +568,12 @@ export function toMarkdown(html: string): string {
 }
 
 export function toHtml(markdown: string, options?: MarkdownOptions): string {
-  return marked.parse(markdown, {
+  const parser = new Marked({
     async: false,
     gfm: true,
     renderer: createMarkedRenderer(options),
-  }) as string;
+  });
+  parser.use({ tokenizer: markedTokenizer });
+
+  return parser.parse(markdown) as string;
 }

--- a/packages/app/test/critic-markup.test.ts
+++ b/packages/app/test/critic-markup.test.ts
@@ -1078,6 +1078,13 @@ describe("Markdown rich-text round-trip regressions", () => {
     expect(richTextRoundTrip(input)).toBe(input);
   });
 
+  it("preserves single tilde approximation text", () => {
+    const input =
+      "Tracked ~57% of work time (~100h), with ~16 posts after ~£300k of finance work.\n";
+
+    expect(richTextRoundTrip(input)).toBe(input);
+  });
+
   it("preserves inline link titles", () => {
     const input = '[Roughdraft](./README.md "Local title")\n';
 

--- a/packages/server/src/review-events.test.ts
+++ b/packages/server/src/review-events.test.ts
@@ -110,6 +110,25 @@ describe("ReviewEventQueue", () => {
     vi.useRealTimers();
   });
 
+  it("allows requested timeouts up to thirty minutes", async () => {
+    vi.useFakeTimers();
+    const queue = new ReviewEventQueue();
+    const waiting = queue.wait({
+      documentPath: "/tmp/project/draft.md",
+      timeoutMs: 1_900_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(queue.waiterCount()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1_500_000);
+    await expect(waiting).resolves.toMatchObject({
+      timedOut: true,
+      events: [],
+    });
+    vi.useRealTimers();
+  });
+
   it("ignores unrelated document paths", async () => {
     vi.useFakeTimers();
     const queue = new ReviewEventQueue();

--- a/packages/server/src/review-events.ts
+++ b/packages/server/src/review-events.ts
@@ -42,6 +42,7 @@ interface Waiter {
 }
 
 const DEFAULT_BATCH_WINDOW_MS = 250;
+const MAX_TIMEOUT_MS = 30 * 60 * 1000;
 const MAX_RETAINED_EVENTS = 100;
 
 type NormalizedWaitOptions = Required<
@@ -183,7 +184,7 @@ function normalizeWaitOptions(
     afterSequence: Math.max(0, options.afterSequence ?? 0),
     timeoutMs:
       options.timeoutMs !== undefined
-        ? clamp(options.timeoutMs, 0, 300_000)
+        ? clamp(options.timeoutMs, 0, MAX_TIMEOUT_MS)
         : undefined,
     batchWindowMs: clamp(
       options.batchWindowMs ?? DEFAULT_BATCH_WINDOW_MS,


### PR DESCRIPTION
## Summary

Single tilde approximation text now stays literal in Roughdraft's rich-text parser, so values like `~57%`, `~100h`, and `~16 posts` no longer become unintended strikethrough spans. Double-tilde GFM strikethrough still round-trips as `~~removed~~`.

Review-event watchers can also wait up to 30 minutes before timing out, which gives longer human review sessions more room without changing the default no-timeout behaviour.

## Validation

- `pnpm check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
