### PR TITLE
fix: popover arrow rendering artifacts in the document file menu

### DIFF
--- a/packages/app/src/components/ui/popover.tsx
+++ b/packages/app/src/components/ui/popover.tsx
@@ -36,7 +36,7 @@ function PopoverContent({
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(
-            "z-50 w-80 max-w-[calc(100vw-1.5rem)] origin-(--transform-origin) rounded-lg border border-[#DCD6CC] dark:border-slate-700 bg-[#FFFDFC] dark:bg-slate-900 p-4 text-sm text-stone-800 dark:text-slate-200 shadow-[0_16px_44px_rgba(57,47,38,0.18)] dark:shadow-[0_16px_44px_rgba(0,0,0,0.45)] outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[ending-style]:animate-out data-[ending-style]:fade-out-0 data-[ending-style]:zoom-out-95 data-[starting-style]:animate-in data-[starting-style]:fade-in-0 data-[starting-style]:zoom-in-95",
+            "isolate z-50 w-80 max-w-[calc(100vw-1.5rem)] origin-(--transform-origin) rounded-lg border border-[#DCD6CC] dark:border-slate-700 bg-[#FFFDFC] dark:bg-slate-900 p-4 text-sm text-stone-800 dark:text-slate-200 shadow-[0_16px_44px_rgba(57,47,38,0.18)] dark:shadow-[0_16px_44px_rgba(0,0,0,0.45)] outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[ending-style]:animate-out data-[ending-style]:fade-out-0 data-[ending-style]:zoom-out-95 data-[starting-style]:animate-in data-[starting-style]:fade-in-0 data-[starting-style]:zoom-in-95",
             className,
           )}
           {...props}

--- a/packages/app/src/components/ui/popover.tsx
+++ b/packages/app/src/components/ui/popover.tsx
@@ -28,6 +28,7 @@ function PopoverContent({
       <PopoverPrimitive.Positioner
         align={align}
         alignOffset={alignOffset}
+        arrowPadding={12}
         side={side}
         sideOffset={sideOffset}
         className="isolate z-[70]"

--- a/packages/app/src/components/ui/popover.tsx
+++ b/packages/app/src/components/ui/popover.tsx
@@ -42,7 +42,7 @@ function PopoverContent({
           {...props}
         >
           {children}
-          <PopoverPrimitive.Arrow className="z-50 size-2.5 rotate-45 rounded-[2px] border-t border-l border-[#DCD6CC] dark:border-slate-700 bg-[#FFFDFC] dark:bg-slate-900 data-[side=bottom]:top-0 data-[side=bottom]:-translate-y-1/2 data-[side=top]:bottom-0 data-[side=top]:translate-y-1/2" />
+          <PopoverPrimitive.Arrow className="z-[-1] size-2.5 rotate-45 rounded-[2px] border-t border-l border-[#DCD6CC] dark:border-slate-700 bg-[#FFFDFC] dark:bg-slate-900 data-[side=bottom]:top-0 data-[side=bottom]:-translate-y-1/2 data-[side=top]:bottom-0 data-[side=top]:translate-y-1/2" />
         </PopoverPrimitive.Popup>
       </PopoverPrimitive.Positioner>
     </PopoverPrimitive.Portal>


### PR DESCRIPTION
The file menu popover's arrow renders with two artifacts: its in-panel base paints over the highlighted first menu row, and on triggers wider than the panel it gets clamped into the rounded corner, which chips its silhouette.

<table>
<tr>
 <td>Before
 </td>
 <td>After</td></tr>
<tr>
 <td>
<img width="334" height="204" alt="tooltip-tail-bug-fix-before" src="https://github.com/user-attachments/assets/27c07e7f-5e12-465e-8546-cffc1b4ddbf2" /></td>

 <td>
<img width="334" height="204" alt="tooltip-tail-bug-fix-after" src="https://github.com/user-attachments/assets/a90656b7-c325-406e-9e5b-1509485286d2" /></td>
</tr>
</table>

Fix: `isolate` the popup and move the arrow to `z-[-1]` so it paints above the panel background/border (continuing the border over the bump) but beneath row highlights, and set `arrowPadding={12}` to keep it clear of the corner radius.

Verified in Chromium in light and dark themes; 225 app tests and 12 smoke tests pass.