### PR TITLE
Keep the Approve button visible after the watcher disconnects

### DIFF
--- a/packages/app/src/DocumentWorkspace.tsx
+++ b/packages/app/src/DocumentWorkspace.tsx
@@ -424,6 +424,7 @@ export function DocumentWorkspace({
   const [reviewHandoffState, setReviewHandoffState] =
     useState<ReviewHandoffState>("idle");
   const [reviewWatcherCount, setReviewWatcherCount] = useState(0);
+  const [reviewWatcherSeen, setReviewWatcherSeen] = useState(false);
   const [reviewHandoffPopoverOpen, setReviewHandoffPopoverOpen] =
     useState(false);
   const [reviewCompleteTitle, setReviewCompleteTitle] = useState(() =>
@@ -470,6 +471,7 @@ export function DocumentWorkspace({
     setReviewHandoffState("idle");
     setReviewHandoffPopoverOpen(false);
     setDocumentChangedSinceOpen(false);
+    setReviewWatcherSeen(false);
     const readyTimer = window.setTimeout(() => {
       documentChangeTrackingReadyRef.current = true;
     }, 0);
@@ -487,7 +489,11 @@ export function DocumentWorkspace({
       try {
         const status = await backend.getReviewWatchStatus?.(activeDocumentPath);
         if (!cancelled) {
-          setReviewWatcherCount(status?.watcherCount ?? 0);
+          const count = status?.watcherCount ?? 0;
+          setReviewWatcherCount(count);
+          if (count > 0) {
+            setReviewWatcherSeen(true);
+          }
         }
       } catch {
         if (!cancelled) {
@@ -675,7 +681,9 @@ export function DocumentWorkspace({
       : conflictNoticeCopy[documentDiskChangeState];
   const showReviewHandoffButton =
     !!activeDocumentPath &&
-    (reviewWatcherCount > 0 || reviewHandoffState !== "idle");
+    (reviewWatcherCount > 0 ||
+      reviewWatcherSeen ||
+      reviewHandoffState !== "idle");
   const reviewHandoffButtonLabel = getReviewHandoffButtonLabel({
     reviewHandoffState,
     documentChangedSinceOpen,


### PR DESCRIPTION
## Problem

The Approve / Done Reviewing button is rendered only while an agent watcher is connected:

```ts
const showReviewHandoffButton =
  !!activeDocumentPath &&
  (reviewWatcherCount > 0 || reviewHandoffState !== "idle");
```

Watcher status is polled every 1.5s, so if the `roughdraft open`/`watch` process dies mid-review (agent crash, server restart, or the >5-minute watch timeout addressed in #144), the button silently unmounts while the reviewer is still reading. From the reviewer's side the Approve button just disappears with no explanation, and there is no way to hand the document back.

This happened in practice: a reviewer finished commenting on a document, went to approve, and the button was gone because the watching agent's process had died minutes earlier.

## Fix

Track whether a watcher has ever been seen for the active document (`reviewWatcherSeen`, reset when the document changes) and keep the button rendered once one has. A transient watcher drop no longer hides the handoff affordance.

Clicking while no watcher is connected already degrades cleanly through the existing machinery: the server reports `delivered: false`, the UI enters the `undelivered` state ("No agent is watching now"), and the existing effect re-arms the button to `idle` when a watcher reconnects — no new states or copy needed.

Documents opened without any watcher behave exactly as before (no button).

## Testing

- `pnpm --filter @roughdraft/app test` — 225 tests pass.
- Manual: registered a watcher via `roughdraft watch`, opened the document (`?path=`), confirmed the button renders; killed the watcher process and waited for the server-side waiter to expire (`/api/review-events/status` reporting `watcherCount: 0`); the button remains visible. On `main` it unmounts within one 1.5s poll.

Independent of #144, but the two failures compound: #144 stops the watcher dying at the 5-minute mark, and this PR stops the UI stranding the reviewer whenever a watcher dies anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)