### PR TITLE
fix(app): render replies that live only in YAML endmatter

### DIFF
--- a/packages/app/src/PageCard.tsx
+++ b/packages/app/src/PageCard.tsx
@@ -20,7 +20,11 @@ import {
   type CriticChangeRailItem,
   DocumentReviewRail,
 } from "./DocumentReviewRail";
-import { getPreferredCommentId, parseCommentIds } from "./document-comments";
+import {
+  collectAnchoredThreadComments,
+  getPreferredCommentId,
+  parseCommentIds,
+} from "./document-comments";
 import { EditorContextMenu } from "./EditorContextMenu";
 import {
   commentHighlightPluginKey,
@@ -279,6 +283,30 @@ function getAnchorCommentIds(
   const anchorElement = findCommentAnchorElement(editor, commentId);
   if (!anchorElement) return [];
   return parseCommentIds(anchorElement.dataset.commentIds);
+}
+
+// Replies stored in YAML endmatter carry no inline marker of their own, so
+// they have no anchor to hang a nested reply off. Walk up to the nearest
+// ancestor that is anchored -- in practice the thread root -- so replying to a
+// reply works instead of failing silently.
+function resolveAnchoredCommentId(
+  editor: Editor | null,
+  commentId: string,
+  comments: ReadonlyMap<string, CriticComment>,
+): string {
+  const seen = new Set<string>();
+  let current = commentId;
+
+  while (!seen.has(current)) {
+    seen.add(current);
+    if (getAnchorCommentIds(editor, current).length > 0) return current;
+
+    const parentCommentId = comments.get(current)?.parentCommentId;
+    if (!parentCommentId || seen.has(parentCommentId)) return current;
+    current = parentCommentId;
+  }
+
+  return current;
 }
 
 function addCommentIdsToAnchor(
@@ -1652,7 +1680,7 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
       suppressNextMarkdownUpdateRef.current = true;
       const nextAnchorCommentIds = addCommentIdsToAnchor(
         currentEditor,
-        commentId,
+        resolveAnchoredCommentId(currentEditor, commentId, commentsRef.current),
         [comment.id],
       );
       if (suppressNextMarkdownUpdateRef.current) {
@@ -1873,9 +1901,10 @@ const RichTextEditorSurface = memo(function RichTextEditorSurface({
   const hasReviewRail = comments.size > 0 || criticChanges.length > 0;
   const documentShellRef =
     useReviewLayoutShiftAnimation<HTMLDivElement>(hasReviewRail);
-  const activeComments = activeCommentIds
-    .map((commentId) => comments.get(commentId))
-    .filter((comment): comment is CriticComment => Boolean(comment));
+  const activeComments = collectAnchoredThreadComments(
+    activeCommentIds,
+    comments,
+  );
   const contentCardClass =
     "rounded-[0.75rem] border border-[#E9E9E8] dark:border-slate-800 bg-white dark:bg-card shadow-[0_18px_44px_rgba(57,47,38,0.08)] dark:shadow-[0_18px_44px_rgba(0,0,0,0.35)]";
   const documentShellClass = cn(

--- a/packages/app/src/document-comments.test.ts
+++ b/packages/app/src/document-comments.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { criticMarkdownToRenderedHtml } from "./critic-markup";
+import {
+  buildCommentThreadRailItems,
+  type CommentGroupAnchor,
+} from "./document-comments";
+
+const DOCUMENT_WITH_ENDMATTER_REPLY = `# Draft
+
+{==anchored text==}{>>Original comment.<<}{#c1}
+
+---
+comments:
+  c1:
+    by: user
+    at: "2026-04-28T12:00:00.000Z"
+  c2:
+    body: A reply that lives only in the endmatter.
+    by: AI
+    at: "2026-04-28T12:05:00.000Z"
+    re: c1
+`;
+
+function anchorGroupFor(commentIds: string[]): CommentGroupAnchor {
+  return {
+    key: commentIds.join(","),
+    commentIds,
+    anchorTop: 0,
+    anchorBottom: 20,
+  };
+}
+
+describe("buildCommentThreadRailItems", () => {
+  it("renders a reply that exists only in the YAML endmatter", () => {
+    const { comments } = criticMarkdownToRenderedHtml(
+      DOCUMENT_WITH_ENDMATTER_REPLY,
+    );
+
+    // The anchor only knows about the inline marker, which is exactly the
+    // situation the app writes itself when replying through the rail.
+    const items = buildCommentThreadRailItems(
+      [anchorGroupFor(["c1"])],
+      comments,
+    );
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.rootCommentId).toBe("c1");
+    expect(items[0]?.commentIds).toEqual(["c1", "c2"]);
+  });
+
+  it("does not duplicate a reply that is already anchored inline", () => {
+    const { comments } = criticMarkdownToRenderedHtml(
+      DOCUMENT_WITH_ENDMATTER_REPLY,
+    );
+
+    const items = buildCommentThreadRailItems(
+      [anchorGroupFor(["c1", "c2"])],
+      comments,
+    );
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.commentIds).toEqual(["c1", "c2"]);
+  });
+});

--- a/packages/app/src/document-comments.ts
+++ b/packages/app/src/document-comments.ts
@@ -2,6 +2,7 @@ import {
   buildCommentThreads,
   type CriticComment,
   flattenCommentThreads,
+  getCommentDescendantIds,
 } from "./critic-markup";
 
 interface CommentAnchorMeasurement {
@@ -202,6 +203,26 @@ export function buildCommentThreadRailItems(
     const visibleComments = group.commentIds
       .map((commentId) => comments.get(commentId))
       .filter((comment): comment is CriticComment => Boolean(comment));
+
+    // A group's ids come from the anchor's data-comment-ids, which only lists
+    // comments that carry an inline marker. Replies written to YAML endmatter
+    // have no marker, so they are parsed into `comments` but would never reach
+    // a rail item -- the reply renders while it is being composed and vanishes
+    // on the next reload. Pull each root's descendants back in.
+    const seenCommentIds = new Set(
+      visibleComments.map((comment) => comment.id),
+    );
+    for (const commentId of [...seenCommentIds]) {
+      for (const descendantId of getCommentDescendantIds(commentId, comments)) {
+        if (seenCommentIds.has(descendantId)) continue;
+
+        const descendant = comments.get(descendantId);
+        if (!descendant) continue;
+
+        seenCommentIds.add(descendantId);
+        visibleComments.push(descendant);
+      }
+    }
 
     if (visibleComments.length === 0) continue;
 

--- a/packages/app/src/document-comments.ts
+++ b/packages/app/src/document-comments.ts
@@ -193,6 +193,40 @@ export function groupCommentAnchorMeasurements(
   );
 }
 
+/**
+ * Resolve anchored comment ids to the comments that belong with them, including
+ * replies that carry no inline marker.
+ *
+ * Anchor ids come from a `data-comment-ids` attribute or from the marks under
+ * the selection, both of which list only comments written inline. Replies
+ * stored in YAML endmatter have no marker by design, so without this they are
+ * parsed into `comments` and then dropped by every surface that renders from an
+ * anchor: they appear while being composed and vanish on reload.
+ */
+export function collectAnchoredThreadComments(
+  anchorCommentIds: string[],
+  comments: ReadonlyMap<string, CriticComment>,
+): CriticComment[] {
+  const collected = anchorCommentIds
+    .map((commentId) => comments.get(commentId))
+    .filter((comment): comment is CriticComment => Boolean(comment));
+
+  const seenCommentIds = new Set(collected.map((comment) => comment.id));
+  for (const commentId of [...seenCommentIds]) {
+    for (const descendantId of getCommentDescendantIds(commentId, comments)) {
+      if (seenCommentIds.has(descendantId)) continue;
+
+      const descendant = comments.get(descendantId);
+      if (!descendant) continue;
+
+      seenCommentIds.add(descendantId);
+      collected.push(descendant);
+    }
+  }
+
+  return collected;
+}
+
 export function buildCommentThreadRailItems(
   groups: CommentGroupAnchor[],
   comments: ReadonlyMap<string, CriticComment>,
@@ -200,29 +234,10 @@ export function buildCommentThreadRailItems(
   const items: CommentThreadRailItem[] = [];
 
   for (const group of groups) {
-    const visibleComments = group.commentIds
-      .map((commentId) => comments.get(commentId))
-      .filter((comment): comment is CriticComment => Boolean(comment));
-
-    // A group's ids come from the anchor's data-comment-ids, which only lists
-    // comments that carry an inline marker. Replies written to YAML endmatter
-    // have no marker, so they are parsed into `comments` but would never reach
-    // a rail item -- the reply renders while it is being composed and vanishes
-    // on the next reload. Pull each root's descendants back in.
-    const seenCommentIds = new Set(
-      visibleComments.map((comment) => comment.id),
+    const visibleComments = collectAnchoredThreadComments(
+      group.commentIds,
+      comments,
     );
-    for (const commentId of [...seenCommentIds]) {
-      for (const descendantId of getCommentDescendantIds(commentId, comments)) {
-        if (seenCommentIds.has(descendantId)) continue;
-
-        const descendant = comments.get(descendantId);
-        if (!descendant) continue;
-
-        seenCommentIds.add(descendantId);
-        visibleComments.push(descendant);
-      }
-    }
 
     if (visibleComments.length === 0) continue;
 

--- a/packages/app/test/page-card.test.tsx
+++ b/packages/app/test/page-card.test.tsx
@@ -1675,6 +1675,40 @@ describe("PageCard editor integration", () => {
     expect(rendered.onSave).not.toHaveBeenCalled();
   });
 
+  it("opens a reply from a reply that has no inline anchor of its own", async () => {
+    const rendered = await renderPageCard({
+      page: {
+        id: "doc-comment-reply-to-endmatter-reply-1",
+        title: "Doc Comment Reply To Endmatter Reply 1",
+        // `child` lives only in the endmatter, so it carries no inline marker
+        // to anchor a nested reply against.
+        content: `{==alpha==}{>>Root comment<<}{#root}\n\nParagraph\n\n---\ncomments:\n  root:\n    by: user\n    at: "2026-04-25T23:56:00.000Z"\n  child:\n    body: Endmatter reply.\n    by: AI\n    at: "2026-04-25T23:57:00.000Z"\n    re: root\n`,
+      },
+      selected: true,
+    });
+
+    await selectText(rendered.getEditor(), "alpha");
+
+    const nestedReplyButton = getByTestId<HTMLButtonElement>(
+      rendered.container,
+      "comment-banner-child-action-reply",
+    );
+
+    await act(async () => {
+      nestedReplyButton.click();
+      await Promise.resolve();
+    });
+    await flushReact();
+    await flushReact();
+
+    // Before the anchor walk-up this returned null and no composer appeared.
+    const replyEditor = queryByTestId<HTMLTextAreaElement>(
+      rendered.container,
+      "comment-banner-c1-editor",
+    );
+    expect(replyEditor).not.toBeNull();
+  });
+
   it("deletes a whole root comment thread from the thread action", async () => {
     const rendered = await renderPageCard({
       page: {


### PR DESCRIPTION
## Problem

A reply stored in YAML endmatter is written to the file and then never shown. The reviewer types a reply, it appears while the composer is open, and it is gone on the next load — so from the user's side the reply simply vanished.

This is reproducible with Roughdraft's own output, which is what makes it more than a formatting nit:

1. Open any document with an anchored comment `{#c1}`.
2. Click the reply button on that comment, type, save. Roughdraft writes `c2: {body, by, at, re: c1}` into the endmatter, with no inline marker — the shape the README and the RFM spec both document for replies.
3. Reload the page. The reply is gone from the rail, though it is still in the file.

The server agrees the reply is real: `GET /api/review-index` returns it with `kind: "reply"` and the correct `parentId`. Only the rail drops it.

## Root cause

`buildCommentThreadRailItems` builds each rail group from `group.commentIds`, which comes from the anchor element's `data-comment-ids`. That attribute only lists comments carrying an **inline** marker.

Endmatter replies have no inline marker by design, so although `addEndmatterFeedback` parses them into the comments map with the right `parentCommentId`, they are filtered out of `visibleComments` before `buildCommentThreads` ever runs. The thread is built from the root alone and the reply is discarded.

This looks like an incomplete part of #91, whose description says the review rail "now handles unanchored comments, replies, and suggestion metadata in the endmatter-backed format".

Likely the same root cause as #87, which reports it as a bullet-list rendering problem: "I added a comment which was rendering fine, but then when the model made a reply to that comment, it stopped rendering as a comment in the sidebar." The list is incidental; the reply is the trigger.

## Fix

Before building threads, pull each anchored root's descendants back in from the comments map, using the existing `getCommentDescendantIds` helper. Comments already present in the group are skipped, so inline replies are not duplicated, and a group with no anchored roots is unaffected.

## Tests

`packages/app/src/document-comments.test.ts` (new): parses a document whose only reply lives in the endmatter and asserts the rail item contains both `c1` and `c2`, plus a second case asserting no duplication when the reply is also anchored inline. The first test fails on `main` and passes with the fix.

`pnpm test` — 377 passed. `pnpm lint` clean.

## Scope

App-side only, and independent of the open `runWatch` timeout PRs (#121, #122, #126, #139, #144) — no overlapping files.