### PR TITLE
Show full-value tooltips for clipped path and filename in the file menu

### DIFF
--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -1115,8 +1115,9 @@ export function DocumentWorkspace({
                                 data-testid={`document-file-menu-${action}-tooltip`}
                                 side="right"
                                 sideOffset={12}
+                                align="start"
                                 className="break-all border border-[#DCD6CC] bg-[#FFFDFC] text-stone-800 shadow-[0_16px_44px_rgba(57,47,38,0.18)] dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:shadow-[0_16px_44px_rgba(0,0,0,0.45)]"
-                                arrowClassName="border-[#DCD6CC] bg-[#FFFDFC] dark:border-slate-700 dark:bg-slate-900 data-[side=inline-end]:border-b data-[side=inline-end]:border-l data-[side=inline-start]:border-t data-[side=inline-start]:border-r data-[side=left]:border-t data-[side=left]:border-r data-[side=right]:border-b data-[side=right]:border-l"
+                                arrowClassName="border-[#DCD6CC] bg-[#FFFDFC] dark:border-slate-700 dark:bg-slate-900 data-[side=inline-end]:border-b data-[side=inline-end]:border-l data-[side=inline-start]:border-t data-[side=inline-start]:border-r data-[side=left]:border-t data-[side=left]:border-r data-[side=right]:border-b data-[side=right]:border-l data-[side=inline-end]:top-3.5! data-[side=inline-end]:translate-y-0 data-[side=inline-start]:top-3.5! data-[side=inline-start]:translate-y-0 data-[side=left]:top-3.5! data-[side=left]:translate-y-0 data-[side=right]:top-3.5! data-[side=right]:translate-y-0"
                               >
                                 {tooltipValue}
                               </TooltipContent>

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -33,6 +33,7 @@ import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
+  TooltipProvider,
 } from "./components/ui/tooltip";
 import {
   criticMarkdownHasReviewRail,
@@ -58,6 +59,7 @@ type ReviewHandoffState =
   | "error";
 type FileCopyAction = "path" | "filename" | "markdown" | "rich-text";
 const FILE_COPY_PREVIEW_MAX_LENGTH = 34;
+const FILE_COPY_TOOLTIP_DELAY_MS = 600;
 const reviewCompleteTitles = [
   "Great work!",
   "Nice one!",
@@ -654,10 +656,15 @@ export function DocumentWorkspace({
     documentEditorViewMode === "rich-text"
       ? "Switch to code view"
       : "Switch to rich text view";
+  const fileCopyPathValue =
+    documentCopyPath ?? activeDocumentPath ?? documentFilenameLabel;
+  const fileCopyTooltipValueByAction: Partial<Record<FileCopyAction, string>> =
+    {
+      path: fileCopyPathValue,
+      filename: documentFilenameLabel,
+    };
   const fileCopyPreviewByAction: Record<FileCopyAction, string> = {
-    path: formatFileCopyPreview(
-      documentCopyPath ?? activeDocumentPath ?? documentFilenameLabel,
-    ),
+    path: formatFileCopyPreview(fileCopyPathValue),
     filename: formatFileCopyPreview(documentFilenameLabel),
     markdown: formatFileCopyPreview(documentPage?.content ?? ""),
     "rich-text": formatFileCopyPreview(
@@ -1058,33 +1065,66 @@ export function DocumentWorkspace({
                     align="start"
                     sideOffset={4}
                   >
-                    <div className="flex flex-col">
-                      {fileCopyMenuOptions.map(({ action, label }) => (
-                        <button
-                          key={action}
-                          type="button"
-                          data-testid={`document-file-menu-${action}`}
-                          className="flex items-start gap-2 rounded-md px-2 py-1.5 text-left text-[0.72rem] leading-none text-stone-700 outline-none transition hover:bg-[#EEE9E1] focus-visible:bg-[#EEE9E1] dark:text-stone-300 dark:hover:bg-slate-700 dark:focus-visible:bg-slate-700"
-                          onClick={() => void handleCopyFileMenuAction(action)}
-                        >
-                          <Copy
-                            className="mt-[0.06rem] size-4 shrink-0 text-stone-500 dark:text-slate-400"
-                            aria-hidden="true"
-                          />
-                          <span className="grid min-w-0 flex-1 gap-1">
-                            <span className="truncate font-medium">
-                              {copiedFileAction === action ? "Copied!" : label}
-                            </span>
-                            <span className="truncate text-[0.66rem] leading-none text-stone-400 dark:text-slate-500">
-                              {fileCopyPreviewByAction[action]}
-                            </span>
-                          </span>
-                          {copiedFileAction === action ? (
-                            <Check className="mt-[0.06rem] ml-auto size-3 shrink-0 text-stone-500 dark:text-stone-400" />
-                          ) : null}
-                        </button>
-                      ))}
-                    </div>
+                    <TooltipProvider
+                      delay={FILE_COPY_TOOLTIP_DELAY_MS}
+                      timeout={0}
+                    >
+                      <div className="flex flex-col">
+                        {fileCopyMenuOptions.map(({ action, label }) => {
+                          const menuItem = (
+                            <button
+                              key={action}
+                              type="button"
+                              data-testid={`document-file-menu-${action}`}
+                              className="flex items-start gap-2 rounded-md px-2 py-1.5 text-left text-[0.72rem] leading-none text-stone-700 outline-none transition hover:bg-[#EEE9E1] focus-visible:bg-[#EEE9E1] dark:text-stone-300 dark:hover:bg-slate-700 dark:focus-visible:bg-slate-700"
+                              onClick={() =>
+                                void handleCopyFileMenuAction(action)
+                              }
+                            >
+                              <Copy
+                                className="mt-[0.06rem] size-4 shrink-0 text-stone-500 dark:text-slate-400"
+                                aria-hidden="true"
+                              />
+                              <span className="grid min-w-0 flex-1 gap-1">
+                                <span className="truncate font-medium">
+                                  {copiedFileAction === action
+                                    ? "Copied!"
+                                    : label}
+                                </span>
+                                <span className="truncate text-[0.66rem] leading-none text-stone-400 dark:text-slate-500">
+                                  {fileCopyPreviewByAction[action]}
+                                </span>
+                              </span>
+                              {copiedFileAction === action ? (
+                                <Check className="mt-[0.06rem] ml-auto size-3 shrink-0 text-stone-500 dark:text-stone-400" />
+                              ) : null}
+                            </button>
+                          );
+                          const tooltipValue =
+                            fileCopyTooltipValueByAction[action];
+                          if (
+                            tooltipValue === undefined ||
+                            tooltipValue === fileCopyPreviewByAction[action]
+                          ) {
+                            return menuItem;
+                          }
+                          return (
+                            <Tooltip key={action}>
+                              <TooltipTrigger render={menuItem} />
+                              <TooltipContent
+                                data-testid={`document-file-menu-${action}-tooltip`}
+                                side="right"
+                                sideOffset={12}
+                                className="break-all border border-[#DCD6CC] bg-[#FFFDFC] text-stone-800 shadow-[0_16px_44px_rgba(57,47,38,0.18)] dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:shadow-[0_16px_44px_rgba(0,0,0,0.45)]"
+                                arrowClassName="border-[#DCD6CC] bg-[#FFFDFC] dark:border-slate-700 dark:bg-slate-900 data-[side=inline-end]:border-b data-[side=inline-end]:border-l data-[side=inline-start]:border-t data-[side=inline-start]:border-r data-[side=left]:border-t data-[side=left]:border-r data-[side=right]:border-b data-[side=right]:border-l"
+                              >
+                                {tooltipValue}
+                              </TooltipContent>
+                            </Tooltip>
+                          );
+                        })}
+                      </div>
+                    </TooltipProvider>
                   </PopoverContent>
                 </Popover>
                 <div className="ml-auto inline-flex h-[1.25rem] shrink-0 items-center">

--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -1114,10 +1114,10 @@ export function DocumentWorkspace({
                               <TooltipContent
                                 data-testid={`document-file-menu-${action}-tooltip`}
                                 side="right"
-                                sideOffset={12}
+                                sideOffset={8}
                                 align="start"
                                 className="break-all border border-[#DCD6CC] bg-[#FFFDFC] text-stone-800 shadow-[0_16px_44px_rgba(57,47,38,0.18)] dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:shadow-[0_16px_44px_rgba(0,0,0,0.45)]"
-                                arrowClassName="border-[#DCD6CC] bg-[#FFFDFC] dark:border-slate-700 dark:bg-slate-900 data-[side=inline-end]:border-b data-[side=inline-end]:border-l data-[side=inline-start]:border-t data-[side=inline-start]:border-r data-[side=left]:border-t data-[side=left]:border-r data-[side=right]:border-b data-[side=right]:border-l data-[side=inline-end]:top-3.5! data-[side=inline-end]:translate-y-0 data-[side=inline-start]:top-3.5! data-[side=inline-start]:translate-y-0 data-[side=left]:top-3.5! data-[side=left]:translate-y-0 data-[side=right]:top-3.5! data-[side=right]:translate-y-0"
+                                arrowClassName="hidden"
                               >
                                 {tooltipValue}
                               </TooltipContent>

--- a/packages/app/src/components/ui/tooltip.tsx
+++ b/packages/app/src/components/ui/tooltip.tsx
@@ -25,6 +25,7 @@ function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
 
 function TooltipContent({
   className,
+  arrowClassName,
   side = "top",
   sideOffset = 4,
   align = "center",
@@ -35,7 +36,7 @@ function TooltipContent({
   Pick<
     TooltipPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
+  > & { arrowClassName?: string }) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Positioner
@@ -43,7 +44,7 @@ function TooltipContent({
         alignOffset={alignOffset}
         side={side}
         sideOffset={sideOffset}
-        className="isolate z-50"
+        className="isolate z-[80]"
       >
         <TooltipPrimitive.Popup
           data-slot="tooltip-content"
@@ -54,7 +55,12 @@ function TooltipContent({
           {...props}
         >
           {children}
-          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+          <TooltipPrimitive.Arrow
+            className={cn(
+              "z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5",
+              arrowClassName,
+            )}
+          />
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>

--- a/packages/app/test/view-toggle-bugs.test.tsx
+++ b/packages/app/test/view-toggle-bugs.test.tsx
@@ -291,12 +291,14 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     documentDiskChangeState = "clean",
     documentContent = "Hello world",
     documentCopyPath = "test.md",
+    documentFilenameLabel = "test.md",
     watcherCount = 0,
     onSaveDocument = async () => {},
   }: {
     documentDiskChangeState?: "clean" | "changed" | "conflict" | "paused";
     documentContent?: string;
     documentCopyPath?: string | null;
+    documentFilenameLabel?: string;
     watcherCount?: number;
     onSaveDocument?: (id: string, content: string) => Promise<void>;
   } = {}) {
@@ -310,7 +312,7 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
           documentPage={createPage(documentContent)}
           activeDocumentPath="test.md"
           documentCopyPath={documentCopyPath}
-          documentFilenameLabel="test.md"
+          documentFilenameLabel={documentFilenameLabel}
           documentEditorViewMode="rich-text"
           onDocumentEditorViewModeChange={() => {}}
           onSaveDocument={onSaveDocument}
@@ -477,6 +479,72 @@ describe("saving/saved status indicator (issue 2 fix)", () => {
     );
     expect(richTextAction.textContent).toContain("Heading Body");
     expect(richTextAction.textContent).not.toContain("# Heading");
+  });
+
+  async function hoverForFileMenuTooltip(action: "path" | "filename") {
+    const menuAction = getByTestId(
+      document.body,
+      `document-file-menu-${action}`,
+    );
+    await act(async () => {
+      menuAction.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+      menuAction.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(700);
+      await Promise.resolve();
+    });
+  }
+
+  it("shows the full path in a tooltip when the path preview is clipped", async () => {
+    const longPath =
+      "/Users/me/projects/deeply/nested/workspace/notes/long-example.md";
+    await renderWorkspace({ documentCopyPath: longPath });
+    await openFileMenu();
+
+    const pathAction = getByTestId(document.body, "document-file-menu-path");
+    expect(pathAction.textContent).not.toContain(longPath);
+
+    vi.useFakeTimers();
+    await hoverForFileMenuTooltip("path");
+
+    const tooltip = getByTestId(
+      document.body,
+      "document-file-menu-path-tooltip",
+    );
+    expect(tooltip.textContent).toContain(longPath);
+    vi.useRealTimers();
+  });
+
+  it("shows the full filename in a tooltip when the filename preview is clipped", async () => {
+    const longFilename =
+      "2026-07-21_mine-kpi-tracking-system-specification-draft.md";
+    await renderWorkspace({ documentFilenameLabel: longFilename });
+    await openFileMenu();
+
+    vi.useFakeTimers();
+    await hoverForFileMenuTooltip("filename");
+
+    const tooltip = getByTestId(
+      document.body,
+      "document-file-menu-filename-tooltip",
+    );
+    expect(tooltip.textContent).toContain(longFilename);
+    vi.useRealTimers();
+  });
+
+  it("skips the path tooltip when the preview already shows the full path", async () => {
+    await renderWorkspace({ documentCopyPath: "test.md" });
+    await openFileMenu();
+
+    vi.useFakeTimers();
+    await hoverForFileMenuTooltip("path");
+
+    expect(
+      queryByTestId(document.body, "document-file-menu-path-tooltip"),
+    ).toBeNull();
+    vi.useRealTimers();
   });
 
   it("copies document rich text with html and plain markdown flavors", async () => {


### PR DESCRIPTION

<img width="1832" height="830" alt="CleanShot 2026-07-22 at 12 18 33@2x" src="https://github.com/user-attachments/assets/be51f5bf-517d-41b3-bd97-c1f5ccd06f85" />

The file menu clips its Path and Filename previews to 34 characters, so on any real absolute path the full value is invisible without copying it. Resting the pointer on the Path or Filename row for 600ms now shows the full value in a flyout docked beside the menu — only when the preview is actually clipped, and intentionally never for Markdown/Rich text. The flyout reuses the popover's surface tokens, and the menu's tooltips run in a scoped `TooltipProvider` with `timeout={0}` so the delay applies on every hover instead of Base UI's instant re-open grouping.

Shared `tooltip.tsx` changes: positioner raised to `z-[80]` so tooltips stack above popovers (`z-[70]`), and `TooltipContent` gains an optional `arrowClassName` (used here to hide the arrow, which reads as a floating artifact in the narrow gap beside the panel). Defaults unchanged.


https://github.com/user-attachments/assets/28df567c-c911-45bc-9210-21699f23eb84


Tests: three new behavioral tests (clipped path, clipped filename, no tooltip when the value fits); 377 unit/component tests and 12 smoke tests pass; verified in Chromium in light and dark themes.