### PR TITLE
fix: 'roughdraft open' crashes after 5 minutes of waiting (UND_ERR_HEADERS_TIMEOUT)

### DIFF
--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -1076,8 +1076,17 @@ describe("cli", () => {
     }
     expect(watchRequestBody).toMatchObject({
       batchWindowSeconds: 0,
+      fromNow: true,
+      afterSequence: 0,
     });
-    expect(watchRequestBody).not.toHaveProperty("timeoutSeconds");
+    // The CLI polls in bounded slices (staying under undici's 5-minute
+    // headers timeout) and re-polls with the server's sequence cursor, so
+    // each request carries a slice timeout even when the overall wait is
+    // unbounded.
+    expect(
+      (watchRequestBody as unknown as { timeoutSeconds?: number })
+        .timeoutSeconds,
+    ).toBeLessThanOrEqual(240);
     await fetch(`http://localhost:${persisted?.port}/api/review-events`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -2117,43 +2117,81 @@ async function runWatch(
     serverUrl = result.server.url;
   }
   const relativePath = path.relative(target.projectDir, target.openPath);
-  const body: {
-    projectPath: string;
-    path: string;
-    timeoutSeconds?: number;
-    batchWindowSeconds: number;
-    fromNow: boolean;
-  } = {
-    projectPath: target.projectDir,
-    path: relativePath,
-    batchWindowSeconds: options.batchWindowSeconds,
-    fromNow: !options.replay,
-  };
-  if (options.timeoutSeconds !== undefined) {
-    body.timeoutSeconds = options.timeoutSeconds;
-  }
+  // Node's built-in fetch (undici) aborts any request whose response headers
+  // have not arrived within 5 minutes (UND_ERR_HEADERS_TIMEOUT). A single
+  // unbounded long-poll therefore crashes whenever a review takes longer than
+  // that. Poll in slices shorter than that ceiling and resume from the
+  // server's sequence cursor so no events are lost between slices.
+  const POLL_SLICE_SECONDS = 240;
 
-  const response = await deps.fetchImpl(
-    new URL("/api/review-events/watch", serverUrl),
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-      ...(options.timeoutSeconds !== undefined
-        ? { signal: AbortSignal.timeout((options.timeoutSeconds + 5) * 1000) }
-        : {}),
-    },
-  );
-
-  if (!response.ok) {
-    throw new Error(`Failed to watch review events: ${response.status}`);
-  }
-
-  const payload = (await response.json()) as {
+  const deadline =
+    options.timeoutSeconds !== undefined
+      ? Date.now() + options.timeoutSeconds * 1000
+      : null;
+  let afterSequence = 0;
+  let fromNow = !options.replay;
+  let payload: {
     events?: unknown[];
     timedOut?: boolean;
     nextSequence?: number;
   };
+
+  for (;;) {
+    const sliceSeconds =
+      deadline === null
+        ? POLL_SLICE_SECONDS
+        : Math.min(
+            POLL_SLICE_SECONDS,
+            Math.max(1, Math.ceil((deadline - Date.now()) / 1000)),
+          );
+
+    const body: {
+      projectPath: string;
+      path: string;
+      timeoutSeconds: number;
+      batchWindowSeconds: number;
+      fromNow: boolean;
+      afterSequence: number;
+    } = {
+      projectPath: target.projectDir,
+      path: relativePath,
+      timeoutSeconds: sliceSeconds,
+      batchWindowSeconds: options.batchWindowSeconds,
+      fromNow,
+      afterSequence,
+    };
+
+    const response = await deps.fetchImpl(
+      new URL("/api/review-events/watch", serverUrl),
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout((sliceSeconds + 5) * 1000),
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to watch review events: ${response.status}`);
+    }
+
+    payload = (await response.json()) as {
+      events?: unknown[];
+      timedOut?: boolean;
+      nextSequence?: number;
+    };
+
+    if (!payload.timedOut) {
+      break;
+    }
+    if (deadline !== null && Date.now() >= deadline) {
+      break;
+    }
+    if (typeof payload.nextSequence === "number") {
+      afterSequence = payload.nextSequence;
+    }
+    fromNow = false;
+  }
 
   if (json) {
     emitJson(deps.log, payload);


### PR DESCRIPTION
## Problem

`roughdraft open <file>` waits for **Done Reviewing** with a single unbounded long-poll to `/api/review-events/watch`. Node's built-in fetch (undici) aborts any request whose response headers haven't arrived within **300 seconds**, so any review that takes longer than five minutes — i.e. most real reviews — crashes the waiting CLI:

```
Waiting for Done Reviewing...
[TypeError: fetch failed] {
  [cause]: HeadersTimeoutError: Headers Timeout Error
    ... code: 'UND_ERR_HEADERS_TIMEOUT'
}
```

(Node v24.15.0, roughdraft 0.1.10. The agent waiting on the exit code silently loses its resume signal.)

## Fix

Poll in 240-second slices (safely under undici's ceiling), resuming from the server's `nextSequence` cursor between slices — `fromNow` only on the first slice — so no events are lost and the observable semantics are unchanged:

- default: unbounded wait, now crash-free
- `--timeout`: bounded wait, sliced the same way, same exit codes

The server already supports `afterSequence`/`timeoutSeconds`/`nextSequence`, so this is CLI-only. Updated the `open --json` test to assert the sliced request shape; all 120 server tests pass.