### PR TITLE
Fix `open`/`watch` crash when a review runs longer than 5 minutes

### DIFF
--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -1077,7 +1077,10 @@ describe("cli", () => {
     expect(watchRequestBody).toMatchObject({
       batchWindowSeconds: 0,
     });
-    expect(watchRequestBody).not.toHaveProperty("timeoutSeconds");
+    // Each long-poll must complete before undici's default 300s headersTimeout,
+    // even when the user sets no overall timeout.
+    expect(watchRequestBody?.timeoutSeconds).toBeGreaterThan(0);
+    expect(watchRequestBody?.timeoutSeconds).toBeLessThan(300);
     await fetch(`http://localhost:${persisted?.port}/api/review-events`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -1101,6 +1104,175 @@ describe("cli", () => {
         },
       ],
     });
+  });
+
+  it("keeps watching after a transient long-poll fetch failure", async () => {
+    const test = createTestDependencies();
+    const documentPath = path.join(projectDir, "draft.md");
+    fs.writeFileSync(documentPath, "# Draft\n");
+
+    let watchAttempts = 0;
+    const deps = {
+      ...test.deps,
+      sleepImpl: async () => {},
+      fetchImpl: async (
+        input: Parameters<typeof fetch>[0],
+        init?: RequestInit,
+      ) => {
+        const url =
+          input instanceof URL
+            ? input
+            : new URL(
+                typeof input === "string" ? input : input.url,
+                "http://localhost",
+              );
+        if (url.pathname === "/api/review-events/watch") {
+          watchAttempts += 1;
+          if (watchAttempts === 1) {
+            throw new TypeError("fetch failed", {
+              cause: Object.assign(new Error("Headers Timeout Error"), {
+                code: "UND_ERR_HEADERS_TIMEOUT",
+              }),
+            });
+          }
+        }
+        return test.deps.fetchImpl(input, init);
+      },
+    };
+
+    const watchPromise = runCli(
+      ["watch", documentPath, "--json", "--batch-window", "0"],
+      deps,
+    );
+
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      if (watchAttempts >= 2) break;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(watchAttempts).toBeGreaterThanOrEqual(2);
+
+    const stateFile = getServerStateFilePath(test.deps.env);
+    const persisted = JSON.parse(fs.readFileSync(stateFile, "utf8")) as {
+      port: number;
+    };
+
+    let watching = false;
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const statusUrl = new URL(
+        `http://localhost:${persisted.port}/api/review-events/status`,
+      );
+      statusUrl.searchParams.set("projectPath", projectDir);
+      statusUrl.searchParams.set("path", "draft.md");
+      const status = (await (await fetch(statusUrl)).json()) as {
+        watching: boolean;
+      };
+      if (status.watching) {
+        watching = true;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(watching).toBe(true);
+
+    await fetch(`http://localhost:${persisted.port}/api/review-events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ projectPath: projectDir, path: "draft.md" }),
+    });
+
+    const exitCode = await watchPromise;
+    const payload = parseOnlyJsonLog<{
+      timedOut: boolean;
+      events: unknown[];
+    }>(test.logs);
+
+    expect(exitCode).toBe(0);
+    expect(payload.timedOut).toBe(false);
+    expect(payload.events).toHaveLength(1);
+  });
+
+  it("resumes the long-poll with afterSequence after a server-side poll timeout", async () => {
+    const test = createTestDependencies();
+    const documentPath = path.join(projectDir, "draft.md");
+    fs.writeFileSync(documentPath, "# Draft\n");
+
+    const watchBodies: Array<Record<string, unknown>> = [];
+    const deps = {
+      ...test.deps,
+      fetchImpl: async (
+        input: Parameters<typeof fetch>[0],
+        init?: RequestInit,
+      ) => {
+        const url =
+          input instanceof URL
+            ? input
+            : new URL(
+                typeof input === "string" ? input : input.url,
+                "http://localhost",
+              );
+        if (
+          url.pathname === "/api/review-events/watch" &&
+          typeof init?.body === "string"
+        ) {
+          watchBodies.push(JSON.parse(init.body) as Record<string, unknown>);
+          if (watchBodies.length === 1) {
+            return new Response(
+              JSON.stringify({ events: [], timedOut: true, nextSequence: 7 }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          }
+          return new Response(
+            JSON.stringify({
+              events: [{ type: "review.completed", documentPath, sequence: 7 }],
+              timedOut: false,
+              nextSequence: 8,
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        return test.deps.fetchImpl(input, init);
+      },
+    };
+
+    const exitCode = await runCli(
+      ["watch", documentPath, "--json", "--batch-window", "0"],
+      deps,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(watchBodies).toHaveLength(2);
+    expect(watchBodies[0]).toMatchObject({ fromNow: true });
+    expect(watchBodies[1]).toMatchObject({ fromNow: false, afterSequence: 6 });
+
+    const payload = parseOnlyJsonLog<{
+      timedOut: boolean;
+      events: unknown[];
+    }>(test.logs);
+    expect(payload.timedOut).toBe(false);
+    expect(payload.events).toHaveLength(1);
+  });
+
+  it("exits with a timeout when no review event arrives before --timeout", async () => {
+    const test = createTestDependencies();
+    const documentPath = path.join(projectDir, "draft.md");
+    fs.writeFileSync(documentPath, "# Draft\n");
+
+    const exitCode = await runCli(
+      [
+        "watch",
+        documentPath,
+        "--json",
+        "--timeout",
+        "1",
+        "--batch-window",
+        "0",
+      ],
+      test.deps,
+    );
+
+    const payload = parseOnlyJsonLog<{ timedOut: boolean }>(test.logs);
+    expect(exitCode).toBe(1);
+    expect(payload.timedOut).toBe(true);
   });
 
   it("cleans stale state during status checks", async () => {

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -28,6 +28,11 @@ const SERVER_WAIT_ATTEMPTS = 40;
 const SERVER_WAIT_DELAY_MS = 150;
 const PROCESS_WAIT_ATTEMPTS = 20;
 const PROCESS_WAIT_DELAY_MS = 150;
+// Each watch long-poll must resolve before undici's default 300s headersTimeout;
+// the server also clamps its own wait to 300s, so an unbounded request is never honored.
+const WATCH_POLL_SECONDS = 240;
+const WATCH_RETRY_DELAY_MS = 2_000;
+const WATCH_MAX_CONSECUTIVE_FAILURES = 5;
 const USAGE_ERROR = 2;
 const KNOWN_COMMANDS = [
   "open",
@@ -2102,6 +2107,14 @@ async function runMarkdownDoctor(
   return validation.ok ? 0 : 1;
 }
 
+interface WatchResultPayload {
+  events?: unknown[];
+  timedOut?: boolean;
+  nextSequence?: number;
+}
+
+class WatchRequestError extends Error {}
+
 async function runWatch(
   deps: CliDependencies,
   targetPath: string,
@@ -2117,43 +2130,87 @@ async function runWatch(
     serverUrl = result.server.url;
   }
   const relativePath = path.relative(target.projectDir, target.openPath);
-  const body: {
-    projectPath: string;
-    path: string;
-    timeoutSeconds?: number;
-    batchWindowSeconds: number;
-    fromNow: boolean;
-  } = {
-    projectPath: target.projectDir,
-    path: relativePath,
-    batchWindowSeconds: options.batchWindowSeconds,
-    fromNow: !options.replay,
-  };
-  if (options.timeoutSeconds !== undefined) {
-    body.timeoutSeconds = options.timeoutSeconds;
+
+  const deadline =
+    options.timeoutSeconds !== undefined
+      ? Date.now() + options.timeoutSeconds * 1000
+      : null;
+  let afterSequence: number | null = null;
+  let consecutiveFailures = 0;
+  let payload: WatchResultPayload;
+
+  while (true) {
+    const remainingSeconds =
+      deadline === null
+        ? WATCH_POLL_SECONDS
+        : Math.max(0, (deadline - Date.now()) / 1000);
+    const pollSeconds = Math.min(WATCH_POLL_SECONDS, remainingSeconds);
+    const body: {
+      projectPath: string;
+      path: string;
+      timeoutSeconds: number;
+      batchWindowSeconds: number;
+      fromNow: boolean;
+      afterSequence?: number;
+    } = {
+      projectPath: target.projectDir,
+      path: relativePath,
+      batchWindowSeconds: options.batchWindowSeconds,
+      timeoutSeconds: pollSeconds,
+      fromNow: afterSequence === null ? !options.replay : false,
+    };
+    if (afterSequence !== null) {
+      body.afterSequence = afterSequence;
+    }
+
+    try {
+      const response = await deps.fetchImpl(
+        new URL("/api/review-events/watch", serverUrl),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+          signal: AbortSignal.timeout((pollSeconds + 5) * 1000),
+        },
+      );
+      if (!response.ok) {
+        throw new WatchRequestError(
+          `Failed to watch review events: ${response.status}`,
+        );
+      }
+      payload = (await response.json()) as WatchResultPayload;
+    } catch (error) {
+      if (error instanceof WatchRequestError) {
+        throw error;
+      }
+      consecutiveFailures += 1;
+      if (consecutiveFailures >= WATCH_MAX_CONSECUTIVE_FAILURES) {
+        throw error;
+      }
+      if (deadline !== null && Date.now() >= deadline) {
+        payload = { events: [], timedOut: true };
+        break;
+      }
+      deps.error(
+        `Watch connection failed (${
+          error instanceof Error ? error.message : String(error)
+        }); retrying...`,
+      );
+      await deps.sleepImpl(WATCH_RETRY_DELAY_MS);
+      continue;
+    }
+
+    consecutiveFailures = 0;
+    if (typeof payload.nextSequence === "number" && payload.nextSequence > 0) {
+      afterSequence = payload.nextSequence - 1;
+    }
+    if (!payload.timedOut) {
+      break;
+    }
+    if (deadline !== null && Date.now() >= deadline) {
+      break;
+    }
   }
-
-  const response = await deps.fetchImpl(
-    new URL("/api/review-events/watch", serverUrl),
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-      ...(options.timeoutSeconds !== undefined
-        ? { signal: AbortSignal.timeout((options.timeoutSeconds + 5) * 1000) }
-        : {}),
-    },
-  );
-
-  if (!response.ok) {
-    throw new Error(`Failed to watch review events: ${response.status}`);
-  }
-
-  const payload = (await response.json()) as {
-    events?: unknown[];
-    timedOut?: boolean;
-    nextSequence?: number;
-  };
 
   if (json) {
     emitJson(deps.log, payload);


### PR DESCRIPTION
`roughdraft open` waits for Done Reviewing with a single unbounded long-poll to `/api/review-events/watch`. Node's built-in fetch (undici) applies a default 300-second `headersTimeout`, so when a reviewer takes more than ~5 minutes the CLI crashes with `TypeError: fetch failed` / `UND_ERR_HEADERS_TIMEOUT`. The server also clamps its own wait to 300s in `review-events.ts`, so an unbounded request was never going to be honored anyway.

### What this changes

- `runWatch` now polls in bounded 240-second chunks — safely under both undici's 300s headers timeout and the server's own 300s clamp — with a per-request abort guard.
- Each poll resumes from the previous response's `nextSequence` (sent as `afterSequence`), so a Done Reviewing event that lands between polls is never missed; the server already retains the last 100 events for exactly this.
- Transient fetch failures now retry (up to 5 consecutive, 2 seconds apart) instead of crashing the CLI mid-review.
- `--timeout` semantics are unchanged, and overall timeouts longer than 300s now actually work (previously the server silently capped them).

### Testing

- New tests reproduce the original crash (a `UND_ERR_HEADERS_TIMEOUT`-style fetch failure mid-watch now retries and completes instead of crashing), and cover the bounded-poll contract, `afterSequence` resumption across a server-side poll timeout, and `--timeout` expiry.
- `pnpm check` and `pnpm test:smoke` pass.
- Live verification: `roughdraft open` sat on "Waiting for Done Reviewing..." for 6 minutes 40 seconds — past the old 300s crash point — then received the Done Reviewing event and exited 0.

Fixes #127, fixes #108, fixes #93. I believe this also resolves #113 (the same 5-minute exit, attributed there to an SSE timeout), and it may explain some of the reports in #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
