### PR TITLE
fix: extend review watch timeout

### DIFF
--- a/packages/server/src/review-events.test.ts
+++ b/packages/server/src/review-events.test.ts
@@ -110,6 +110,25 @@ describe("ReviewEventQueue", () => {
     vi.useRealTimers();
   });
 
+  it("allows requested timeouts up to thirty minutes", async () => {
+    vi.useFakeTimers();
+    const queue = new ReviewEventQueue();
+    const waiting = queue.wait({
+      documentPath: "/tmp/project/draft.md",
+      timeoutMs: 1_900_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(queue.waiterCount()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1_500_000);
+    await expect(waiting).resolves.toMatchObject({
+      timedOut: true,
+      events: [],
+    });
+    vi.useRealTimers();
+  });
+
   it("ignores unrelated document paths", async () => {
     vi.useFakeTimers();
     const queue = new ReviewEventQueue();

--- a/packages/server/src/review-events.ts
+++ b/packages/server/src/review-events.ts
@@ -42,6 +42,7 @@ interface Waiter {
 }
 
 const DEFAULT_BATCH_WINDOW_MS = 250;
+const MAX_TIMEOUT_MS = 30 * 60 * 1000;
 const MAX_RETAINED_EVENTS = 100;
 
 type NormalizedWaitOptions = Required<
@@ -183,7 +184,7 @@ function normalizeWaitOptions(
     afterSequence: Math.max(0, options.afterSequence ?? 0),
     timeoutMs:
       options.timeoutMs !== undefined
-        ? clamp(options.timeoutMs, 0, 300_000)
+        ? clamp(options.timeoutMs, 0, MAX_TIMEOUT_MS)
         : undefined,
     batchWindowMs: clamp(
       options.batchWindowMs ?? DEFAULT_BATCH_WINDOW_MS,


### PR DESCRIPTION
## Summary

Review-event watchers can now wait up to 30 minutes before timing out, which gives longer human review sessions more room. The default no-timeout behaviour remains unchanged when callers omit a timeout.

## Validation

- `pnpm --filter @roughdraft/server test -- review-events.test.ts`
- `pnpm --filter @roughdraft/server build`
- `pnpm lint`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
